### PR TITLE
Better way of highlighting the second cell in each table row

### DIFF
--- a/master.js
+++ b/master.js
@@ -10,7 +10,7 @@ function test(expression) {
   var result = expression ? 'Yes' : 'No';
   document.write('<td class="' + result.toLowerCase() + '">' + result + '</td><td></td>');
 }
-document.write('<style>td:nth-child(3) { outline: #aaf solid 3px; }</style>');
+document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 
 domready(function() {
   if (!/#showold$/.test(location.href))


### PR DESCRIPTION
### Before

![](http://i.imgur.com/6hV9y.png)

(There are two `<script>` elements in the Generators row, so the second script gets the outline rather than the table cell.)
### After

![](http://i.imgur.com/pKYbL.png)
