### PR TITLE
A build system to convert data->table

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,229 @@
+// Copyright 2012 Dan Wolff | danwolff.se
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var fs = require('fs');
+
+// let prototypes declared below in this file be initialized
+process.nextTick(function () {
+  handle(require('./data-es5'));
+  handle(require('./data-es6'));
+  handle(require('./data-non-standard'));
+});
+
+
+function handle(options) {
+  var skeleton = fs.readFileSync(__dirname + '/' + options.skeleton_file, 'utf-8');
+  var html = dataToHtml(options.browsers, options.tests);
+
+  var result = replaceAndIndent(skeleton, [
+    ["<!-- TABLE HEADERS -->", html.tableHeaders],
+    ["<!-- TABLE BODY -->", html.tableBody],
+    ["<!-- FOOTNOTES -->", html.footnotes]
+  ]).replace(/\t/g, '  ');
+
+  var target_file = __dirname + '/' + options.target_file;
+  var old_result;
+  try {
+    old_result = fs.readFileSync(target_file, 'utf-8');
+  } catch (e) {}
+  if (old_result === result) {
+    console.log('[' + options.name + '] ' + options.target_file + ' not changed');
+  } else {
+    fs.writeFileSync(target_file, result);
+    console.log('[' + options.name + '] Write to file ' + options.target_file);
+  }
+}
+
+function dataToHtml(browsers, tests) {
+  var i, j, browserId, footnote;
+
+  var footnoter = new Footnoter();
+
+  // headers
+  var b,
+    headers = [];
+  for (browserId in browsers) {
+    b = browsers[browserId];
+    if (!b) {
+      throw new Error('No browser with ID ' + browserId);
+    }
+    headers.push(
+      '<th class="' + browserId + '">' +
+      (b.link ? '<a href="' + b.link + '">' : '') +
+      (b.short ? '<abbr title="' + b.full + '">' + b.short + '</abbr>' : b.full) +
+      (b.link ? '</a>' : '') +
+      footnoter.get(b) +
+      '</th>'
+    );
+  }
+
+  // body rows
+  var val,
+    body = [];
+  for (i = 0; i < tests.length; i++) {
+    t = tests[i];
+    body.push(
+      '<tr>',
+      '\t<td>' + t.name + footnoter.get(t) + '</td>\n' +
+      testScript(t.exec)
+    );
+
+    // each browser for this test
+    for (browserId in browsers) {
+      val = t.res[browserId];
+      if (val == null) {
+        body.push('\t<td class="' + browserId + '"></td>');
+      } else {
+        body.push(
+          '\t<td class="' + boolToString(val).toLowerCase() + ' ' + browserId + '">' +
+          boolToString(val) +
+          footnoter.get(val) +
+          '</td>'
+        );
+      }
+    }
+
+    body.push('</tr>');
+    if (t.separator === 'after') {
+      body.push(
+        '<tr>',
+        '\t<th colspan="' + (Object.keys(browsers).length + 3) + '" class="separator"></th>',
+        '</tr>'
+      );
+    }
+  }
+
+  return {
+    tableHeaders: headers,
+    tableBody: body,
+    footnotes: footnoter.getAll()
+  };
+}
+
+function boolToString(val) {
+  if (typeof val === 'object') {
+    val = val.val;
+  }
+  return val ? 'Yes' : 'No';
+}
+
+// Footnoter
+function Footnoter() {
+  this.indexById = Object.create(null);
+  this.notes = [];
+}
+
+Footnoter.prototype.get = function (val) {
+  var id;
+  if (typeof val === 'object' && val.note_id) {
+    id = val.note_id;
+    // save if it's new
+    if (this.indexById[id] == null) {
+      this.indexById[id] = this.notes.length;
+      this.notes.push(val.note_html);
+    }
+    // save html if such exists (may replace existing)
+    else if (val.note_html) {
+      this.notes[ this.indexById[id] ] = val.note_html;
+    }
+
+    // return the index + 1
+    return '<a href="#' + id + '-note"><sup>[' +
+      (this.indexById[id] + 1) +
+      ']</sup></a>';
+  }
+  return '';
+};
+
+Footnoter.prototype.getAll = function() {
+  var id, index,
+    html = [];
+
+  for (id in this.indexById) {
+    index = this.indexById[id];
+    html.push(
+      '<p id="' + id + '-note">',
+      '\t<sup>[' + (index + 1) + ']</sup> ' + this.notes[index],
+      '</p>'
+    );
+  }
+  return html;
+};
+
+function replaceAndIndent(str, replacements) {
+  var i, replacement, indent;
+  for (i = 0; i < replacements.length; i++) {
+    replacement = replacements[i];
+    indent = new RegExp('(\n[ \t]*)' + replacement[0]).exec(str);
+    if (!indent) {
+      throw new Error('Could not find indent for ' + replacement[0]);
+    }
+    str = str
+      .split(replacement[0])
+      .join(replacement[1].join(indent[1]));
+  }
+  return str;
+}
+
+function deindentFunc(fn) {
+  fn += '';
+  var indent = /\n([\t ]*)[^\n]*$/.exec(fn);
+  if (indent) {
+    fn = fn.replace(new RegExp('\n' + indent[1], 'g'), '\n');
+  }
+  return fn;
+}
+
+function testScript(fn) {
+  if (typeof fn === 'function') {
+    fn = deindentFunc(fn);
+
+    // find the expression if it's there
+    var expr = /^function \(\) \{\s*return\s+([\s\S]+?);?\s*\}$/.exec(fn);
+    expr = expr && expr[1];
+
+    // if there wasn't an expression, make the function statement into one
+    if (!expr) {
+      expr = fn + '()';
+    }
+
+    return '<script>\n' +
+      'test(' + expr + ');\n' +
+      '</script>\n';
+  } else {
+    // it's an array of objects like the following:
+    // { type: 'application/javascript;version=1.8', script: function () { ... } }
+    var i, script,
+      scripts = [];
+    for (i = 0; i < fn.length; i++) {
+      script = fn[i];
+      scripts.push(
+        '<script' + (script.type ? ' type="' + script.type + '"' : '') + '>',
+        deindentFunc(
+          (script.script+'').replace(/^function \(\) \{\s*|\s*\}$/g, '')
+        ),
+        '</script>'
+      );
+    }
+    return scripts.join('\n') + '\n';
+  }
+}

--- a/data-es5.js
+++ b/data-es5.js
@@ -1,0 +1,1505 @@
+// exports browsers and tests
+
+exports.name = 'ES5';
+exports.target_file = 'index.html';
+exports.skeleton_file = 'skeleton.html';
+
+exports.browsers = {
+  ie7: {
+    full: 'Internet Explorer 7',
+    short: 'IE 7'
+  },
+  ie8: {
+    full: 'Internet Explorer 8',
+    short: 'IE 8'
+  },
+  ie9: {
+    full: 'Internet Explorer 9',
+    short: 'IE 9'
+  },
+  ie10: {
+    full: 'Internet Explorer 10 PP2',
+    short: 'IE 10'
+  },
+
+  firefox3: {
+    full: 'Firefox 3',
+    short: 'FF 3'
+  },
+  firefox3_5: {
+    full: 'Firefox 3.5, Firefox 3.6',
+    short: 'FF 3.5, 3.6'
+  },
+  firefox4: {
+    full: 'Firefox 4, Firefox 5, Firefox 6.0, Firefox 7.0.1, Firefox 8.0, Firefox 9.0, Firefox 10.0, Firefox 11.0, Firefox 12.0, Firefox 13.0',
+    short: 'FF 4-13'
+  },
+
+  safari3: {
+    full: 'Safari 3.2',
+    short: 'SF 3.2'
+  },
+  safari4: {
+    full: 'Safari 4.0.5',
+    short: 'SF 4'
+  },
+  safari5: {
+    full: 'Safari 5.0.5',
+    short: 'SF 5'
+  },
+  safari51: {
+    full: 'Safari 5.1',
+    short: 'SF 5.1'
+  },
+  safari6: {
+    full: 'Safari 6.0',
+    short: 'SF 6'
+  },
+  webkit: {
+    full: 'Webkit r120398 (June 20, 2012)',
+    short: 'WebKit'
+  },
+
+  chrome5: {
+    full: 'Chrome 5 (5.0.375.127)',
+    short: 'CH 5'
+  },
+  chrome6: {
+    full: 'Chrome 6 (6.0.472.55)',
+    short: 'CH 6'
+  },
+  chrome7: {
+    full: 'Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev), Chrome 10, Chrome 11, Chrome 12 (12.0.742.91)',
+    short: 'CH 7-12'
+  },
+  chrome13: {
+    full: 'Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)',
+    short: 'CH 13-16'
+  },
+  chrome19: {
+    full: 'Chrome 19 (19.0.1084.56 stable)',
+    short: 'CH 19+'
+  },
+
+  opera10_10: {
+    full: 'Opera 10.10',
+    short: 'OP 10.1'
+  },
+  opera10_50: {
+    full: 'Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156), Opera 11.10 (build 2048), Opera 11.11 (build 2109), Opera 11.50 (build 1074)',
+    short: 'OP 10.50-11.50'
+  },
+  opera12: {
+    full: 'Opera 12 (build 1065)',
+    short: 'OP 12'
+  },
+  opera12_10: {
+    full: 'Opera 12.10 (build 1652)',
+    short: 'OP 12.10'
+  },
+
+  konq: {
+    full: 'Konqueror 4.3',
+    short: 'Konq 4.3'
+  },
+
+  besen: {
+    full: 'Bero\'s EcmaScript Engine (version 1.0.0.489)',
+    short: 'BESEN',
+    link: 'http://besen.sourceforge.net/'
+  },
+
+  rhino: {
+    full: 'Rhino 1.7 release 3 PRERELEASE 2010 01 14',
+    short: 'Rhino 1.7'
+  }
+};
+
+exports.tests = [
+{
+  name: 'Object.create',
+  exec: function () {
+    return typeof Object.create == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.defineProperty',
+  exec: function () {
+    return typeof Object.defineProperty == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: {
+      val: true,
+      note_id: 'define-property-ie',
+      note_html: 'In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects ' +
+        '(<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).'
+    },
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: {
+      val: true,
+      note_id: 'define-property-webkit',
+      note_html: 'In some versions of WebKit <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.'
+    },
+    safari51: true,
+    safari6: true,
+    webkit: {
+      val: true,
+      note_id: 'define-property-webkit'
+    },
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.defineProperties',
+  exec: function () {
+    return typeof Object.defineProperties == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.getPrototypeOf',
+  exec: function () {
+    return typeof Object.getPrototypeOf == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.keys',
+  exec: function () {
+    return typeof Object.keys == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.seal',
+  exec: function () {
+    return typeof Object.seal == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.freeze',
+  exec: function () {
+    return typeof Object.freeze == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.preventExtensions',
+  exec: function () {
+    return typeof Object.preventExtensions == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.isSealed',
+  exec: function () {
+    return typeof Object.isSealed == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.isFrozen',
+  exec: function () {
+    return typeof Object.isFrozen == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.isExtensible',
+  exec: function () {
+    return typeof Object.isExtensible == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.getOwnPropertyDescriptor',
+  exec: function () {
+    return typeof Object.getOwnPropertyDescriptor == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: true,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Object.getOwnPropertyNames',
+  exec: function () {
+    return typeof Object.getOwnPropertyNames == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'Date.prototype.toISOString',
+  exec: function () {
+    return typeof Date.prototype.toISOString == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Date.now',
+  exec: function () {
+    return typeof Date.now == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.isArray',
+  exec: function () {
+    return typeof Array.isArray == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'JSON',
+  exec: function () {
+    return typeof JSON == 'object';
+  },
+  res: {
+    ie7: false,
+    ie8: true,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Function.prototype.bind',
+  exec: function () {
+    return typeof Function.prototype.bind == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: {
+      val: false,
+      note_id: 'safari-bind',
+      note_html: '<code>Function.prototype.bind</code> is now supported in Safari 5.1.4'
+    },
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: false,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.trim',
+  exec: function () {
+    return typeof String.prototype.trim == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'Array.prototype.indexOf',
+  exec: function () {
+    return typeof Array.prototype.indexOf == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.lastIndexOf',
+  exec: function () {
+    return typeof Array.prototype.lastIndexOf == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.every',
+  exec: function () {
+    return typeof Array.prototype.every == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.some',
+  exec: function () {
+    return typeof Array.prototype.some == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.forEach',
+  exec: function () {
+    return typeof Array.prototype.forEach == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.map',
+  exec: function () {
+    return typeof Array.prototype.map == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.filter',
+  exec: function () {
+    return typeof Array.prototype.filter == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.reduce',
+  exec: function () {
+    return typeof Array.prototype.reduce == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Array.prototype.reduceRight',
+  exec: function () {
+    return typeof Array.prototype.reduceRight == 'function';
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'Getter in property initializer',
+  exec: function () {
+    try {
+      return eval('({ get x(){ return 1 } }).x === 1');
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Setter in property initializer',
+  exec: function () {
+    try {
+      var value;
+      eval('({ set x(v){ value = v; } }).x = 1');
+      return value === 1;
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'Property access on strings',
+  note_id: 'property-access-on-strings',
+  note_html: 'For example: <code>"foobar"[3] === "b"</code>',
+  exec: function () {
+    return "foobar"[3] === "b";
+  },
+  res: {
+    ie7: false,
+    ie8: true,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: true,
+    chrome6: true,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: true,
+    opera10_50: true,
+    opera12: true,
+    opera12_10: true,
+
+    konq: true,
+
+    besen: true,
+    rhino: true
+  }
+
+},
+{
+  name: 'Reserved words as property names',
+  note_id: 'reserved-words',
+  note_html: 'For example: <code>({ if: 1 })</code>',
+  exec: function () {
+    try {
+      var obj = { };
+      eval('obj = ({ if: 1 })');
+      return obj['if'] === 1;
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: false,
+    chrome7: true,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: 'Zero-width chars in identifiers',
+  exec: function (){
+    try {
+      return eval('_\u200c\u200d = true');
+    } catch(e) { }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: {
+      val: true,
+      note_id: 'zero-width-char',
+      note_html: 'Firefox 4 &amp; 5 fail this test'
+    },
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: false,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: false,
+    chrome7: false,
+    chrome13: false,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: false,
+    opera12_10: true,
+
+    konq: null,
+
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'Strict mode',
+  link: 'http://kangax.github.com/es5-compat-table/strict-mode/',
+  note_id: 'strict-mode',
+  note_html: 'Strict mode is assumed to be supported when the following expression evaluates to <code>true</code> — ' +
+    '<code>(function(){ "use strict"; return !this; })();</code>',
+  exec: function (){
+    "use strict";
+    return !this;
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    ie10: {
+      val: false,
+      note_id: 'strict-mode-ie10',
+      note_html: 'IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>'
+    },
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: true,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: false,
+    chrome7: false,
+    chrome13: true,
+    chrome19: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: true,
+    opera12_10: true,
+
+    konq: false,
+
+    besen: true,
+    rhino: false
+  }
+}
+];

--- a/data-es6.js
+++ b/data-es6.js
@@ -1,0 +1,1431 @@
+// exports browsers and tests
+
+exports.name = 'ES6';
+exports.target_file = 'es6/index.html';
+exports.skeleton_file = 'es6/skeleton.html';
+
+exports.browsers = {
+  ie10: {
+    full: 'Internet Explorer',
+    short: 'IE 10'
+  },
+  firefox11: {
+    full: 'Firefox',
+    short: 'FF 11, 12'
+  },
+  firefox12: {
+    full: 'Firefox',
+    short: 'FF 13'
+  },
+  firefox16: {
+    full: 'Firefox',
+    short: 'FF 16'
+  },
+  firefox17: {
+    full: 'Firefox',
+    short: 'FF 17'
+  },
+  firefox18: {
+    full: 'Firefox',
+    short: 'FF 18'
+  },
+  chrome: {
+    full: 'Chrome',
+    short: 'CH &lt;19'
+  },
+  chromeDev: {
+    full: 'Chrome',
+    short: 'CH 19',
+    note_id: 'experimental-flag',
+    note_html: 'Have to be enabled via "Experimental Javascript features" flag'
+  },
+  chrome21: {
+    full: 'Chrome',
+    short: 'CH 21-24',
+    note_id: 'experimental-flag'
+  },
+  safari51: {
+    full: 'Safari',
+    short: 'SF 5.1'
+  },
+  safari6: {
+    full: 'Safari',
+    short: 'SF 6'
+  },
+  webkit: {
+    full: 'WebKit'
+  },
+  opera: {
+    full: 'Opera 12'
+  },
+  rhino17: {
+    full: 'Rhino 1.7'
+  },
+  node08: {
+    full: 'Node 0.8'
+  }
+};
+
+exports.tests = [
+{
+  name: 'class',
+  exec: function () {
+    try {
+      return eval('class C{ constructor() { this.own = true; } } (new C()).own;');
+      /*
+      class C{
+        constructor() {
+          this.own = true;
+        }
+      }
+      (new C()).own; // true
+      */
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'let',
+  exec: [
+    {
+      type: 'application/javascript;version=1.8',
+      script: function () {
+        test(function () {
+          try {
+            return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+          } catch(error) {
+            return false;
+          }
+        }());
+        __let_script_executed = true;
+      }
+    },
+    {
+      script: function () {
+        if (!__let_script_executed ) {
+          test(function () {
+            try {
+              return eval('(function(){ "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+            } catch(error) {
+              return false;
+            }
+          }());
+        }
+      }
+    }
+  ],
+  res: {
+    ie10: false,
+    firefox11: true,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: true,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'const',
+  exec: function () {
+    try {
+      return eval('(function() { const foobarbaz = 12; return typeof foobarbaz === "number" })()');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: true,
+    chromeDev: true,
+    chrome21: true,
+    safari51: false,
+    safari6: true,
+    webkit: true,
+    opera: true,
+    rhino17: false,
+    node08: true
+  }
+},
+{
+  name: 'default function params',
+  exec: function () {
+    try {
+      return eval('(function(a = 5) {return a === 5})()');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'rest parameters',
+  exec: function () {
+    try {
+      return eval('(function(...args) { return typeof args !== "undefined"; })()')
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'spread call (...) operator',
+  exec: function () {
+    try {
+      return eval('Math.max(...[1, 2, 3]) === 3');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'spread array (...) operator',
+  exec: function () {
+    try {
+      return eval('[...[1, 2, 3]][2] === 3');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: '<del title="Temporarily disabled due to Chrome crash">Modules</del>',
+  exec: function () {
+    try {
+      // this line crashes Chrome 21-24
+      // return eval('module foo { }');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'For..of loops',
+  exec: function () {
+    try {
+      return eval('(function() {var arr = [5]; for (var item of arr) return item === 5;})()');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Array comprehensions',
+  exec: function () {
+    try {
+      eval('[a * a for (a of [1, 2, 3])][0] === 1');
+      return true;
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Generator expressions',
+  exec: function () {
+    try {
+      eval('(a for (a of [1, 2, 3]))');
+      return true;
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Iterators',
+  exec: function () {
+    try {
+      eval('for (var a of {b: 5}) {}');
+      return true;
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Generators (yield)',
+  exec: [
+    {
+      type: 'application/javascript;version=1.8',
+      script: function () {
+        test((function () {
+          try {
+            eval('(function() {yield 5;})()');
+            return true;
+          } catch(error) {
+            return false;
+          }
+        })())
+        __yield_script_executed = true;
+      }
+    },
+    {
+      script: function () {
+        if (!__yield_script_executed) {
+          test(false);
+          __yield_script_executed = false;
+        }
+      }
+    }
+  ],
+  res: {
+    ie10: false,
+    firefox11: true,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Template Strings',
+  exec: function () {
+    try {
+      eval('var u = function() {return true}; u`literal`');
+      return true;
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'RegExp "y" flag',
+  exec: function () {
+    try {
+      var re = new RegExp('\\w');
+      var re2 = new RegExp('\\w', 'y');
+      re.exec('xy');
+      re2.exec('xy');
+      return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+    } catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: true,
+    firefox12: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Maps',
+  exec: function () {
+    return typeof Map !== 'undefined' &&
+      typeof Map.prototype.get === 'function' &&
+      typeof Map.prototype.set === 'function' &&
+      typeof Map.prototype.clear === 'function' &&
+      typeof Map.prototype.has === 'function' &&
+      typeof Map.prototype.forEach === 'function' &&
+      typeof Map.prototype.size === 'number' &&
+      Map([["key", "val"]]).has("key");
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Sets',
+  exec: function () {
+    return typeof Set !== 'undefined' &&
+      typeof Set.prototype.add === 'function' &&
+      typeof Set.prototype.values === 'function' &&
+      typeof Set.prototype.clear === 'function' &&
+      typeof Set.prototype.has === 'function' &&
+      typeof Set.prototype.forEach === 'function' &&
+      typeof Set.prototype.size === 'number' &&
+      Set([1]).has(1);
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'WeakMaps',
+  exec: function () {
+    return typeof WeakMap !== 'undefined' &&
+      typeof WeakMap.prototype.get === 'function' &&
+      typeof WeakMap.prototype.set === 'function' &&
+      typeof WeakMap.prototype.clear === 'function' &&
+      typeof WeakMap.prototype.has === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Proxies',
+  exec: function () {
+    return typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' && typeof Proxy.createFunction == 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Structs (binary data storage)',
+  exec: function () {
+    return typeof StructType !== 'undefined';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Block-level function declaration',
+  exec: function() {
+    'use strict';
+    try {
+      return eval('{function f(){}} typeof f == "undefined"');
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Object.getOwnPropertyDescriptors',
+  exec: function () {
+    return typeof Object.getOwnPropertyDescriptors === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Object.getPropertyDescriptor',
+  exec: function () {
+    return typeof Object.getPropertyDescriptor === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Object.getPropertyNames',
+  exec: function () {
+    return typeof Object.getPropertyNames === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Object.is',
+  exec: function () {
+    return typeof Object.is === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: true,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: true
+  }
+},
+{
+  name: 'Object.isnt',
+  exec: function () {
+    return typeof Object.isnt === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.fromCodePoint',
+  exec: function () {
+    return typeof String.fromCodePoint === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.codePointAt',
+  exec: function () {
+    return typeof String.prototype.codePointAt === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.repeat',
+  exec: function () {
+    return typeof String.prototype.repeat === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.startsWith',
+  exec: function () {
+    return typeof String.prototype.startsWith === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.endsWith',
+  exec: function () {
+    return typeof String.prototype.endsWith === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.contains',
+  exec: function () {
+    return typeof String.prototype.contains === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'String.prototype.toArray',
+  exec: function () {
+    return typeof String.prototype.toArray === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Unicode code point escapes',
+  exec: function() {
+    try {
+      return eval("'\\u{1d306}' == '\\ud834\\udf06'");
+    } catch(error) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Array.from',
+  exec: function () {
+    return typeof Array.from === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Array.of',
+  exec: function () {
+    return typeof Array.of === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Number.isFinite',
+  exec: function () {
+    return typeof Number.isFinite === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: true,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: true
+  }
+},
+{
+  name: 'Number.isInteger',
+  exec: function () {
+    return typeof Number.isInteger === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Number.isNaN',
+  exec: function () {
+    return typeof Number.isNaN === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: true,
+    chrome21: true,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: true
+  }
+},
+{
+  name: 'Number.toInteger',
+  exec: function () {
+    return typeof Number.toInteger === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.sign',
+  exec: function () {
+    return typeof Math.sign === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.log10',
+  exec: function () {
+    return typeof Math.log10 === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.log2',
+  exec: function () {
+    return typeof Math.log2 === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.log1p',
+  exec: function () {
+    return typeof Math.log1p === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.expm1',
+  exec: function () {
+    return typeof Math.expm1 === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.cosh',
+  exec: function () {
+    return typeof Math.cosh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.sinh',
+  exec: function () {
+    return typeof Math.sinh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.tanh',
+  exec: function () {
+    return typeof Math.tanh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.acosh',
+  exec: function () {
+    return typeof Math.acosh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.asinh',
+  exec: function () {
+    return typeof Math.asinh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.atanh',
+  exec: function () {
+    return typeof Math.atanh === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.hypot',
+  exec: function () {
+    return typeof Math.hypot === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+},
+{
+  name: 'Math.trunc',
+  exec: function () {
+    return typeof Math.trunc === 'function';
+  },
+  res: {
+    ie10: false,
+    firefox11: false,
+    firefox12: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    chrome: false,
+    chromeDev: false,
+    chrome21: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    rhino17: false,
+    node08: false
+  }
+}
+];

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1,0 +1,1376 @@
+// exports browsers and tests
+
+exports.name = 'Non-standard';
+exports.target_file = 'non-standard/index.html';
+exports.skeleton_file = 'non-standard/skeleton.html';
+
+exports.browsers = {
+  ie7: {
+    full: 'Internet Explorer 7',
+    short: 'IE 7'
+  },
+  ie8: {
+    full: 'Inernet Explorer 8',
+    short: 'IE 8'
+  },
+  ie9: {
+    full: 'Inernet Explorer 9 RC',
+    short: 'IE 9'
+  },
+  firefox3: {
+    full: 'Firefox 3',
+    short: 'FF 3'
+  },
+  firefox3_5: {
+    full: 'Firefox 3.5, Firefox 3.6',
+    short: 'FF 3.5, 3.6'
+  },
+  firefox4: {
+    full: 'Firefox 4.0b12pre',
+    short: 'FF 4'
+  },
+  firefox5: {
+    full: 'Firefox 5',
+    short: 'FF 5'
+  },
+  firefox6: {
+    full: 'Firefox 6',
+    short: 'FF 6'
+  },
+  firefox7: {
+    full: 'Firefox 7, Firefox 8, Firefox 9, Firefox 10, Firefox 11',
+    short: 'FF 7-11'
+  },
+  firefox12: {
+    full: 'Firefox 12',
+    short: 'FF 12'
+  },
+  safari3: {
+    full: 'Safari 3.2',
+    short: 'SF 3.2'
+  },
+  safari4: {
+    full: 'Safari 4.0.5',
+    short: 'SF 4'
+  },
+  safari5: {
+    full: 'Safari 5',
+    short: 'SF 5'
+  },
+  webkit: {
+    full: 'Webkit r72487 (Nov 24, 2010)',
+    short: 'WebKit'
+  },
+  chrome7: {
+    full: 'Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev)',
+    short: 'CH 7-10'
+  },
+  opera10_10: {
+    full: 'Opera 10.10',
+    short: 'OP 10.10'
+  },
+  opera10_50: {
+    full: 'Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156)',
+    short: 'OP 10.50-11.10'
+  },
+  konq: {
+    full: 'Konqueror 4.4',
+    short: 'Konq 4.4'
+  },
+  besen: {
+    full: 'Bero\'s EcmaScript Engine (version 1.0.0.489)',
+    short: 'BESEN',
+    link: 'http://besen.sourceforge.net/'
+  },
+  rhino: {
+    full:'Rhino 1.7 release 3 PRERELEASE 2010 01 14',
+    short: 'Rhino 1.7'
+  }
+};
+
+exports.tests = [
+{
+  name: '<a href="http://kangax.github.com/nfe/#function-statements">function statement</a>',
+  exec: function () {
+    try {
+      eval('if (1) { function f(){ } } else { function f(){ } }');
+      return typeof f === 'function';
+    } catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: {
+      val: true,
+      note_id: 'function-statments-strict-mode-firefox',
+      note_html: 'From Firefox 4 on, function statements in strict mode functions are only accepted at top level or immediately within another function.'
+    },
+    firefox5: {
+      val: true,
+      note_id: 'function-statments-strict-mode-firefox'
+    },
+    firefox6: {
+      val: true,
+      note_id: 'function-statments-strict-mode-firefox'
+    },
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: {
+      val: true,
+      note_id: 'besen-extensions',
+      note_html: "With 'Javascript-specific extensions' option enabled"
+    },
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'uneval',
+  exec: function () { return typeof uneval == 'function'; },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '"toSource" method',
+  exec: function () { return 'toSource' in (function(){}) && 'toSource' in ({}) },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'function "name" property',
+  exec: function () { return (function foo(){}).name == 'foo' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'function "caller" property',
+  exec: function () { return 'caller' in (function(){}) },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'function "arity" property',
+  exec: function () {
+    return (function(){}).arity === 0 && (function(x){}).arity === 1 && (function(x, y){}).arity === 2;
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'function "arguments" property',
+  exec: function () {
+    function f(a, b) { return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo' }
+    return f(1, 'boo');
+  },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: null,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a>',
+  exec: function () { return typeof Function.prototype.isGenerator == 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a>',
+  exec: function () { return ({}).__proto__ === Object.prototype && [].__proto__ === Array.prototype },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a>',
+  exec: function () { return typeof ({}).__count__ === "number" && ({ x: 1, y: 2 }).__count__ === 2 },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a>',
+  exec: function () { return typeof ({}).__parent__ !== "undefined" },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a>',
+  exec: function () {
+    var o = { }, executed = false;
+    o.__noSuchMethod__ = function() { executed = true; }
+    try {
+      o.__i_dont_exist();
+    }
+    catch(err) { }
+    return executed;
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a>',
+  exec: function () { return '__defineGetter__' in ({ }) },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a>',
+  exec: function () { return '__defineSetter__' in ({ }) },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'const',
+  exec: function () {
+    try {
+      eval('const foobarbaz = 12');
+      return typeof foobarbaz === 'number';
+    }
+    catch(err) { return false }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'let',
+  exec: [
+    {
+      type: 'application/javascript;version=1.8',
+      script: function () {
+        test((function(){ 
+          try { return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()'); }
+          catch(err) { return false; }
+        })());
+        __script_executed = true
+      }
+    },
+    {
+      script: function () {
+        if (!__script_executed) {
+          test(false);
+          __script_executed = false;
+        }
+      }
+    }
+  ],
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'Array generics',
+  exec: function () { return typeof Array.slice === "function" && Array.slice('123').length === 3 },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'Expression closures',
+  exec: function () {
+    try {
+      return eval('(function(x)x)(1)') === 1;
+    } catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: true,
+    rhino: false
+  }
+},
+{
+  name: 'e4x',
+  exec: function () {
+    try {
+      return eval('typeof <foo/> === "xml"');
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: '<a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a>',
+  exec: function () {
+    try {
+      return eval('(function(){ var arr = #1=[1, #1#, 3]; return arr[1] === arr; })()');
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: false,
+    safari3: null,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: null,
+    opera10_50: false,
+    konq: null,
+    besen: null,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: 'RegExp "y" flag',
+  exec: function () {
+    try {
+      var re = new RegExp('\\w');
+      var re2 = new RegExp('\\w', 'y');
+      re.exec('xy');
+      re2.exec('xy');
+      return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+    }
+    catch(err) { return false }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: true,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'RegExp "x" flag',
+  exec: function () {
+    try {
+      var re = RegExp("^ ( \\d+ ) \
+                         ( \\w+ ) \
+                         ( foo  )", "x");
+      return re.exec('23xfoo')[0] === '23xfoo';
+    }
+    catch(err) { return false }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: true,
+    opera10_50: true,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'RegExp "lastMatch"',
+  exec: function () {
+    var re = /\w/;
+    re.exec('x');
+    return RegExp.lastMatch === 'x';
+  },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'RegExp.$1-$9',
+  exec: function () {
+    for (var i = 1; i < 10; i++) {
+      if (!(('$' + i) in RegExp)) return false;
+    }
+    return true;
+  },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'Callable RegExp',
+  exec: function () {
+    try {
+      return eval('/\\w/("x")[0] === "x"');
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: false,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'RegExp named groups',
+  exec: function () {
+    try {
+      return eval("/(?P<name>a)(?P=name)/.test('aa')");
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: null,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: null,
+    opera10_50: true,
+    konq: null,
+    besen: null,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: 'String.prototype.substr',
+  exec: function () { return typeof String.prototype.substr === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.trimLeft',
+  exec: function () { return typeof String.prototype.trimLeft === 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'String.prototype.trimRight',
+  exec: function () { return typeof String.prototype.trimRight === 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'String.prototype.anchor',
+  exec: function () { return typeof String.prototype.anchor === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.big',
+  exec: function () { return typeof String.prototype.big === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.blink',
+  exec: function () { return typeof String.prototype.blink === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.bold',
+  exec: function () { return typeof String.prototype.bold === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  }
+},
+{
+  name: 'String.prototype.link',
+  exec: function () { return typeof String.prototype.link === 'function' },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'Object.prototype.watch',
+  exec: function () { return typeof Object.prototype.watch == 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'Object.prototype.unwatch',
+  exec: function () { return typeof Object.prototype.unwatch == 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'Object.prototype.eval',
+  exec: function () { return typeof Object.prototype.eval == 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: true,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: 'Octal literals',
+  exec: function () {
+    try {
+      return eval('070 === 56');
+    }
+    catch(err) {
+      return false;
+    }
+  },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: true,
+    safari4: true,
+    safari5: true,
+    webkit: true,
+    chrome7: true,
+    opera10_10: true,
+    opera10_50: true,
+    konq: true,
+    besen: true,
+    rhino: true
+  },
+  separator: 'after'
+},
+{
+  name: 'error "stack"',
+  exec: function () { return 'stack' in new Error },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: true,
+    opera10_10: false,
+    opera10_50: true,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: 'error "lineNumber"',
+  exec: function () { return 'lineNumber' in new Error },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'error "fileName"',
+  exec: function () { return 'fileName' in new Error },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: true,
+    firefox3_5: true,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: true
+  }
+},
+{
+  name: 'error "description"',
+  exec: function () { return 'description' in new Error },
+  res: {
+    ie7: true,
+    ie8: true,
+    ie9: true,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: false,
+    firefox6: false,
+    firefox7: false,
+    firefox12: false,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  },
+  separator: 'after'
+},
+{
+  name: '<a href="http://wiki.ecmascript.org/doku.php?id=harmony:proxies">Proxy</a>',
+  exec: function () { return typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: true,
+    firefox5: true,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+},
+{
+  name: '<a href="http://wiki.ecmascript.org/doku.php?id=harmony:weak_maps">WeakMap</a>',
+  exec: function () {
+    return typeof WeakMap !== 'undefined' &&
+      typeof new WeakMap().get == 'function' &&
+      typeof new WeakMap().set == 'function'
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: false,
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox5: false,
+    firefox6: true,
+    firefox7: true,
+    firefox12: true,
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    webkit: false,
+    chrome7: false,
+    opera10_10: false,
+    opera10_50: false,
+    konq: false,
+    besen: false,
+    rhino: false
+  }
+}
+];

--- a/es6/index.html
+++ b/es6/index.html
@@ -52,17 +52,17 @@
           <th class="test-name">Feature name</th>
           <th class="current">Current browser</th>
           <th></th>
-          <th class="ie10" title="Internet Explorer">IE 10</th>
-          <th class="firefox11" title="Firefox">FF 11, 12</th>
-          <th class="firefox12" title="Firefox">FF 13</th>
-          <th class="firefox16" title="Firefox">FF 16</th>
-          <th class="firefox17" title="Firefox">FF 17</th>
-          <th class="firefox18" title="Firefox">FF 18</th>
-          <th class="chrome" title="Chrome">CH &lt;19</th>
-          <th class="chromeDev" title="Chrome">CH 19<a href="#experimental-flag"><sup>*</sup></a></th>
-          <th class="chrome21" title="Chrome">CH 21-24<a href="#experimental-flag"><sup>*</sup></a></th>
-          <th class="safari51" title="Safari">SF 5.1</th>
-          <th class="safari6" title="Safari">SF 6</th>
+          <th class="ie10"><abbr title="Internet Explorer">IE 10</abbr></th>
+          <th class="firefox11"><abbr title="Firefox">FF 11, 12</abbr></th>
+          <th class="firefox12"><abbr title="Firefox">FF 13</abbr></th>
+          <th class="firefox16"><abbr title="Firefox">FF 16</abbr></th>
+          <th class="firefox17"><abbr title="Firefox">FF 17</abbr></th>
+          <th class="firefox18"><abbr title="Firefox">FF 18</abbr></th>
+          <th class="chrome"><abbr title="Chrome">CH &lt;19</abbr></th>
+          <th class="chromeDev"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
+          <th class="chrome21"><abbr title="Chrome">CH 21-24</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
+          <th class="safari51"><abbr title="Safari">SF 5.1</abbr></th>
+          <th class="safari6"><abbr title="Safari">SF 6</abbr></th>
           <th class="webkit">WebKit</th>
           <th class="opera">Opera 12</th>
           <th class="rhino17">Rhino 1.7</th>
@@ -71,379 +71,367 @@
       </thead>
       <tbody>
         <tr>
-          <td>
-            class
-          </td>
-          <script>
-            test(function () {
-              try {
-                return eval('class C{ constructor() { this.own = true; } } (new C()).own;');
-                /*
-                class C{
-                  constructor() {
-                    this.own = true;
-                  }
-                }
-                (new C()).own; // true
-                */
-              } catch(error) {
-                return false;
-              }
-            }());
-          </script>
-          <td class="ie10 no">No</td>
+          <td>class</td>
+<script>
+test(function () {
+  try {
+    return eval('class C{ constructor() { this.own = true; } } (new C()).own;');
+    /*
+    class C{
+      constructor() {
+        this.own = true;
+      }
+    }
+    (new C()).own; // true
+    */
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-          <td class="firefox16 no">No</td>
-          <td class="firefox17 no">No</td>
-          <td class="firefox18 no">No</td>
-          <td class="chrome no">No</td>
-          <td class="chromeDev no">No</td>
-          <td class="chrome21 no">No</td>
-          <td class="safari51 no">No</td>
-          <td class="safari6 no">No</td>
-          <td class="webkit no">No</td>
-          <td class="opera no">No</td>
-          <td class="rhino17 no">No</td>
-          <td class="node08 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
         </tr>
         <tr>
-          <td>
-            let
-          </td>
-          <script type="application/javascript;version=1.8">
-            test(function () {
-              try {
-                return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-              } catch(error) {
-                return false;
-              }
-            }());
-            __let_script_executed = true;
-          </script>
-          <script>
-            if (!__let_script_executed ) {
-              test(function () {
-                try {
-                  return eval('(function(){ "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-                } catch(error) {
-                  return false;
-                }
-              }());
-            }
-          </script>
-            <td class="ie10 no">No</td>
+          <td>let</td>
+<script type="application/javascript;version=1.8">
+test(function () {
+  try {
+    return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+  } catch(error) {
+    return false;
+  }
+}());
+__let_script_executed = true;
+</script>
+<script>
+if (!__let_script_executed ) {
+  test(function () {
+    try {
+      return eval('(function(){ "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+    } catch(error) {
+      return false;
+    }
+  }());
+}
+</script>
 
-            <td class="firefox11 yes">Yes</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
+          <td class="no ie10">No</td>
+          <td class="yes firefox11">Yes</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="yes chromeDev">Yes</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>const</td>
+<script>
+test(function () {
+  try {
+    return eval('(function() { const foobarbaz = 12; return typeof foobarbaz === "number" })()');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          <tr>
-            <td>
-              const
-            </td>
-            <script>test((function () {
-          try {
-            return eval('(function() { const foobarbaz = 12; return typeof foobarbaz === "number" })()');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="yes chrome">Yes</td>
+          <td class="yes chromeDev">Yes</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="no rhino17">No</td>
+          <td class="yes node08">Yes</td>
+        </tr>
+        <tr>
+          <td>default function params</td>
+<script>
+test(function () {
+  try {
+    return eval('(function(a = 5) {return a === 5})()');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome yes">Yes</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 yes">Yes</td>
-            <td class="webkit yes">Yes</td>
-            <td class="opera yes">Yes</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 yes">Yes</td>
-          </tr>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>rest parameters</td>
+<script>
+test(function () {
+  try {
+    return eval('(function(...args) { return typeof args !== "undefined"; })()')
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          <tr>
-            <td>
-              default function params
-            </td>
-            <script>test((function () {
-          try {
-            return eval('(function(a = 5) {return a === 5})()');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>spread call (...) operator</td>
+<script>
+test(function () {
+  try {
+    return eval('Math.max(...[1, 2, 3]) === 3');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>spread array (...) operator</td>
+<script>
+test(function () {
+  try {
+    return eval('[...[1, 2, 3]][2] === 3');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          </tr>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td><del title="Temporarily disabled due to Chrome crash">Modules</del></td>
+<script>
+test(function () {
+  try {
+    // this line crashes Chrome 21-24
+    // return eval('module foo { }');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          <tr>
-            <td>
-              rest parameters
-            </td>
-            <script>test((function () {
-          try {
-            return eval('(function(...args) { return typeof args !== "undefined"; })()')
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>For..of loops</td>
+<script>
+test(function () {
+  try {
+    return eval('(function() {var arr = [5]; for (var item of arr) return item === 5;})()');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Array comprehensions</td>
+<script>
+test(function () {
+  try {
+    eval('[a * a for (a of [1, 2, 3])][0] === 1');
+    return true;
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          </tr>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Generator expressions</td>
+<script>
+test(function () {
+  try {
+    eval('(a for (a of [1, 2, 3]))');
+    return true;
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-          <tr>
-            <td>
-              spread call (...) operator
-            </td>
-            <script>test((function () {
-          try {
-            return eval('Math.max(...[1, 2, 3]) === 3');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Iterators</td>
+<script>
+test(function () {
+  try {
+    eval('for (var a of {b: 5}) {}');
+    return true;
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
 
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              spread array (...) operator
-            </td>
-            <script>test((function () {
-          try {
-            return eval('[...[1, 2, 3]][2] === 3');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-          <tr>
-            <td>
-              <del title="Temporarily disabled due to Chrome crash">Modules</del>
-            </td>
-            <script>test((function () {
-          try {
-            // this line crashes Chrome 21-24
-            // return eval('module foo { }');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              For..of loops
-            </td>
-            <script>test((function () {
-          try {
-            return eval('(function() {var arr = [5]; for (var item of arr) return item === 5;})()');
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              Array comprehensions
-            </td>
-            <script>test((function () {
-          try {
-            eval('[a * a for (a of [1, 2, 3])][0] === 1');
-            return true;
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Generator expressions
-            </td>
-            <script>test((function () {
-          try {
-            eval('(a for (a of [1, 2, 3]))');
-            return true;
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Iterators
-            </td>
-            <script>test((function () {
-          try {
-            eval('for (var a of {b: 5}) {}');
-            return true;
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Generators (yield)
-            </td>
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Generators (yield)</td>
 <script type="application/javascript;version=1.8">
 test((function () {
   try {
@@ -456,1008 +444,962 @@ test((function () {
 __yield_script_executed = true;
 </script>
 <script>
-  if (!__yield_script_executed) {
-    test(false);
-    __yield_script_executed = false;
-  }
+if (!__yield_script_executed) {
+  test(false);
+  __yield_script_executed = false;
+}
 </script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 yes">Yes</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Template Strings
-            </td>
-            <script>test((function () {
-          try {
-            eval('var u = function() {return true}; u`literal`');
-            return true;
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              RegExp "y" flag
-            </td>
-            <script>test((function () {
-          try {
-            var re = new RegExp('\\w');
-            var re2 = new RegExp('\\w', 'y');
-            re.exec('xy');
-            re2.exec('xy');
-            return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-          } catch(err) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 yes">Yes</td><td class="firefox12 yes">Yes</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              Maps
-            </td>
-            <script>test((function () {
-          return typeof Map !== 'undefined' &&
-            typeof Map.prototype.get === 'function' &&
-            typeof Map.prototype.set === 'function' &&
-            typeof Map.prototype.clear === 'function' &&
-            typeof Map.prototype.has === 'function' &&
-            typeof Map.prototype.forEach === 'function' &&
-            typeof Map.prototype.size === 'number' &&
-            Map([["key", "val"]]).has("key");
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              Sets
-            </td>
-            <script>test((function () {
-
-          return typeof Set !== 'undefined' &&
-            typeof Set.prototype.add === 'function' &&
-            typeof Set.prototype.values === 'function' &&
-            typeof Set.prototype.clear === 'function' &&
-            typeof Set.prototype.has === 'function' &&
-            typeof Set.prototype.forEach === 'function' &&
-            typeof Set.prototype.size === 'number' &&
-            Set([1]).has(1);
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              WeakMaps
-            </td>
-            <script>test((function () {
-          return typeof WeakMap !== 'undefined' &&
-            typeof WeakMap.prototype.get === 'function' &&
-            typeof WeakMap.prototype.set === 'function' &&
-            typeof WeakMap.prototype.clear === 'function' &&
-            typeof WeakMap.prototype.has === 'function';
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              Proxies
-            </td>
-            <script>test((function () {
-          return typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' && typeof Proxy.createFunction == 'function';
-        })())</script>
-              <td class="ie10 no">No</td>
-
-              <td class="firefox11 no">No</td><td class="firefox12 No">No</td>
-              <td class="firefox16 yes">Yes</td>
-              <td class="firefox17 yes">Yes</td>
-              <td class="firefox18 yes">Yes</td>
-              <td class="chrome no">No</td>
-              <td class="chromeDev no">No</td>
-              <td class="chrome21 yes">Yes</td>
-              <td class="safari51 no">No</td>
-              <td class="safari6 no">No</td>
-              <td class="webkit no">No</td>
-              <td class="opera no">No</td>
-              <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-          </tr>
-
-          <tr>
-            <td>
-              Structs (binary data storage)
-            </td>
-            <script>test(typeof StructType !== 'undefined')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Block-level function declaration
-            </td>
-            <script>
-              test((function() {
-                'use strict';
-                try {
-                  return eval('{function f(){}} typeof f == "undefined"');
-                } catch(error) {
-                  return false;
-                }
-              })());
-            </script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Object.getOwnPropertyDescriptors
-            </td>
-            <script>test(typeof Object.getOwnPropertyDescriptors === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Object.getPropertyDescriptor
-            </td>
-            <script>test(typeof Object.getPropertyDescriptor === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Object.getPropertyNames
-            </td>
-            <script>test(typeof Object.getPropertyNames === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Object.is
-            </td>
-            <script>test(typeof Object.is === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 yes">Yes</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Object.isnt
-            </td>
-            <script>test(typeof Object.isnt === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.fromCodePoint
-            </td>
-            <script>test(typeof String.fromCodePoint === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.codePointAt
-            </td>
-            <script>test(typeof String.prototype.codePointAt === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.repeat
-            </td>
-            <script>test(typeof String.prototype.repeat === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.startsWith
-            </td>
-            <script>test(typeof String.prototype.startsWith === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.endsWith
-            </td>
-            <script>test(typeof String.prototype.endsWith === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.contains
-            </td>
-            <script>test(typeof String.prototype.contains === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              String.prototype.toArray
-            </td>
-            <script>test(typeof String.prototype.toArray === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Unicode code point escapes
-            </td>
-            <script>test((function() {
-          try {
-            return eval("'\\u{1d306}' == '\\ud834\\udf06'");
-          } catch(error) {
-            return false;
-          }
-        })())</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Array.from
-            </td>
-            <script>test(typeof Array.from === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Array.of
-            </td>
-            <script>test(typeof Array.of === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Number.isFinite
-            </td>
-            <script>test(typeof Number.isFinite === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 yes">Yes</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Number.isInteger
-            </td>
-            <script>test(typeof Number.isInteger === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Number.isNaN
-            </td>
-            <script>test(typeof Number.isNaN === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev yes">Yes</td>
-            <td class="chrome21 yes">Yes</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 yes">Yes</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Number.toInteger
-            </td>
-            <script>test(typeof Number.toInteger === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 yes">Yes</td>
-            <td class="firefox17 yes">Yes</td>
-            <td class="firefox18 yes">Yes</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.sign
-            </td>
-            <script>test(typeof Math.sign === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.log10
-            </td>
-            <script>test(typeof Math.log10 === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.log2
-            </td>
-            <script>test(typeof Math.log2 === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.log1p
-            </td>
-            <script>test(typeof Math.log1p === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.expm1
-            </td>
-            <script>test(typeof Math.expm1 === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.cosh
-            </td>
-            <script>test(typeof Math.cosh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.sinh
-            </td>
-            <script>test(typeof Math.sinh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.tanh
-            </td>
-            <script>test(typeof Math.tanh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.acosh
-            </td>
-            <script>test(typeof Math.acosh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.asinh
-            </td>
-            <script>test(typeof Math.asinh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.atanh
-            </td>
-            <script>test(typeof Math.atanh === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.hypot
-            </td>
-            <script>test(typeof Math.hypot === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
-
-          <tr>
-            <td>
-              Math.trunc
-            </td>
-            <script>test(typeof Math.trunc === 'function')</script>
-            <td class="ie10 no">No</td>
-
-            <td class="firefox11 no">No</td><td class="firefox12 no">No</td>
-            <td class="firefox16 no">No</td>
-            <td class="firefox17 no">No</td>
-            <td class="firefox18 no">No</td>
-            <td class="chrome no">No</td>
-            <td class="chromeDev no">No</td>
-            <td class="chrome21 no">No</td>
-            <td class="safari51 no">No</td>
-            <td class="safari6 no">No</td>
-            <td class="webkit no">No</td>
-            <td class="opera no">No</td>
-            <td class="rhino17 no">No</td>
-            <td class="node08 no">No</td>
-
-          </tr>
 
+          <td class="no ie10">No</td>
+          <td class="yes firefox11">Yes</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Template Strings</td>
+<script>
+test(function () {
+  try {
+    eval('var u = function() {return true}; u`literal`');
+    return true;
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>RegExp "y" flag</td>
+<script>
+test(function () {
+  try {
+    var re = new RegExp('\\w');
+    var re2 = new RegExp('\\w', 'y');
+    re.exec('xy');
+    re2.exec('xy');
+    return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+  } catch(err) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="yes firefox11">Yes</td>
+          <td class="yes firefox12">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Maps</td>
+<script>
+test(typeof Map !== 'undefined' &&
+    typeof Map.prototype.get === 'function' &&
+    typeof Map.prototype.set === 'function' &&
+    typeof Map.prototype.clear === 'function' &&
+    typeof Map.prototype.has === 'function' &&
+    typeof Map.prototype.forEach === 'function' &&
+    typeof Map.prototype.size === 'number' &&
+    Map([["key", "val"]]).has("key"));
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Sets</td>
+<script>
+test(typeof Set !== 'undefined' &&
+    typeof Set.prototype.add === 'function' &&
+    typeof Set.prototype.values === 'function' &&
+    typeof Set.prototype.clear === 'function' &&
+    typeof Set.prototype.has === 'function' &&
+    typeof Set.prototype.forEach === 'function' &&
+    typeof Set.prototype.size === 'number' &&
+    Set([1]).has(1));
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>WeakMaps</td>
+<script>
+test(typeof WeakMap !== 'undefined' &&
+    typeof WeakMap.prototype.get === 'function' &&
+    typeof WeakMap.prototype.set === 'function' &&
+    typeof WeakMap.prototype.clear === 'function' &&
+    typeof WeakMap.prototype.has === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Proxies</td>
+<script>
+test(typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' && typeof Proxy.createFunction == 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Structs (binary data storage)</td>
+<script>
+test(typeof StructType !== 'undefined');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Block-level function declaration</td>
+<script>
+test(function () {
+  'use strict';
+  try {
+    return eval('{function f(){}} typeof f == "undefined"');
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Object.getOwnPropertyDescriptors</td>
+<script>
+test(typeof Object.getOwnPropertyDescriptors === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Object.getPropertyDescriptor</td>
+<script>
+test(typeof Object.getPropertyDescriptor === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Object.getPropertyNames</td>
+<script>
+test(typeof Object.getPropertyNames === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Object.is</td>
+<script>
+test(typeof Object.is === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="yes chromeDev">Yes</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="yes node08">Yes</td>
+        </tr>
+        <tr>
+          <td>Object.isnt</td>
+<script>
+test(typeof Object.isnt === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.fromCodePoint</td>
+<script>
+test(typeof String.fromCodePoint === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.codePointAt</td>
+<script>
+test(typeof String.prototype.codePointAt === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.repeat</td>
+<script>
+test(typeof String.prototype.repeat === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.startsWith</td>
+<script>
+test(typeof String.prototype.startsWith === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.endsWith</td>
+<script>
+test(typeof String.prototype.endsWith === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.contains</td>
+<script>
+test(typeof String.prototype.contains === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>String.prototype.toArray</td>
+<script>
+test(typeof String.prototype.toArray === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Unicode code point escapes</td>
+<script>
+test(function () {
+  try {
+    return eval("'\\u{1d306}' == '\\ud834\\udf06'");
+  } catch(error) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Array.from</td>
+<script>
+test(typeof Array.from === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Array.of</td>
+<script>
+test(typeof Array.of === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Number.isFinite</td>
+<script>
+test(typeof Number.isFinite === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="yes chromeDev">Yes</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="yes node08">Yes</td>
+        </tr>
+        <tr>
+          <td>Number.isInteger</td>
+<script>
+test(typeof Number.isInteger === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Number.isNaN</td>
+<script>
+test(typeof Number.isNaN === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="yes chromeDev">Yes</td>
+          <td class="yes chrome21">Yes</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="yes node08">Yes</td>
+        </tr>
+        <tr>
+          <td>Number.toInteger</td>
+<script>
+test(typeof Number.toInteger === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.sign</td>
+<script>
+test(typeof Math.sign === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.log10</td>
+<script>
+test(typeof Math.log10 === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.log2</td>
+<script>
+test(typeof Math.log2 === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.log1p</td>
+<script>
+test(typeof Math.log1p === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.expm1</td>
+<script>
+test(typeof Math.expm1 === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.cosh</td>
+<script>
+test(typeof Math.cosh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.sinh</td>
+<script>
+test(typeof Math.sinh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.tanh</td>
+<script>
+test(typeof Math.tanh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.acosh</td>
+<script>
+test(typeof Math.acosh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.asinh</td>
+<script>
+test(typeof Math.asinh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.atanh</td>
+<script>
+test(typeof Math.atanh === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.hypot</td>
+<script>
+test(typeof Math.hypot === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
+        <tr>
+          <td>Math.trunc</td>
+<script>
+test(typeof Math.trunc === 'function');
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no firefox11">No</td>
+          <td class="no firefox12">No</td>
+          <td class="no firefox16">No</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no chrome">No</td>
+          <td class="no chromeDev">No</td>
+          <td class="no chrome21">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+        </tr>
       </tbody>
     </table>
     </div>
     <div id="footnotes">
-      <p id="experimental-flag">
-        <sup>*</sup> Have to be enabled via "Experimental Javascript features" flag
+      <p id="experimental-flag-note">
+        <sup>[1]</sup> Have to be enabled via "Experimental Javascript features" flag
       </p>
     </div>
   </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -1,0 +1,69 @@
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>ECMAScript compatibility table</title>
+    <link rel="stylesheet" href="../master.css" type="text/css">
+    <script src="../ready.js"></script>
+    <script src="../master.js"></script>
+    <script>
+      var __yield_script_executed, __let_script_executed;
+    </script>
+</head>
+<body class="es6">
+  <div id="header">
+    <h1 style="overflow:hidden">
+      <a href="http://kangax.github.com/es-compat-table/" style="float:left">
+        <span title="ECMA-262">ECMAScript</span> 6 compatibility table
+      </a>
+
+      <span style="font-size:0.8em;float:right;font-weight:normal;">
+        <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://kangax.github.com/es5-compat-table/non-standard"></a>
+        <noscript>
+          <a href="https://flattr.com/thing/138679/ECMAScript-5-compatibility-table-non-standard-extensions" target="_blank">
+            <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0">
+          </a>
+        </noscript>
+        <script async="" src="http://www.google-analytics.com/ga.js"></script>
+        <script>
+          (function() {
+            var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
+            s.async = true;
+            s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+            t.parentNode.insertBefore(s, t);
+          })();
+        </script>
+        <span style="position:relative;top:-6px">
+          by <a href="http://twitter.com/kangax" style="color:#eee">kangax</a>
+        </span>
+      </span>
+    </h1>
+  </div>
+  <div id="body">
+    <p class="warning">Please note that <i>some of these tests</i> represent <strong>existence</strong>,
+      not functionality or full conformance.</p>
+    <div id="table-wrapper">
+      <table>
+      <colgroup>
+        <col>
+        <col class="this-browser-col">
+      </colgroup>
+      <thead>
+        <tr>
+          <th class="test-name">Feature name</th>
+          <th class="current">Current browser</th>
+          <th></th>
+          <!-- TABLE HEADERS -->
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TABLE BODY -->
+      </tbody>
+    </table>
+    </div>
+    <div id="footnotes">
+      <!-- FOOTNOTES -->
+    </div>
+  </div>
+  <pre class="info-tooltip" style="display:none"></pre>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -70,44 +70,32 @@
             <th class="ie8"><abbr title="Internet Explorer 8">IE 8</abbr></th>
             <th class="ie9"><abbr title="Internet Explorer 9">IE 9</abbr></th>
             <th class="ie10"><abbr title="Internet Explorer 10 PP2">IE 10</abbr></th>
-
             <th class="firefox3"><abbr title="Firefox 3">FF 3</abbr></th>
             <th class="firefox3_5"><abbr title="Firefox 3.5, Firefox 3.6">FF 3.5, 3.6</abbr></th>
-            <th class="firefox4">
-              <abbr title="Firefox 4, Firefox 5, Firefox 6.0, Firefox 7.0.1, Firefox 8.0, Firefox 9.0, Firefox 10.0, Firefox 11.0, Firefox 12.0, Firefox 13.0">FF 4-13</abbr>
-            </th>
-
+            <th class="firefox4"><abbr title="Firefox 4, Firefox 5, Firefox 6.0, Firefox 7.0.1, Firefox 8.0, Firefox 9.0, Firefox 10.0, Firefox 11.0, Firefox 12.0, Firefox 13.0">FF 4-13</abbr></th>
             <th class="safari3"><abbr title="Safari 3.2">SF 3.2</abbr></th>
             <th class="safari4"><abbr title="Safari 4.0.5">SF 4</abbr></th>
             <th class="safari5"><abbr title="Safari 5.0.5">SF 5</abbr></th>
             <th class="safari51"><abbr title="Safari 5.1">SF 5.1</abbr></th>
             <th class="safari6"><abbr title="Safari 6.0">SF 6</abbr></th>
-            <th class="webkit" title="Webkit r120398 (June 20, 2012)">WebKit</th>
-
+            <th class="webkit"><abbr title="Webkit r120398 (June 20, 2012)">WebKit</abbr></th>
             <th class="chrome5"><abbr title="Chrome 5 (5.0.375.127)">CH 5</abbr></th>
             <th class="chrome6"><abbr title="Chrome 6 (6.0.472.55)">CH 6</abbr></th>
             <th class="chrome7"><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev), Chrome 10, Chrome 11, Chrome 12 (12.0.742.91)">CH 7-12</abbr></th>
             <th class="chrome13"><abbr title="Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)">CH 13-16</abbr></th>
             <th class="chrome19"><abbr title="Chrome 19 (19.0.1084.56 stable)">CH 19+</abbr></th>
-
             <th class="opera10_10"><abbr title="Opera 10.10">OP 10.1</abbr></th>
-            <th class="opera10_50"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156), Opera 11.10 (build 2048), Opera 11.11 (build 2109), Opera 11.50 (build 1074)">
-              OP 10.50-11.50
-            </abbr></th>
+            <th class="opera10_50"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156), Opera 11.10 (build 2048), Opera 11.11 (build 2109), Opera 11.50 (build 1074)">OP 10.50-11.50</abbr></th>
             <th class="opera12"><abbr title="Opera 12 (build 1065)">OP 12</abbr></th>
             <th class="opera12_10"><abbr title="Opera 12.10 (build 1652)">OP 12.10</abbr></th>
-
-            <th><abbr title="Konqueror 4.3">Konq 4.3</abbr></th>
-
-            <th><a title="Bero's EcmaScript Engine (version 1.0.0.489)" href="http://besen.sourceforge.net/">BESEN</a></th>
-
-            <th><span title="Rhino 1.7 release 3 PRERELEASE 2010 01 14">Rhino 1.7</span></th>
+            <th class="konq"><abbr title="Konqueror 4.3">Konq 4.3</abbr></th>
+            <th class="besen"><a href="http://besen.sourceforge.net/"><abbr title="Bero's EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
+            <th class="rhino"><abbr title="Rhino 1.7 release 3 PRERELEASE 2010 01 14">Rhino 1.7</abbr></th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>Object.create</td>
-
 <script>
 test(typeof Object.create == 'function');
 </script>
@@ -116,76 +104,62 @@ test(typeof Object.create == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.defineProperty</td>
-
 <script>
 test(typeof Object.defineProperty == 'function');
 </script>
 
             <td class="no ie7">No</td>
-            <td class="yes ie8">Yes <a href="#define-property-ie-note"><sup>[1]</sup></a></td>
+            <td class="yes ie8">Yes<a href="#define-property-ie-note"><sup>[1]</sup></a></td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
-            <td class="yes safari5">Yes <a href="#define-property-webkit-note"><sup>[6]</sup></a></td>
+            <td class="yes safari5">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
-            <td class="yes webkit">Yes <a href="#define-property-webkit-note"><sup>[6]</sup></a></td>
-
+            <td class="yes webkit">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.defineProperties</td>
-
 <script>
 test(typeof Object.defineProperties == 'function');
 </script>
@@ -194,37 +168,30 @@ test(typeof Object.defineProperties == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.getPrototypeOf</td>
-
 <script>
 test(typeof Object.getPrototypeOf == 'function');
 </script>
@@ -233,37 +200,30 @@ test(typeof Object.getPrototypeOf == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.keys</td>
-
 <script>
 test(typeof Object.keys == 'function');
 </script>
@@ -272,37 +232,30 @@ test(typeof Object.keys == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.seal</td>
-
 <script>
 test(typeof Object.seal == 'function');
 </script>
@@ -311,37 +264,30 @@ test(typeof Object.seal == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.freeze</td>
-
 <script>
 test(typeof Object.freeze == 'function');
 </script>
@@ -350,37 +296,30 @@ test(typeof Object.freeze == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.preventExtensions</td>
-
 <script>
 test(typeof Object.preventExtensions == 'function');
 </script>
@@ -389,38 +328,30 @@ test(typeof Object.preventExtensions == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>Object.isSealed</td>
-
 <script>
 test(typeof Object.isSealed == 'function');
 </script>
@@ -429,37 +360,30 @@ test(typeof Object.isSealed == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.isFrozen</td>
-
 <script>
 test(typeof Object.isFrozen == 'function');
 </script>
@@ -468,37 +392,30 @@ test(typeof Object.isFrozen == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.isExtensible</td>
-
 <script>
 test(typeof Object.isExtensible == 'function');
 </script>
@@ -507,37 +424,30 @@ test(typeof Object.isExtensible == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.getOwnPropertyDescriptor</td>
-
 <script>
 test(typeof Object.getOwnPropertyDescriptor == 'function');
 </script>
@@ -546,37 +456,30 @@ test(typeof Object.getOwnPropertyDescriptor == 'function');
             <td class="yes ie8">Yes</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Object.getOwnPropertyNames</td>
-
 <script>
 test(typeof Object.getOwnPropertyNames == 'function');
 </script>
@@ -585,40 +488,33 @@ test(typeof Object.getOwnPropertyNames == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <th colspan="11" class="separator"></th>
+            <th colspan="28" class="separator"></th>
           </tr>
           <tr>
             <td>Date.prototype.toISOString</td>
-
 <script>
 test(typeof Date.prototype.toISOString == 'function');
 </script>
@@ -627,38 +523,30 @@ test(typeof Date.prototype.toISOString == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>Date.now</td>
-
 <script>
 test(typeof Date.now == 'function');
 </script>
@@ -667,38 +555,30 @@ test(typeof Date.now == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>Array.isArray</td>
-
 <script>
 test(typeof Array.isArray == 'function');
 </script>
@@ -707,38 +587,30 @@ test(typeof Array.isArray == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>JSON</td>
-
 <script>
 test(typeof JSON == 'object');
 </script>
@@ -747,38 +619,30 @@ test(typeof JSON == 'object');
             <td class="yes ie8">Yes</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
-            <td class="no">No</td>
-
+            <td class="no konq">No</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>Function.prototype.bind</td>
-
 <script>
 test(typeof Function.prototype.bind == 'function');
 </script>
@@ -787,38 +651,30 @@ test(typeof Function.prototype.bind == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
-            <td class="no safari51">No <sup><a href="#safari-bind">[8]</a></sup></td>
+            <td class="no safari51">No<a href="#safari-bind-note"><sup>[3]</sup></a></td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="no chrome6">No</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
-
           <tr>
             <td>String.prototype.trim</td>
-
 <script>
 test(typeof String.prototype.trim == 'function');
 </script>
@@ -827,40 +683,33 @@ test(typeof String.prototype.trim == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <th colspan="11" class="separator"></th>
+            <th colspan="28" class="separator"></th>
           </tr>
           <tr>
             <td>Array.prototype.indexOf</td>
-
 <script>
 test(typeof Array.prototype.indexOf == 'function');
 </script>
@@ -869,37 +718,30 @@ test(typeof Array.prototype.indexOf == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.lastIndexOf</td>
-
 <script>
 test(typeof Array.prototype.lastIndexOf == 'function');
 </script>
@@ -908,37 +750,30 @@ test(typeof Array.prototype.lastIndexOf == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.every</td>
-
 <script>
 test(typeof Array.prototype.every == 'function');
 </script>
@@ -947,37 +782,30 @@ test(typeof Array.prototype.every == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.some</td>
-
 <script>
 test(typeof Array.prototype.some == 'function');
 </script>
@@ -986,37 +814,30 @@ test(typeof Array.prototype.some == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.forEach</td>
-
 <script>
 test(typeof Array.prototype.forEach == 'function');
 </script>
@@ -1025,37 +846,30 @@ test(typeof Array.prototype.forEach == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.map</td>
-
 <script>
 test(typeof Array.prototype.map == 'function');
 </script>
@@ -1064,37 +878,30 @@ test(typeof Array.prototype.map == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.filter</td>
-
 <script>
 test(typeof Array.prototype.filter == 'function');
 </script>
@@ -1103,37 +910,30 @@ test(typeof Array.prototype.filter == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.reduce</td>
-
 <script>
 test(typeof Array.prototype.reduce == 'function');
 </script>
@@ -1142,37 +942,30 @@ test(typeof Array.prototype.reduce == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Array.prototype.reduceRight</td>
-
 <script>
 test(typeof Array.prototype.reduceRight == 'function');
 </script>
@@ -1181,85 +974,74 @@ test(typeof Array.prototype.reduceRight == 'function');
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <th colspan="11" class="separator"></th>
+            <th colspan="28" class="separator"></th>
           </tr>
           <tr>
             <td>Getter in property initializer</td>
 <script>
-test((function(){
+test(function () {
   try {
-    return eval('({ get x(){ return 1 } }).x === 1')
+    return eval('({ get x(){ return 1 } }).x === 1');
   }
   catch(err) {
-    return false
+    return false;
   }
-})());
+}());
 </script>
+
             <td class="no ie7">No</td>
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
             <td>Setter in property initializer</td>
 <script>
-test((function(){
+test(function () {
   try {
     var value;
     eval('({ set x(v){ value = v; } }).x = 1');
@@ -1268,49 +1050,40 @@ test((function(){
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
+
             <td class="no ie7">No</td>
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <th colspan="11" class="separator"></th>
+            <th colspan="28" class="separator"></th>
           </tr>
           <tr>
-            <td>
-              Property access on strings
-              <sup><a href="#property-access-on-strings">[2]</a></sup>
-            </td>
-
+            <td>Property access on strings<a href="#property-access-on-strings-note"><sup>[4]</sup></a></td>
 <script>
 test("foobar"[3] === "b");
 </script>
@@ -1319,42 +1092,32 @@ test("foobar"[3] === "b");
             <td class="yes ie8">Yes</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="yes safari3">Yes</td>
             <td class="yes safari4">Yes</td>
             <td class="yes safari5">Yes</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="yes chrome5">Yes</td>
             <td class="yes chrome6">Yes</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="yes opera10_10">Yes</td>
             <td class="yes opera10_50">Yes</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="yes konq">Yes</td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td>
-              Reserved words as property names
-              <sup><a href="#reserved-words-note">[3]</a></sup>
-            </td>
-
+            <td>Reserved words as property names<a href="#reserved-words-note"><sup>[5]</sup></a></td>
 <script>
-test(function(){
+test(function () {
   try {
     var obj = { };
     eval('obj = ({ if: 1 })');
@@ -1370,185 +1133,131 @@ test(function(){
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="yes firefox3">Yes</td>
             <td class="yes firefox3_5">Yes</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="no chrome6">No</td>
             <td class="yes chrome7">Yes</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="no rhino">No</td>
           </tr>
           <tr>
-            <th colspan="11" class="separator"></th>
+            <th colspan="28" class="separator"></th>
           </tr>
           <tr>
-            <td>
-              Zero-width chars in identifiers
-            </td>
-
+            <td>Zero-width chars in identifiers</td>
 <script>
-test((function(){
+test(function (){
   try {
     return eval('_\u200c\u200d = true');
   } catch(e) { }
-})());
+}());
 </script>
 
             <td class="no ie7">No</td>
             <td class="no ie8">No</td>
             <td class="yes ie9">Yes</td>
             <td class="yes ie10">Yes</td>
-
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
-            <td class="yes firefox4">Yes <sup><a href="#zero-width-char-note">[4]</a></sup></td>
-
+            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[6]</sup></a></td>
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="no safari51">No</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="no chrome6">No</td>
             <td class="no chrome7">No</td>
             <td class="no chrome13">No</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="no opera12">No</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="konq"></td>
-
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td>
-              <a href="http://kangax.github.com/es5-compat-table/strict-mode/" style="text-decoration: underline; font-size: 1em">Strict mode</a>
-              <sup><a href="#strict-mode-note">[5]</a></sup>
-            </td>
-
+            <td>Strict mode<a href="#strict-mode-note"><sup>[7]</sup></a></td>
 <script>
-test((function(){
+test(function (){
   "use strict";
   return !this;
-})());
+}());
 </script>
 
             <td class="no ie7">No</td>
             <td class="no ie8">No</td>
             <td class="no ie9">No</td>
-            <td class="no ie10">No<a href="#strict-mode-ie10"><sup>[7]</sup></a></td>
-
+            <td class="no ie10">No<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
             <td class="no firefox3">No</td>
             <td class="no firefox3_5">No</td>
             <td class="yes firefox4">Yes</td>
-
             <td class="no safari3">No</td>
             <td class="no safari4">No</td>
             <td class="no safari5">No</td>
             <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
-
             <td class="no chrome5">No</td>
             <td class="no chrome6">No</td>
             <td class="no chrome7">No</td>
             <td class="yes chrome13">Yes</td>
             <td class="yes chrome19">Yes</td>
-
             <td class="no opera10_10">No</td>
             <td class="no opera10_50">No</td>
             <td class="yes opera12">Yes</td>
             <td class="yes opera12_10">Yes</td>
-
             <td class="no konq">No</td>
-
             <td class="yes besen">Yes</td>
             <td class="no rhino">No</td>
           </tr>
         </tbody>
       </table>
+
     </div>
     <div id="footnotes">
       <p id="define-property-ie-note">
-        <sup>[1]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects
-          (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).
-      </p>
-      <p id="property-access-on-strings">
-        <sup>[2]</sup> For example: <code>"foobar"[3] === "b"</code>
-      </p>
-      <p id="reserved-words-note">
-        <sup>[3]</sup> For example: <code>({ if: 1 })</code>
-      </p>
-      <p id="zero-width-char-note">
-        <sup>[4]</sup>Firefox 4 &amp; 5 fail this test
-      </p>
-      <p id="strict-mode-note">
-        <sup>[5]</sup> Strict mode is assumed to be supported when the following expression evaluates to <code>true</code> —
-          <code>(function(){ "use strict"; return !this; })();</code>
+        <sup>[1]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).
       </p>
       <p id="define-property-webkit-note">
-        <sup>[6]</sup> In some versions of WebKit <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.
+        <sup>[2]</sup> In some versions of WebKit <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.
       </p>
-      <p id="strict-mode-ie10">
-        <sup>[7]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
+      <p id="safari-bind-note">
+        <sup>[3]</sup> <code>Function.prototype.bind</code> is now supported in Safari 5.1.4
       </p>
-      <p id="safari-bind">
-        <sup>[8]</sup> <code>Function.prototype.bind</code> is now supported in Safari 5.1.4
+      <p id="property-access-on-strings-note">
+        <sup>[4]</sup> For example: <code>"foobar"[3] === "b"</code>
+      </p>
+      <p id="reserved-words-note">
+        <sup>[5]</sup> For example: <code>({ if: 1 })</code>
+      </p>
+      <p id="zero-width-char-note">
+        <sup>[6]</sup> Firefox 4 &amp; 5 fail this test
+      </p>
+      <p id="strict-mode-note">
+        <sup>[7]</sup> Strict mode is assumed to be supported when the following expression evaluates to <code>true</code> — <code>(function(){ "use strict"; return !this; })();</code>
+      </p>
+      <p id="strict-mode-ie10-note">
+        <sup>[8]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
       </p>
     </div>
-
-    <!--
-
-      Additional ES5 tests (compat. sensitive changes):
-
-      7.1
-      7.2         eval('var x\uFEFFy = 1') // should be a syntax error
-      7.3         eval('var x = "a\\\nb"'); x === 'ab'
-      7.8.5		    /x/ === /x/
-      7.8.5		    /[/]/ is allowed
-      10.4.2		  (1,eval)('…') <— should be global
-      15.4.4		  [].toString.call({ length: 0 })
-      10.6        (function(x, y){ var arr = []; for (var p in arguments) { arr.push(p) } return arr })(1, 2)
-      10.6        (function(){ return ({}).toString.call(arguments) === 'Arguments' })()
-      12.6.4      for (var p in null) { /* no type error */ }
-      15.1.1      NaN = undefined = Infinity = null; NaN !== null && Infinity !== null && undefined !== null;
-      15.1.2.2    parseInt('010') !== 8
-      15.3.4.3    (function(x){return x}).apply(null, { length: 1, 0: 1 }) === 1
-      15.3.5.2    var arr = []; for (var p in (function(){})) { arr.push(p) }; arr.indexOf('prototype') === -1;
-      15.5.5.2
-      15.9.4.2
-      15.10.2.12  /\s/.test('\uFEFF')
-      15.10.4.1
-      15.10.6.4
-      15.11.2.1, 15.11.4.3
-      15.11.4.4
-
-    -->
   </body>
 </html>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -70,7 +70,6 @@
             <th class="ie7"><abbr title="Internet Explorer 7">IE 7</abbr></th>
             <th class="ie8"><abbr title="Inernet Explorer 8">IE 8</abbr></th>
             <th class="ie9"><abbr title="Inernet Explorer 9 RC">IE 9</abbr></th>
-
             <th class="firefox3"><abbr title="Firefox 3">FF 3</abbr></th>
             <th class="firefox3_5"><abbr title="Firefox 3.5, Firefox 3.6">FF 3.5, 3.6</abbr></th>
             <th class="firefox4"><abbr title="Firefox 4.0b12pre">FF 4</abbr></th>
@@ -78,434 +77,339 @@
             <th class="firefox6"><abbr title="Firefox 6">FF 6</abbr></th>
             <th class="firefox7"><abbr title="Firefox 7, Firefox 8, Firefox 9, Firefox 10, Firefox 11">FF 7-11</abbr></th>
             <th class="firefox12"><abbr title="Firefox 12">FF 12</abbr></th>
-
             <th class="safari3"><abbr title="Safari 3.2">SF 3.2</abbr></th>
             <th class="safari4"><abbr title="Safari 4.0.5">SF 4</abbr></th>
             <th class="safari5"><abbr title="Safari 5">SF 5</abbr></th>
-            <th class="webkit" title="Webkit r72487 (Nov 24, 2010)">WebKit</th>
-
-            <th><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev)">CH 7-10</abbr></th>
-
+            <th class="webkit"><abbr title="Webkit r72487 (Nov 24, 2010)">WebKit</abbr></th>
+            <th class="chrome7"><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev)">CH 7-10</abbr></th>
             <th class="opera10_10"><abbr title="Opera 10.10">OP 10.10</abbr></th>
-            <th><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156)">
-              OP 10.50-11.10
-            </abbr></th>
-            
-            <th><abbr title="Konqueror 4.4">Konq 4.4</abbr></th>
-            
-            <th><a title="Bero's EcmaScript Engine (version 1.0.0.489)" href="http://besen.sourceforge.net/">BESEN</a></th>
-            
-            <th><span title="Rhino 1.7 release 3 PRERELEASE 2010 01 14">Rhino 1.7</span></th>
+            <th class="opera10_50"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156)">OP 10.50-11.10</abbr></th>
+            <th class="konq"><abbr title="Konqueror 4.4">Konq 4.4</abbr></th>
+            <th class="besen"><a href="http://besen.sourceforge.net/"><abbr title="Bero's EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
+            <th class="rhino"><abbr title="Rhino 1.7 release 3 PRERELEASE 2010 01 14">Rhino 1.7</abbr></th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>
-              <a href="http://kangax.github.com/nfe/#function-statements">function statement</a>
-            </td>
-            
+            <tr>
+              <td><a href="http://kangax.github.com/nfe/#function-statements">function statement</a></td>
 <script>
-test((function(){ 
+test(function () {
   try {
     eval('if (1) { function f(){ } } else { function f(){ } }');
     return typeof f === 'function';
   } catch(err) {
     return false;
   }
-})());
+}());
 </script>
-            
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes<a href="#function-statments-strict-mode-firefoxe"><sup>[1]</sup></a></td>
-            <td class="yes firefox5">Yes<a href="#function-statments-strict-mode-firefox"><sup>[1]</sup></a></td>
-            <td class="yes firefox6">Yes<a href="#function-statments-strict-mode-firefox"><sup>[1]</sup></a></td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="yes konq">Yes</td>
-            
-            <td class="yes besen" title="with 'Javascript-specific extensions' option enabled">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>uneval</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes<a href="#function-statments-strict-mode-firefox-note"><sup>[1]</sup></a></td>
+              <td class="yes firefox5">Yes<a href="#function-statments-strict-mode-firefox-note"><sup>[1]</sup></a></td>
+              <td class="yes firefox6">Yes<a href="#function-statments-strict-mode-firefox-note"><sup>[1]</sup></a></td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes<a href="#besen-extensions-note"><sup>[2]</sup></a></td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>uneval</td>
 <script>
 test(typeof uneval == 'function');
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>"toSource" method</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>"toSource" method</td>
 <script>
 test('toSource' in (function(){}) && 'toSource' in ({}));
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>          
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>function "name" property</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>function "name" property</td>
 <script>
 test((function foo(){}).name == 'foo');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="yes konq">Yes</td>
-            
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>function "caller" property</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>function "caller" property</td>
 <script>
 test('caller' in (function(){}));
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="yes konq">Yes</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>function "arity" property</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>function "arity" property</td>
 <script>
 test((function(){}).arity === 0 && (function(x){}).arity === 1 && (function(x, y){}).arity === 2);
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>function "arguments" property</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>function "arguments" property</td>
 <script>
-test((function() {
+test(function () {
   function f(a, b) { return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo' }
   return f(1, 'boo');
-})());
+}());
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class=" safari3"></td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="yes konq">Yes</td>
-            
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></td>
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="safari3"></td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></td>
 <script>
 test(typeof Function.prototype.isGenerator == 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>          
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a></td>
 <script>
 test(({}).__proto__ === Object.prototype && [].__proto__ === Array.prototype);
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="yes konq">Yes</td>
-            
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></td>
 <script>
 test(typeof ({}).__count__ === "number" && ({ x: 1, y: 2 }).__count__ === 2);
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="no firefox4">No</td>        
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></td>
 <script>
 test(typeof ({}).__parent__ !== "undefined");
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></td>
 <script>
-test((function(){
+test(function () {
   var o = { }, executed = false;
   o.__noSuchMethod__ = function() { executed = true; }
   try {
@@ -513,154 +417,122 @@ test((function(){
   }
   catch(err) { }
   return executed;
-})());
+}());
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td> 
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></td>
 <script>
 test('__defineGetter__' in ({ }));
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a>
-            </td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></td>
 <script>
 test('__defineSetter__' in ({ }));
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>const</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>const</td>
 <script>
-test((function(){ 
-  try { 
-    eval('const foobarbaz = 12'); 
-    return typeof foobarbaz === 'number'; 
-  } 
+test(function () {
+  try {
+    eval('const foobarbaz = 12');
+    return typeof foobarbaz === 'number';
+  }
   catch(err) { return false }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>let</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>let</td>
 <script type="application/javascript;version=1.8">
 test((function(){ 
   try { return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()'); }
@@ -668,1089 +540,887 @@ test((function(){
 })());
 __script_executed = true
 </script>
-            
-            <script>
-              if (!__script_executed) {
-                test(false);
-                __script_executed = false;
-              }
-            </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
+<script>
+if (!__script_executed) {
+  test(false);
+  __script_executed = false;
+}
+</script>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">no</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>Array generics</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>Array generics</td>
 <script>
 test(typeof Array.slice === "function" && Array.slice('123').length === 3);
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>Expression closures</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>Expression closures</td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval('(function(x)x)(1)') === 1;
   } catch(err) {
     return false;
   }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="yes besen">Yes</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>e4x</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="yes besen">Yes</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>e4x</td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval('typeof <foo/> === "xml"');
   }
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></td>
-
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval('(function(){ var arr = #1=[1, #1#, 3]; return arr[1] === arr; })()');
   }
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="no firefox12">No</td>
-
-            <td class=" safari3"></td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class=" opera10_10"></td>
-            <td class="no opera10_50">No</td>
-
-            <td class=" konq"></td>
-
-            <td class=" besen"></td>
-            <td class="no rhino">No</td>
-          </tr>
-
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          
-          <tr>
-            <td>RegExp "y" flag</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="no firefox12">No</td>
+              <td class="safari3"></td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="opera10_10"></td>
+              <td class="no opera10_50">No</td>
+              <td class="konq"></td>
+              <td class="besen"></td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>RegExp "y" flag</td>
 <script>
-test((function(){
+test(function () {
   try {
     var re = new RegExp('\\w');
     var re2 = new RegExp('\\w', 'y');
     re.exec('xy');
     re2.exec('xy');
     return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-  } 
+  }
   catch(err) { return false }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>RegExp "x" flag</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>RegExp "x" flag</td>
 <script>
-test((function(){
+test(function () {
   try {
     var re = RegExp("^ ( \\d+ ) \
                        ( \\w+ ) \
                        ( foo  )", "x");
     return re.exec('23xfoo')[0] === '23xfoo';
-  } 
+  }
   catch(err) { return false }
-})());
+}());
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          
-          <tr>
-            <td>RegExp "lastMatch"</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>RegExp "lastMatch"</td>
 <script>
-test((function(){
+test(function () {
   var re = /\w/;
   re.exec('x');
   return RegExp.lastMatch === 'x';
-})());
+}());
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-            
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>RegExp.$1-$9</td>
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>RegExp.$1-$9</td>
 <script>
-test((function(){
+test(function () {
   for (var i = 1; i < 10; i++) {
     if (!(('$' + i) in RegExp)) return false;
   }
   return true;
-})());
+}());
 </script>
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>Callable RegExp</td>
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>Callable RegExp</td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval('/\\w/("x")[0] === "x"');
   }
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="no webkit">No</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>RegExp named groups</td>
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="no webkit">No</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>RegExp named groups</td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval("/(?P<name>a)(?P=name)/.test('aa')");
   }
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class=" safari3"></td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class=" opera10_10"></td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class=" konq"></td>
-
-            <td class=" besen"></td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>  
-          <tr>
-            <td>String.prototype.substr</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="safari3"></td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="opera10_10"></td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="konq"></td>
+              <td class="besen"></td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>String.prototype.substr</td>
 <script>
 test(typeof String.prototype.substr === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>String.prototype.trimLeft</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>String.prototype.trimLeft</td>
 <script>
 test(typeof String.prototype.trimLeft === 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-        <tr>
-            <td>String.prototype.trimRight</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>String.prototype.trimRight</td>
 <script>
 test(typeof String.prototype.trimRight === 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>String.prototype.anchor</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>String.prototype.anchor</td>
 <script>
 test(typeof String.prototype.anchor === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-            
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>String.prototype.big</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>String.prototype.big</td>
 <script>
 test(typeof String.prototype.big === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>String.prototype.blink</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>String.prototype.blink</td>
 <script>
 test(typeof String.prototype.blink === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>String.prototype.bold</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>String.prototype.bold</td>
 <script>
 test(typeof String.prototype.bold === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>String.prototype.link</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>String.prototype.link</td>
 <script>
 test(typeof String.prototype.link === 'function');
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>Object.prototype.watch</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>Object.prototype.watch</td>
 <script>
 test(typeof Object.prototype.watch == 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>Object.prototype.unwatch</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>Object.prototype.unwatch</td>
 <script>
 test(typeof Object.prototype.unwatch == 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>Object.prototype.eval</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>Object.prototype.eval</td>
 <script>
 test(typeof Object.prototype.eval == 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>Octal literals</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="yes besen">Yes</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>Octal literals</td>
 <script>
-test((function(){
+test(function () {
   try {
     return eval('070 === 56');
   }
   catch(err) {
     return false;
   }
-})());
+}());
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="yes safari3">Yes</td>
-            <td class="yes safari4">Yes</td>
-            <td class="yes safari5">Yes</td>
-            <td class="yes webkit">Yes</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="yes opera10_10">Yes</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="yes konq">Yes</td>
-
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td>error "stack"</td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="yes safari3">Yes</td>
+              <td class="yes safari4">Yes</td>
+              <td class="yes safari5">Yes</td>
+              <td class="yes webkit">Yes</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="yes opera10_10">Yes</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="yes konq">Yes</td>
+              <td class="yes besen">Yes</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td>error "stack"</td>
 <script>
 test('stack' in new Error);
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="yes chrome7">Yes</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="yes opera10_50">Yes</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td>error "lineNumber"</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="yes chrome7">Yes</td>
+              <td class="no opera10_10">No</td>
+              <td class="yes opera10_50">Yes</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td>error "lineNumber"</td>
 <script>
 test('lineNumber' in new Error);
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>error "fileName"</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>error "fileName"</td>
 <script>
 test('fileName' in new Error);
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="yes firefox3">Yes</td>
-            <td class="yes firefox3_5">Yes</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="yes rhino">Yes</td>
-          </tr>
-          <tr>
-            <td>error "description"</td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="yes firefox3">Yes</td>
+              <td class="yes firefox3_5">Yes</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="yes rhino">Yes</td>
+            </tr>
+            <tr>
+              <td>error "description"</td>
 <script>
 test('description' in new Error);
 </script>
 
-            <td class="yes ie7">Yes</td>
-            <td class="yes ie8">Yes</td>
-            <td class="yes ie9">Yes</td>
-
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="no firefox6">No</td>
-            <td class="no firefox7">No</td>
-            <td class="no firefox12">No</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <th colspan="11" class="separator"></th>
-          </tr>
-          <tr>
-            <td><a href="http://wiki.ecmascript.org/doku.php?id=harmony:proxies">Proxy</a></td>
-            
+              <td class="yes ie7">Yes</td>
+              <td class="yes ie8">Yes</td>
+              <td class="yes ie9">Yes</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="no firefox6">No</td>
+              <td class="no firefox7">No</td>
+              <td class="no firefox12">No</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <th colspan="23" class="separator"></th>
+            </tr>
+            <tr>
+              <td><a href="http://wiki.ecmascript.org/doku.php?id=harmony:proxies">Proxy</a></td>
 <script>
 test(typeof Proxy !== 'undefined' && typeof Proxy.create == 'function');
 </script>
 
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
-
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="yes firefox4">Yes</td>
-            <td class="yes firefox5">Yes</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-            
-            <td class="no konq">No</td>
-            
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
-          <tr>
-            <td><a href="http://wiki.ecmascript.org/doku.php?id=harmony:weak_maps">WeakMap</a></td>
-            
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="yes firefox4">Yes</td>
+              <td class="yes firefox5">Yes</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
+            <tr>
+              <td><a href="http://wiki.ecmascript.org/doku.php?id=harmony:weak_maps">WeakMap</a></td>
 <script>
-test(
-  typeof WeakMap !== 'undefined' && 
-  typeof new WeakMap().get == 'function' && 
-  typeof new WeakMap().set == 'function'
-);
+test(typeof WeakMap !== 'undefined' &&
+    typeof new WeakMap().get == 'function' &&
+    typeof new WeakMap().set == 'function');
 </script>
-            
-            <td class="no ie7">No</td>
-            <td class="no ie8">No</td>
-            <td class="no ie9">No</td>
 
-            <td class="no firefox3">No</td>
-            <td class="no firefox3_5">No</td>
-            <td class="no firefox4">No</td>
-            <td class="no firefox5">No</td>
-            <td class="yes firefox6">Yes</td>
-            <td class="yes firefox7">Yes</td>
-            <td class="yes firefox12">Yes</td>
-
-            <td class="no safari3">No</td>
-            <td class="no safari4">No</td>
-            <td class="no safari5">No</td>
-            <td class="no webkit">No</td>
-
-            <td class="no chrome7">No</td>
-
-            <td class="no opera10_10">No</td>
-            <td class="no opera10_50">No</td>
-
-            <td class="no konq">No</td>
-
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-          </tr>
+              <td class="no ie7">No</td>
+              <td class="no ie8">No</td>
+              <td class="no ie9">No</td>
+              <td class="no firefox3">No</td>
+              <td class="no firefox3_5">No</td>
+              <td class="no firefox4">No</td>
+              <td class="no firefox5">No</td>
+              <td class="yes firefox6">Yes</td>
+              <td class="yes firefox7">Yes</td>
+              <td class="yes firefox12">Yes</td>
+              <td class="no safari3">No</td>
+              <td class="no safari4">No</td>
+              <td class="no safari5">No</td>
+              <td class="no webkit">No</td>
+              <td class="no chrome7">No</td>
+              <td class="no opera10_10">No</td>
+              <td class="no opera10_50">No</td>
+              <td class="no konq">No</td>
+              <td class="no besen">No</td>
+              <td class="no rhino">No</td>
+            </tr>
         </tbody>
       </table>
     </div>
     <div id="footnotes">
-      <p id="function-statments-strict-mode-firefox">
-        <sup>[1]</sup> From Firefox 4 on, function statements in 
-		strict mode functions are only accepted at top level or 
-		immediately within another function.
-      </p>
+        <p id="function-statments-strict-mode-firefox-note">
+          <sup>[1]</sup> From Firefox 4 on, function statements in strict mode functions are only accepted at top level or immediately within another function.
+        </p>
+        <p id="besen-extensions-note">
+          <sup>[2]</sup> With 'Javascript-specific extensions' option enabled
+        </p>
     </div>
     
     <!-- 

--- a/non-standard/skeleton.html
+++ b/non-standard/skeleton.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>ECMAScript 5 extensions compatibility table</title>
+    
+    <link rel="stylesheet" href="../master.css">
+    
+    <script src="../ready.js"></script>
+    <script src="../master.js"></script>
+    
+    <script>
+      var __script_executed;
+    </script>
+    
+  </head>
+  <body class="non-standard">
+    <div id="header">
+      <h1>
+        <a href="http://kangax.github.com/es5-compat-table/non-standard">
+          <span title="ECMA-262">ECMAScript</span> extensions compatibility table
+        </a>
+        
+        <span style="font-size:0.8em;float:right;font-weight:normal;">
+          <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://kangax.github.com/es5-compat-table/non-standard"></a>
+          <noscript>
+            <a href="https://flattr.com/thing/138679/ECMAScript-5-compatibility-table-non-standard-extensions" target="_blank">
+              <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0">
+            </a>
+          </noscript>
+          <script async="" src="http://www.google-analytics.com/ga.js"></script>
+          <script>
+            (function() {
+              var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
+              s.async = true;
+              s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+              t.parentNode.insertBefore(s, t);
+            })();
+          </script>
+          <span style="position:relative;top:-6px">
+            by <a href="http://twitter.com/kangax/" style="color:#eee">kangax</a>
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div id="body">
+      <p class="warning">Please note that <i>some of these tests</i> represent <strong>existence</strong>, 
+        not functionality or full conformance.
+        I hope to test conformance sometime in the future.</p>
+      <p>
+        <a href="http://kangax.github.com/es5-compat-table/">&larr; back to the main table</a>
+      </p>
+      <p id="show-old-browsers-wrapper" style="display: none;">
+        <input type="checkbox" id="show-old-browsers">
+        <label for="show-old-browsers">Show older browsers (IE7, Firefox 3, Safari 3.2)</label>
+      </p>
+      <table>
+        <colgroup>
+          <col>
+          <col class="this-browser-col">
+        </colgroup>
+        <thead>
+          <tr>
+            <th class="test-name"></th>
+            
+            <script>
+              document.write('<th class="this-browser" title="' + navigator.userAgent + '">This browser</th><th></th>');
+            </script>
+            
+            <!-- TABLE HEADERS -->
+          </tr>
+        </thead>
+        <tbody>
+            <!-- TABLE BODY -->
+        </tbody>
+      </table>
+    </div>
+    <div id="footnotes">
+        <!-- FOOTNOTES -->
+    </div>
+    
+    <!-- 
+    <td class=" ie7">-</td>
+    <td class=" ie8">-</td>
+    <td class=" ie9">-</td>
+
+    <td class=" firefox3">-</td>
+    <td class=" firefox3_5">-</td>
+    <td class=" firefox4">-</td>
+
+    <td class=" safari3">-</td>
+    <td class=" safari4">-</td>
+    <td class=" safari5">-</td>
+    <td class=" webkit">-</td>
+
+    <td class=" chrome7">-</td>
+
+    <td class=" opera10_10">-</td>
+    <td class=" opera10_50">-</td>
+    
+    <td class=" konq">-</td>
+    
+    <td class=" besen">-</td>
+    <td class=" rhino">-</td> 
+    -->
+  </body>
+</html>

--- a/skeleton.html
+++ b/skeleton.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>ECMAScript 5 compatibility table</title>
+
+    <link rel="stylesheet" href="master.css">
+
+    <script src="ready.js"></script>
+    <script src="master.js"></script>
+
+  </head>
+  <body>
+    <div id="header">
+      <h1>
+        <a href="http://kangax.github.com/es5-compat-table/">
+          <span title="ECMA-262 5th edition">ECMAScript 5</span> compatibility table
+        </a>
+        <p class="also-see">
+          Also see:
+          Compatibility table of
+          <a href="es6"><strong>ES6</strong></a> /
+          <a href="non-standard"><strong>non-standard</strong></a>
+          features
+        </p>
+        <span style="font-size:0.8em;float:right;font-weight:normal;">
+          <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://kangax.github.com/es5-compat-table/"></a>
+          <noscript>
+            <a href="http://flattr.com/thing/135115/ECMAScript-5-compatibility-table" target="_blank">
+              <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" />
+            </a>
+          </noscript>
+          <script>
+            (function() {
+              var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
+              s.async = true;
+              s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+              t.parentNode.insertBefore(s, t);
+            })();
+          </script>
+
+          <span style="position:relative;top:-6px">
+            by <a href="http://twitter.com/kangax/" style="color:#eee">kangax</a>
+          </span>
+        </span>
+      </h1>
+    </div>
+    <div id="body">
+      <p class="warning">Please note that these tests represent <strong>existence</strong>, not functionality or full conformance.
+        I hope to test conformance sometime in the future.</p>
+
+      <p id="show-old-browsers-wrapper" style="display: none;">
+        <input type="checkbox" id="show-old-browsers">
+        <label for="show-old-browsers">Show older browsers (IE 7; FF 3; SF 3.2, 4; CH 5,6; OP 10.1)</label>
+      </p>
+      <table>
+        <colgroup>
+          <col>
+          <col class="this-browser-col">
+        </colgroup>
+        <thead>
+          <tr>
+            <th class="test-name"></th>
+
+            <script>
+              document.write('<th class="this-browser" title="' + navigator.userAgent + '">This browser</th><th></th>');
+            </script>
+
+            <!-- TABLE HEADERS -->
+          </tr>
+        </thead>
+        <tbody>
+          <!-- TABLE BODY -->
+        </tbody>
+      </table>
+
+    </div>
+    <div id="footnotes">
+      <!-- FOOTNOTES -->
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This commit adds a script to generate the tables from data, as discussed in issue #29.

My goal was to generate HTML that was as close to `index.html` (ES5 tests) as possible, while also normalizing and simplifying it. For that reason the `index.html` (ES5) diff is quite readable, which you can't say about the other tables.

It works like this:
- The data is available in `data-es5.js`, `data-es6.js` and `data-non-standard.js`
- `skeleton.html` in the three directories (`./`, `es6/`, `non-standard/`) have the base HTML which is used as a template for the to-be-generated `index.html`
- Run `node build.js` to generate the `index.html` files

What do you think?

Edit: Oh, and you can view the result at http://skalman.github.com/es5-compat-table/.
