### PR TITLE
Add note about why Firefox 13-18 fails the Map test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -542,10 +542,23 @@ exports.tests = [
   res: {
     ie10: false,
     firefox11: false,
-    firefox12: false,
-    firefox16: false,
-    firefox17: false,
-    firefox18: true,
+    firefox12: {
+      val: false,
+      note_id: 'firefox-map',
+      note_html: 'Firefox 13-18 fails the test because of lacking <code>Map.prototype.forEach</code> and because <code>Map.prototype.size</code> is a function instead of a number'
+    },
+    firefox16: {
+      val: false,
+      note_id: 'firefox-map'
+    },
+    firefox17: {
+      val: false,
+      note_id: 'firefox-map'
+    },
+    firefox18: {
+      val: false,
+      note_id: 'firefox-map'
+    },
     chrome: false,
     chromeDev: false,
     chrome21: false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -542,10 +542,10 @@ test(typeof Map !== 'undefined' &&
 
           <td class="no ie10">No</td>
           <td class="no firefox11">No</td>
-          <td class="no firefox12">No</td>
-          <td class="no firefox16">No</td>
-          <td class="no firefox17">No</td>
-          <td class="yes firefox18">Yes</td>
+          <td class="no firefox12">No<a href="#firefox-map-note"><sup>[2]</sup></a></td>
+          <td class="no firefox16">No<a href="#firefox-map-note"><sup>[2]</sup></a></td>
+          <td class="no firefox17">No<a href="#firefox-map-note"><sup>[2]</sup></a></td>
+          <td class="no firefox18">No<a href="#firefox-map-note"><sup>[2]</sup></a></td>
           <td class="no chrome">No</td>
           <td class="no chromeDev">No</td>
           <td class="no chrome21">No</td>
@@ -1400,6 +1400,9 @@ test(typeof Math.trunc === 'function');
     <div id="footnotes">
       <p id="experimental-flag-note">
         <sup>[1]</sup> Have to be enabled via "Experimental Javascript features" flag
+      </p>
+      <p id="firefox-map-note">
+        <sup>[2]</sup> Firefox 13-18 fails the test because of lacking <code>Map.prototype.forEach</code> and because <code>Map.prototype.size</code> is a function instead of a number
       </p>
     </div>
   </div>


### PR DESCRIPTION
In my pull request #45 I set Fx 18 as supporting. It turns out it doesn't support all of it, though, so now I added a note about that.
