### PR TITLE
Add tests for ES6 code point escapes, `String.fromCodePoint`, and `String#codePointAt`.

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -33,7 +33,7 @@
           })();
         </script>
         <span style="position:relative;top:-6px">
-          by <a href="http://twitter.com/kangax/" style="color:#eee">kangax</a>
+          by <a href="http://twitter.com/kangax" style="color:#eee">kangax</a>
         </span>
       </span>
     </h1>
@@ -635,6 +635,40 @@ __yield_script_executed = true;
 
           <tr>
             <td>
+              String.fromCodePoint
+            </td>
+            <script>test(typeof String.fromCodePoint === 'function')</script>
+            <td class="ie10 no">No</td>
+
+            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
+            <td class="chrome no">No</td>
+            <td class="chromeDev no">No</td>
+            <td class="safari51 no">No</td>
+            <td class="webkit no">No</td>
+            <td class="opera no">No</td>
+            <td class="rhino17 no">No</td>
+
+          </tr>
+
+          <tr>
+            <td>
+              String.prototype.codePointAt
+            </td>
+            <script>test(typeof String.prototype.codePointAt === 'function')</script>
+            <td class="ie10 no">No</td>
+
+            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
+            <td class="chrome no">No</td>
+            <td class="chromeDev no">No</td>
+            <td class="safari51 no">No</td>
+            <td class="webkit no">No</td>
+            <td class="opera no">No</td>
+            <td class="rhino17 no">No</td>
+
+          </tr>
+
+          <tr>
+            <td>
               String.prototype.repeat
             </td>
             <script>test(typeof String.prototype.repeat === 'function')</script>
@@ -706,6 +740,29 @@ __yield_script_executed = true;
               String.prototype.toArray
             </td>
             <script>test(typeof String.prototype.toArray === 'function')</script>
+            <td class="ie10 no">No</td>
+
+            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
+            <td class="chrome no">No</td>
+            <td class="chromeDev no">No</td>
+            <td class="safari51 no">No</td>
+            <td class="webkit no">No</td>
+            <td class="opera no">No</td>
+            <td class="rhino17 no">No</td>
+
+          </tr>
+
+          <tr>
+            <td>
+              Unicode code point escapes
+            </td>
+            <script>test((function() {
+          try {
+            return eval("'\\u{1d306}' == '\\ud834\\udf06'");
+          } catch(error) {
+            return false;
+          }
+        })())</script>
             <td class="ie10 no">No</td>
 
             <td class="firefox11 no">No</td><td class="firefox12 no">No</td>

--- a/master.js
+++ b/master.js
@@ -31,9 +31,9 @@ domready(function() {
       }
     };
   }
-  
+
   var mouseoverTimeout;
-  
+
   var infoTooltip = document.createElement('pre');
   infoTooltip.className = 'info-tooltip';
   infoTooltip.style.display = 'none';
@@ -44,16 +44,16 @@ domready(function() {
   infoTooltip.onmouseover = function() {
     mouseoverTimeout = null;
   };
-  
+
   var rows = document.getElementsByTagName('table')[0].rows;
   for (var i = 1; i < rows.length; i++) {
     if (/separator/.test(rows[i].cells[0].className)) continue;
-    
+
     var infoEl = document.createElement('span');
     infoEl.className = 'info';
     infoEl.innerHTML = 'c';
     rows[i].cells[0].appendChild(infoEl);
-    
+
     infoEl.onmouseover = function(e) {
       mouseoverTimeout = null;
       var scriptEl = this.parentNode.parentNode.getElementsByTagName('script')[0];


### PR DESCRIPTION
Add tests for ES6 code point escapes, `String.fromCodePoint`, and `String#codePointAt`.

See http://mathiasbynens.be/notes/javascript-escapes#unicode-code-point. 

Preview: http://mathiasbynens.github.com/es5-compat-table/es6/
