### PR TITLE
add #showold URL option & use ready.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>ECMAScript 5 compatibility table</title>
     
     <link rel="stylesheet" href="master.css">
+    <script src="ready.js"></script>
     <script src="master.js"></script>
     
   </head>

--- a/master.js
+++ b/master.js
@@ -12,17 +12,22 @@ function test(expression) {
 }
 document.write('<style>td:nth-child(3) { outline: #aaf solid 3px; }</style>');
 
-window.onload = function() {
-  document.body.className += ' hide-old-browsers';
+domready(function() {
+  if (!/#showold$/.test(location.href))
+    document.body.className += ' hide-old-browsers';
+  else
+    document.getElementById('show-old-browsers').checked = true
   var wrapper = document.getElementById('show-old-browsers-wrapper');
   if (wrapper) {
     wrapper.style.display = '';
     document.getElementById('show-old-browsers').onclick = function() {
       if (this.checked) {
         document.body.className = document.body.className.replace('hide-old-browsers', '');
+        location.href = location.href.replace(/#*$/, '#showold')
       }
       else {
         document.body.className += 'hide-old-browsers';
+        location.href = location.href.replace(/(#showold)*$/, '#')
       }
     };
   }
@@ -65,4 +70,4 @@ window.onload = function() {
       }, 500);
     };
   }
-};
+})

--- a/ready.js
+++ b/ready.js
@@ -1,0 +1,51 @@
+!function (name, definition) {
+  if (typeof module != 'undefined') module.exports = definition()
+  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+  else this[name] = definition()
+}('domready', function (ready) {
+
+  var fns = [], fn, f = false
+    , doc = document
+    , testEl = doc.documentElement
+    , hack = testEl.doScroll
+    , domContentLoaded = 'DOMContentLoaded'
+    , addEventListener = 'addEventListener'
+    , onreadystatechange = 'onreadystatechange'
+    , loaded = /^loade|c/.test(doc.readyState)
+
+  function flush(f) {
+    loaded = 1
+    while (f = fns.shift())
+      try { f() } catch (e) {}
+  }
+
+  doc[addEventListener] && doc[addEventListener](domContentLoaded, fn = function () {
+    doc.removeEventListener(domContentLoaded, fn, f)
+    flush()
+  }, f)
+
+
+  hack && doc.attachEvent(onreadystatechange, (fn = function () {
+    if (/^c/.test(doc.readyState)) {
+      doc.detachEvent(onreadystatechange, fn)
+      flush()
+    }
+  }))
+
+  return (ready = hack ?
+    function (fn) {
+      self != top ?
+        loaded ? fn() : fns.push(fn) :
+        function () {
+          try {
+            testEl.doScroll('left')
+          } catch (e) {
+            return setTimeout(function() { ready(fn) }, 50)
+          }
+          fn()
+        }()
+    } :
+    function (fn) {
+      loaded ? fn() : fns.push(fn)
+    })
+})

--- a/ready.js
+++ b/ready.js
@@ -1,3 +1,6 @@
+/*!
+  * domready (c) Dustin Diaz 2012 - License MIT
+  */
 !function (name, definition) {
   if (typeof module != 'undefined') module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
@@ -11,12 +14,12 @@
     , domContentLoaded = 'DOMContentLoaded'
     , addEventListener = 'addEventListener'
     , onreadystatechange = 'onreadystatechange'
-    , loaded = /^loade|c/.test(doc.readyState)
+    , readyState = 'readyState'
+    , loaded = /^loade|c/.test(doc[readyState])
 
   function flush(f) {
     loaded = 1
-    while (f = fns.shift())
-      try { f() } catch (e) {}
+    while (f = fns.shift()) f()
   }
 
   doc[addEventListener] && doc[addEventListener](domContentLoaded, fn = function () {
@@ -25,12 +28,12 @@
   }, f)
 
 
-  hack && doc.attachEvent(onreadystatechange, (fn = function () {
-    if (/^c/.test(doc.readyState)) {
+  hack && doc.attachEvent(onreadystatechange, fn = function () {
+    if (/^c/.test(doc[readyState])) {
       doc.detachEvent(onreadystatechange, fn)
       flush()
     }
-  }))
+  })
 
   return (ready = hack ?
     function (fn) {


### PR DESCRIPTION
Couple of things in here, firstly I wanted to pass on a link to the page but have it show old browsers and not have to tell them how to turn them on (it's not exactly obvious) so I've added an option to have `#showold` in the URL which will turn it on by default, the `location` is updated so if you turn it on and copy the URL you'll get what you expect/want.

Secondly, `window.onload` takes a long time now you have Flattr stuff in there (and perhaps other things) so I've included ready.js from https://github.com/ded/domready which is nice and small but gives a much quicker load.

I hope this is all cool; no problems if it doesn't fit nicely with what you want for the page.
