### PR TITLE
Added Node 0.8 to ES6 table

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -66,6 +66,7 @@
           <th class="webkit">WebKit</th>
           <th class="opera">Opera 12</th>
           <th class="rhino17">Rhino 1.7</th>
+          <th class="node08">Node 0.8</th>
         </tr>
       </thead>
       <tbody>
@@ -108,6 +109,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -135,6 +137,7 @@
             <td class="webkit yes">Yes</td>
             <td class="opera yes">Yes</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 yes">Yes</td>
           </tr>
 
           <tr>
@@ -162,6 +165,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -190,6 +194,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -218,6 +223,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -246,6 +252,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -274,6 +281,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -303,6 +311,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -332,6 +341,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -360,6 +370,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -388,6 +399,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -417,6 +429,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -446,6 +459,7 @@
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -484,6 +498,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -506,6 +521,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -534,6 +550,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -565,6 +582,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -590,6 +608,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -615,6 +634,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -640,6 +660,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -663,6 +684,7 @@ __yield_script_executed = true;
               <td class="webkit no">No</td>
               <td class="opera no">No</td>
               <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
           </tr>
 
           <tr>
@@ -684,6 +706,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -706,6 +729,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -728,6 +752,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -750,6 +775,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -772,6 +798,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 yes">Yes</td>
 
           </tr>
 
@@ -794,6 +821,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -816,6 +844,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -838,6 +867,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -860,6 +890,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -882,6 +913,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -904,6 +936,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -926,6 +959,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -948,6 +982,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -976,6 +1011,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -998,6 +1034,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1020,6 +1057,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1042,6 +1080,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 yes">Yes</td>
 
           </tr>
 
@@ -1064,6 +1103,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1086,6 +1126,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 yes">Yes</td>
 
           </tr>
 
@@ -1108,6 +1149,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1130,6 +1172,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1152,6 +1195,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1174,6 +1218,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1196,6 +1241,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1218,6 +1264,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1240,6 +1287,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1262,6 +1310,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1284,6 +1333,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1306,6 +1356,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1328,6 +1379,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1350,6 +1402,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1372,6 +1425,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 
@@ -1394,6 +1448,7 @@ __yield_script_executed = true;
             <td class="webkit no">No</td>
             <td class="opera no">No</td>
             <td class="rhino17 no">No</td>
+            <td class="node08 no">No</td>
 
           </tr>
 

--- a/node.js
+++ b/node.js
@@ -1,0 +1,28 @@
+// run `npm install` to install deps first, then `node ./` to execute
+
+var fs = require('fs')
+  , colors = require('colors')
+  , path = require('path')
+  , cheerio = require('cheerio')
+
+  , page = fs.readFileSync(path.join(__dirname, 'es6', 'index.html')).toString()
+  , $ = cheerio.load(page)
+
+  , test = function test (expression) {
+      return expression
+    }
+
+$('#body tbody tr').each(function () {
+  var desc = this.find('td')[0].children[0].data.trim()
+    , scripts = this.find('script')
+    , result = false
+    , i = 0, scr
+
+  // can be multiple scripts
+  for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {
+    scr = scripts[i].children[0].data.trim()
+    result = eval(scr)
+  }
+
+  console.log(((result ? '\u2714' : '\u2718') + '\t' + desc + '\t')[result ? 'green' : 'red'])
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "es5-compat-table",
+  "version": "0.0.0",
+  "main": "node.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rvagg/es5-compat-table.git"
+  },
+  "private": true,
+  "dependencies": {
+    "colors": "~0.6.0-1",
+    "cheerio": "~0.10.1"
+  }
+}


### PR DESCRIPTION
Since V8 isn't compiled with experimental addons I thought it would be useful to have a column showing what's available in Node.js. I considered adding an 0.9 column but ES6 support is identical to 0.8 at the moment but that could change before the end of 0.9
Is this reasonable / useful?
