### PR TITLE
Firefox 18 supports maps

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -559,7 +559,7 @@ __yield_script_executed = true;
             <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
             <td class="firefox16 no">No</td>
             <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
+            <td class="firefox18 yes">Yes</td>
             <td class="chrome no">No</td>
             <td class="chromeDev no">No</td>
             <td class="chrome21 no">No</td>


### PR DESCRIPTION
I noticed that the page stated that Firefox 18 does not support the ES6 Map, though my "Current browser" did, which happens to be Firefox 18 (I highly doubt it matters, but I'm using Aurora 2012-11-04).
