### PR TITLE
typeof null === "null" will not be in ES6

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -473,28 +473,6 @@ __yield_script_executed = true;
 
           <tr>
             <td>
-              Typeof null is null
-            </td>
-            <script>test(typeof null === 'null')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
               Quasi-Literals
             </td>
             <script>test((function () {


### PR DESCRIPTION
Signed-off-by: Rick Waldron waldron.rick@gmail.com
