### PR TITLE
Quasi-Literals have been renamed the friendlier "Template Strings"

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -495,7 +495,7 @@ __yield_script_executed = true;
 
           <tr>
             <td>
-              Quasi-Literals
+              Template Strings
             </td>
             <script>test((function () {
           try {


### PR DESCRIPTION
Signed-off-by: Rick Waldron waldron.rick@gmail.com
