### PR TITLE
Improve JS formatting

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -1232,8 +1232,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('({ get x(){ return 1 } }).x === 1');
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -1278,8 +1277,7 @@ exports.tests = [
       var value;
       eval('({ set x(v){ value = v; } }).x = 1');
       return value === 1;
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -1358,7 +1356,6 @@ exports.tests = [
     besen: true,
     rhino: true
   }
-
 },
 {
   name: 'Reserved words as property names',
@@ -1369,8 +1366,7 @@ exports.tests = [
       var obj = { };
       eval('obj = ({ if: 1 })');
       return obj['if'] === 1;
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -1411,10 +1407,10 @@ exports.tests = [
 },
 {
   name: 'Zero-width chars in identifiers',
-  exec: function (){
+  exec: function () {
     try {
       return eval('_\u200c\u200d = true');
-    } catch(e) { }
+    } catch (e) { }
   },
   res: {
     ie7: false,
@@ -1460,7 +1456,7 @@ exports.tests = [
   note_id: 'strict-mode',
   note_html: 'Strict mode is assumed to be supported when the following expression evaluates to <code>true</code> — ' +
     '<code>(function(){ "use strict"; return !this; })();</code>',
-  exec: function (){
+  exec: function () {
     "use strict";
     return !this;
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -80,7 +80,7 @@ exports.tests = [
       }
       (new C()).own; // true
       */
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -108,26 +108,26 @@ exports.tests = [
     {
       type: 'application/javascript;version=1.8',
       script: function () {
-        test(function () {
+        test((function () {
           try {
-            return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-          } catch(error) {
+            return eval('(function () { let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
+          } catch (e) {
             return false;
           }
-        }());
+        }()));
         __let_script_executed = true;
       }
     },
     {
       script: function () {
-        if (!__let_script_executed ) {
-          test(function () {
+        if (!__let_script_executed) {
+          test((function () {
             try {
-              return eval('(function(){ "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-            } catch(error) {
+              return eval('(function () { "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
+            } catch (e) {
               return false;
             }
-          }());
+          }()));
         }
       }
     }
@@ -154,8 +154,8 @@ exports.tests = [
   name: 'const',
   exec: function () {
     try {
-      return eval('(function() { const foobarbaz = 12; return typeof foobarbaz === "number" })()');
-    } catch(error) {
+      return eval('(function () { const foobarbaz = 12; return typeof foobarbaz === "number"; }())');
+    } catch (e) {
       return false;
     }
   },
@@ -181,8 +181,8 @@ exports.tests = [
   name: 'default function params',
   exec: function () {
     try {
-      return eval('(function(a = 5) {return a === 5})()');
-    } catch(error) {
+      return eval('(function (a = 5) { return a === 5; }())');
+    } catch (e) {
       return false;
     }
   },
@@ -208,8 +208,8 @@ exports.tests = [
   name: 'rest parameters',
   exec: function () {
     try {
-      return eval('(function(...args) { return typeof args !== "undefined"; })()')
-    } catch(error) {
+      return eval('(function (...args) { return typeof args !== "undefined"; }())');
+    } catch (e) {
       return false;
     }
   },
@@ -236,7 +236,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('Math.max(...[1, 2, 3]) === 3');
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -263,7 +263,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('[...[1, 2, 3]][2] === 3');
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -291,7 +291,7 @@ exports.tests = [
     try {
       // this line crashes Chrome 21-24
       // return eval('module foo { }');
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -317,8 +317,8 @@ exports.tests = [
   name: 'For..of loops',
   exec: function () {
     try {
-      return eval('(function() {var arr = [5]; for (var item of arr) return item === 5;})()');
-    } catch(error) {
+      return eval('(function () { var arr = [5]; for (var item of arr) return item === 5; }())');
+    } catch (e) {
       return false;
     }
   },
@@ -346,7 +346,7 @@ exports.tests = [
     try {
       eval('[a * a for (a of [1, 2, 3])][0] === 1');
       return true;
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -374,7 +374,7 @@ exports.tests = [
     try {
       eval('(a for (a of [1, 2, 3]))');
       return true;
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -402,7 +402,7 @@ exports.tests = [
     try {
       eval('for (var a of {b: 5}) {}');
       return true;
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -432,12 +432,12 @@ exports.tests = [
       script: function () {
         test((function () {
           try {
-            eval('(function() {yield 5;})()');
+            eval('(function () { yield 5; }())');
             return true;
-          } catch(error) {
+          } catch (e) {
             return false;
           }
-        })())
+        }()));
         __yield_script_executed = true;
       }
     },
@@ -472,9 +472,9 @@ exports.tests = [
   name: 'Template Strings',
   exec: function () {
     try {
-      eval('var u = function() {return true}; u`literal`');
+      eval('var u = function () { return true }; u`literal`');
       return true;
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -505,7 +505,7 @@ exports.tests = [
       re.exec('xy');
       re2.exec('xy');
       return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-    } catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -617,7 +617,9 @@ exports.tests = [
 {
   name: 'Proxies',
   exec: function () {
-    return typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' && typeof Proxy.createFunction == 'function';
+    return typeof Proxy !== 'undefined' &&
+      typeof Proxy.create == 'function' &&
+      typeof Proxy.createFunction == 'function';
   },
   res: {
     ie10: false,
@@ -662,11 +664,11 @@ exports.tests = [
 },
 {
   name: 'Block-level function declaration',
-  exec: function() {
+  exec: function () {
     'use strict';
     try {
       return eval('{function f(){}} typeof f == "undefined"');
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },
@@ -966,10 +968,10 @@ exports.tests = [
 },
 {
   name: 'Unicode code point escapes',
-  exec: function() {
+  exec: function () {
     try {
       return eval("'\\u{1d306}' == '\\ud834\\udf06'");
-    } catch(error) {
+    } catch (e) {
       return false;
     }
   },

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -83,7 +83,7 @@ exports.browsers = {
     link: 'http://besen.sourceforge.net/'
   },
   rhino: {
-    full:'Rhino 1.7 release 3 PRERELEASE 2010 01 14',
+    full: 'Rhino 1.7 release 3 PRERELEASE 2010 01 14',
     short: 'Rhino 1.7'
   }
 };
@@ -95,7 +95,7 @@ exports.tests = [
     try {
       eval('if (1) { function f(){ } } else { function f(){ } }');
       return typeof f === 'function';
-    } catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -139,7 +139,9 @@ exports.tests = [
 },
 {
   name: 'uneval',
-  exec: function () { return typeof uneval == 'function'; },
+  exec: function () {
+    return typeof uneval == 'function';
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -165,7 +167,9 @@ exports.tests = [
 },
 {
   name: '"toSource" method',
-  exec: function () { return 'toSource' in (function(){}) && 'toSource' in ({}) },
+  exec: function () {
+    return 'toSource' in (function (){}) && 'toSource' in ({});
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -192,7 +196,9 @@ exports.tests = [
 },
 {
   name: 'function "name" property',
-  exec: function () { return (function foo(){}).name == 'foo' },
+  exec: function () {
+    return (function foo(){}).name == 'foo';
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -218,7 +224,9 @@ exports.tests = [
 },
 {
   name: 'function "caller" property',
-  exec: function () { return 'caller' in (function(){}) },
+  exec: function () {
+    return 'caller' in (function(){});
+  },
   res: {
     ie7: true,
     ie8: true,
@@ -245,7 +253,9 @@ exports.tests = [
 {
   name: 'function "arity" property',
   exec: function () {
-    return (function(){}).arity === 0 && (function(x){}).arity === 1 && (function(x, y){}).arity === 2;
+    return (function (){}).arity === 0 &&
+      (function (x){}).arity === 1 &&
+      (function (x, y){}).arity === 2;
   },
   res: {
     ie7: false,
@@ -273,7 +283,9 @@ exports.tests = [
 {
   name: 'function "arguments" property',
   exec: function () {
-    function f(a, b) { return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo' }
+    function f(a, b) {
+      return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo';
+    }
     return f(1, 'boo');
   },
   res: {
@@ -301,7 +313,9 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a>',
-  exec: function () { return typeof Function.prototype.isGenerator == 'function' },
+  exec: function () {
+    return typeof Function.prototype.isGenerator == 'function';
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -328,7 +342,10 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a>',
-  exec: function () { return ({}).__proto__ === Object.prototype && [].__proto__ === Array.prototype },
+  exec: function () {
+    return ({}).__proto__ === Object.prototype &&
+      [].__proto__ === Array.prototype;
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -354,7 +371,10 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a>',
-  exec: function () { return typeof ({}).__count__ === "number" && ({ x: 1, y: 2 }).__count__ === 2 },
+  exec: function () {
+    return typeof ({}).__count__ === 'number' &&
+      ({ x: 1, y: 2 }).__count__ === 2;
+    },
   res: {
     ie7: false,
     ie8: false,
@@ -380,7 +400,9 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a>',
-  exec: function () { return typeof ({}).__parent__ !== "undefined" },
+  exec: function () {
+    return typeof ({}).__parent__ !== 'undefined';
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -408,11 +430,10 @@ exports.tests = [
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a>',
   exec: function () {
     var o = { }, executed = false;
-    o.__noSuchMethod__ = function() { executed = true; }
+    o.__noSuchMethod__ = function () { executed = true; }
     try {
       o.__i_dont_exist();
-    }
-    catch(err) { }
+    } catch (e) { }
     return executed;
   },
   res: {
@@ -440,7 +461,9 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a>',
-  exec: function () { return '__defineGetter__' in ({ }) },
+  exec: function () {
+    return '__defineGetter__' in ({ });
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -466,7 +489,9 @@ exports.tests = [
 },
 {
   name: '<a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a>',
-  exec: function () { return '__defineSetter__' in ({ }) },
+  exec: function () {
+    return '__defineSetter__' in ({ });
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -497,8 +522,9 @@ exports.tests = [
     try {
       eval('const foobarbaz = 12');
       return typeof foobarbaz === 'number';
+    } catch (e) {
+      return false;
     }
-    catch(err) { return false }
   },
   res: {
     ie7: false,
@@ -530,8 +556,11 @@ exports.tests = [
       type: 'application/javascript;version=1.8',
       script: function () {
         test((function(){ 
-          try { return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()'); }
-          catch(err) { return false; }
+          try {
+            return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+          } catch (e) {
+            return false;
+          }
         })());
         __script_executed = true
       }
@@ -570,7 +599,9 @@ exports.tests = [
 },
 {
   name: 'Array generics',
-  exec: function () { return typeof Array.slice === "function" && Array.slice('123').length === 3 },
+  exec: function () {
+    return typeof Array.slice === 'function' && Array.slice('123').length === 3;
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -599,7 +630,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('(function(x)x)(1)') === 1;
-    } catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -631,8 +662,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('typeof <foo/> === "xml"');
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -663,9 +693,8 @@ exports.tests = [
   name: '<a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a>',
   exec: function () {
     try {
-      return eval('(function(){ var arr = #1=[1, #1#, 3]; return arr[1] === arr; })()');
-    }
-    catch(err) {
+      return eval('(function () { var arr = #1=[1, #1#, 3]; return arr[1] === arr; }())');
+    } catch (e) {
       return false;
     }
   },
@@ -702,8 +731,9 @@ exports.tests = [
       re.exec('xy');
       re2.exec('xy');
       return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+    } catch (e) {
+      return false;
     }
-    catch(err) { return false }
   },
   res: {
     ie7: false,
@@ -732,12 +762,13 @@ exports.tests = [
   name: 'RegExp "x" flag',
   exec: function () {
     try {
-      var re = RegExp("^ ( \\d+ ) \
+      var re = RegExp('^ ( \\d+ ) \
                          ( \\w+ ) \
-                         ( foo  )", "x");
+                         ( foo  )', 'x');
       return re.exec('23xfoo')[0] === '23xfoo';
+    } catch (e) {
+      return false;
     }
-    catch(err) { return false }
   },
   res: {
     ie7: false,
@@ -828,8 +859,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('/\\w/("x")[0] === "x"');
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -860,9 +890,8 @@ exports.tests = [
   name: 'RegExp named groups',
   exec: function () {
     try {
-      return eval("/(?P<name>a)(?P=name)/.test('aa')");
-    }
-    catch(err) {
+      return eval('/(?P<name>a)(?P=name)/.test("aa")');
+    } catch (e) {
       return false;
     }
   },
@@ -1183,8 +1212,7 @@ exports.tests = [
   exec: function () {
     try {
       return eval('070 === 56');
-    }
-    catch(err) {
+    } catch (e) {
       return false;
     }
   },
@@ -1214,7 +1242,9 @@ exports.tests = [
 },
 {
   name: 'error "stack"',
-  exec: function () { return 'stack' in new Error },
+  exec: function () {
+    return 'stack' in new Error;
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -1240,7 +1270,9 @@ exports.tests = [
 },
 {
   name: 'error "lineNumber"',
-  exec: function () { return 'lineNumber' in new Error },
+  exec: function () {
+    return 'lineNumber' in new Error;
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -1266,7 +1298,9 @@ exports.tests = [
 },
 {
   name: 'error "fileName"',
-  exec: function () { return 'fileName' in new Error },
+  exec: function () {
+    return 'fileName' in new Error;
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -1292,7 +1326,9 @@ exports.tests = [
 },
 {
   name: 'error "description"',
-  exec: function () { return 'description' in new Error },
+  exec: function () {
+    return 'description' in new Error;
+  },
   res: {
     ie7: true,
     ie8: true,
@@ -1319,7 +1355,10 @@ exports.tests = [
 },
 {
   name: '<a href="http://wiki.ecmascript.org/doku.php?id=harmony:proxies">Proxy</a>',
-  exec: function () { return typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' },
+  exec: function () {
+    return typeof Proxy !== 'undefined' &&
+      typeof Proxy.create == 'function';
+  },
   res: {
     ie7: false,
     ie8: false,
@@ -1348,7 +1387,7 @@ exports.tests = [
   exec: function () {
     return typeof WeakMap !== 'undefined' &&
       typeof new WeakMap().get == 'function' &&
-      typeof new WeakMap().set == 'function'
+      typeof new WeakMap().set == 'function';
   },
   res: {
     ie7: false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -84,7 +84,7 @@ test(function () {
     }
     (new C()).own; // true
     */
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -109,24 +109,24 @@ test(function () {
         <tr>
           <td>let</td>
 <script type="application/javascript;version=1.8">
-test(function () {
+test((function () {
   try {
-    return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-  } catch(error) {
+    return eval('(function () { let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
+  } catch (e) {
     return false;
   }
-}());
+}()));
 __let_script_executed = true;
 </script>
 <script>
-if (!__let_script_executed ) {
-  test(function () {
+if (!__let_script_executed) {
+  test((function () {
     try {
-      return eval('(function(){ "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-    } catch(error) {
+      return eval('(function () { "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
+    } catch (e) {
       return false;
     }
-  }());
+  }()));
 }
 </script>
 
@@ -151,8 +151,8 @@ if (!__let_script_executed ) {
 <script>
 test(function () {
   try {
-    return eval('(function() { const foobarbaz = 12; return typeof foobarbaz === "number" })()');
-  } catch(error) {
+    return eval('(function () { const foobarbaz = 12; return typeof foobarbaz === "number"; }())');
+  } catch (e) {
     return false;
   }
 }());
@@ -179,8 +179,8 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval('(function(a = 5) {return a === 5})()');
-  } catch(error) {
+    return eval('(function (a = 5) { return a === 5; }())');
+  } catch (e) {
     return false;
   }
 }());
@@ -207,8 +207,8 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval('(function(...args) { return typeof args !== "undefined"; })()')
-  } catch(error) {
+    return eval('(function (...args) { return typeof args !== "undefined"; }())');
+  } catch (e) {
     return false;
   }
 }());
@@ -236,7 +236,7 @@ test(function () {
 test(function () {
   try {
     return eval('Math.max(...[1, 2, 3]) === 3');
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -264,7 +264,7 @@ test(function () {
 test(function () {
   try {
     return eval('[...[1, 2, 3]][2] === 3');
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -293,7 +293,7 @@ test(function () {
   try {
     // this line crashes Chrome 21-24
     // return eval('module foo { }');
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -320,8 +320,8 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval('(function() {var arr = [5]; for (var item of arr) return item === 5;})()');
-  } catch(error) {
+    return eval('(function () { var arr = [5]; for (var item of arr) return item === 5; }())');
+  } catch (e) {
     return false;
   }
 }());
@@ -350,7 +350,7 @@ test(function () {
   try {
     eval('[a * a for (a of [1, 2, 3])][0] === 1');
     return true;
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -379,7 +379,7 @@ test(function () {
   try {
     eval('(a for (a of [1, 2, 3]))');
     return true;
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -408,7 +408,7 @@ test(function () {
   try {
     eval('for (var a of {b: 5}) {}');
     return true;
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -435,12 +435,12 @@ test(function () {
 <script type="application/javascript;version=1.8">
 test((function () {
   try {
-    eval('(function() {yield 5;})()');
+    eval('(function () { yield 5; }())');
     return true;
-  } catch(error) {
+  } catch (e) {
     return false;
   }
-})())
+}()));
 __yield_script_executed = true;
 </script>
 <script>
@@ -471,9 +471,9 @@ if (!__yield_script_executed) {
 <script>
 test(function () {
   try {
-    eval('var u = function() {return true}; u`literal`');
+    eval('var u = function () { return true }; u`literal`');
     return true;
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -505,7 +505,7 @@ test(function () {
     re.exec('xy');
     re2.exec('xy');
     return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-  } catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -614,7 +614,9 @@ test(typeof WeakMap !== 'undefined' &&
         <tr>
           <td>Proxies</td>
 <script>
-test(typeof Proxy !== 'undefined' && typeof Proxy.create == 'function' && typeof Proxy.createFunction == 'function');
+test(typeof Proxy !== 'undefined' &&
+    typeof Proxy.create == 'function' &&
+    typeof Proxy.createFunction == 'function');
 </script>
 
           <td class="no ie10">No</td>
@@ -662,7 +664,7 @@ test(function () {
   'use strict';
   try {
     return eval('{function f(){}} typeof f == "undefined"');
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());
@@ -954,7 +956,7 @@ test(typeof String.prototype.toArray === 'function');
 test(function () {
   try {
     return eval("'\\u{1d306}' == '\\ud834\\udf06'");
-  } catch(error) {
+  } catch (e) {
     return false;
   }
 }());

--- a/index.html
+++ b/index.html
@@ -1005,8 +1005,7 @@ test(typeof Array.prototype.reduceRight == 'function');
 test(function () {
   try {
     return eval('({ get x(){ return 1 } }).x === 1');
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -1046,8 +1045,7 @@ test(function () {
     var value;
     eval('({ set x(v){ value = v; } }).x = 1');
     return value === 1;
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -1122,8 +1120,7 @@ test(function () {
     var obj = { };
     eval('obj = ({ if: 1 })');
     return obj['if'] === 1;
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -1161,10 +1158,10 @@ test(function () {
           <tr>
             <td>Zero-width chars in identifiers</td>
 <script>
-test(function (){
+test(function () {
   try {
     return eval('_\u200c\u200d = true');
-  } catch(e) { }
+  } catch (e) { }
 }());
 </script>
 
@@ -1197,7 +1194,7 @@ test(function (){
           <tr>
             <td>Strict mode<a href="#strict-mode-note"><sup>[7]</sup></a></td>
 <script>
-test(function (){
+test(function () {
   "use strict";
   return !this;
 }());

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -97,7 +97,7 @@ test(function () {
   try {
     eval('if (1) { function f(){ } } else { function f(){ } }');
     return typeof f === 'function';
-  } catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -157,7 +157,7 @@ test(typeof uneval == 'function');
             <tr>
               <td>"toSource" method</td>
 <script>
-test('toSource' in (function(){}) && 'toSource' in ({}));
+test('toSource' in (function (){}) && 'toSource' in ({}));
 </script>
 
               <td class="no ie7">No</td>
@@ -241,7 +241,9 @@ test('caller' in (function(){}));
             <tr>
               <td>function "arity" property</td>
 <script>
-test((function(){}).arity === 0 && (function(x){}).arity === 1 && (function(x, y){}).arity === 2);
+test((function (){}).arity === 0 &&
+    (function (x){}).arity === 1 &&
+    (function (x, y){}).arity === 2);
 </script>
 
               <td class="no ie7">No</td>
@@ -269,7 +271,9 @@ test((function(){}).arity === 0 && (function(x){}).arity === 1 && (function(x, y
               <td>function "arguments" property</td>
 <script>
 test(function () {
-  function f(a, b) { return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo' }
+  function f(a, b) {
+    return f.arguments && f.arguments[0] === 1 && f.arguments[1] === 'boo';
+  }
   return f(1, 'boo');
 }());
 </script>
@@ -328,7 +332,8 @@ test(typeof Function.prototype.isGenerator == 'function');
             <tr>
               <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a></td>
 <script>
-test(({}).__proto__ === Object.prototype && [].__proto__ === Array.prototype);
+test(({}).__proto__ === Object.prototype &&
+    [].__proto__ === Array.prototype);
 </script>
 
               <td class="no ie7">No</td>
@@ -355,7 +360,8 @@ test(({}).__proto__ === Object.prototype && [].__proto__ === Array.prototype);
             <tr>
               <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></td>
 <script>
-test(typeof ({}).__count__ === "number" && ({ x: 1, y: 2 }).__count__ === 2);
+test(typeof ({}).__count__ === 'number' &&
+  ({ x: 1, y: 2 }).__count__ === 2);
 </script>
 
               <td class="no ie7">No</td>
@@ -382,7 +388,7 @@ test(typeof ({}).__count__ === "number" && ({ x: 1, y: 2 }).__count__ === 2);
             <tr>
               <td><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></td>
 <script>
-test(typeof ({}).__parent__ !== "undefined");
+test(typeof ({}).__parent__ !== 'undefined');
 </script>
 
               <td class="no ie7">No</td>
@@ -411,11 +417,10 @@ test(typeof ({}).__parent__ !== "undefined");
 <script>
 test(function () {
   var o = { }, executed = false;
-  o.__noSuchMethod__ = function() { executed = true; }
+  o.__noSuchMethod__ = function () { executed = true; }
   try {
     o.__i_dont_exist();
-  }
-  catch(err) { }
+  } catch (e) { }
   return executed;
 }());
 </script>
@@ -505,8 +510,9 @@ test(function () {
   try {
     eval('const foobarbaz = 12');
     return typeof foobarbaz === 'number';
+  } catch (e) {
+    return false;
   }
-  catch(err) { return false }
 }());
 </script>
 
@@ -535,8 +541,11 @@ test(function () {
               <td>let</td>
 <script type="application/javascript;version=1.8">
 test((function(){ 
-  try { return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()'); }
-  catch(err) { return false; }
+  try {
+    return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
+  } catch (e) {
+    return false;
+  }
 })());
 __script_executed = true
 </script>
@@ -571,7 +580,7 @@ if (!__script_executed) {
             <tr>
               <td>Array generics</td>
 <script>
-test(typeof Array.slice === "function" && Array.slice('123').length === 3);
+test(typeof Array.slice === 'function' && Array.slice('123').length === 3);
 </script>
 
               <td class="no ie7">No</td>
@@ -601,7 +610,7 @@ test(typeof Array.slice === "function" && Array.slice('123').length === 3);
 test(function () {
   try {
     return eval('(function(x)x)(1)') === 1;
-  } catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -634,8 +643,7 @@ test(function () {
 test(function () {
   try {
     return eval('typeof <foo/> === "xml"');
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -667,9 +675,8 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval('(function(){ var arr = #1=[1, #1#, 3]; return arr[1] === arr; })()');
-  }
-  catch(err) {
+    return eval('(function () { var arr = #1=[1, #1#, 3]; return arr[1] === arr; }())');
+  } catch (e) {
     return false;
   }
 }());
@@ -709,8 +716,9 @@ test(function () {
     re.exec('xy');
     re2.exec('xy');
     return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+  } catch (e) {
+    return false;
   }
-  catch(err) { return false }
 }());
 </script>
 
@@ -740,12 +748,13 @@ test(function () {
 <script>
 test(function () {
   try {
-    var re = RegExp("^ ( \\d+ ) \
+    var re = RegExp('^ ( \\d+ ) \
                        ( \\w+ ) \
-                       ( foo  )", "x");
+                       ( foo  )', 'x');
     return re.exec('23xfoo')[0] === '23xfoo';
+  } catch (e) {
+    return false;
   }
-  catch(err) { return false }
 }());
 </script>
 
@@ -839,8 +848,7 @@ test(function () {
 test(function () {
   try {
     return eval('/\\w/("x")[0] === "x"');
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -872,9 +880,8 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval("/(?P<name>a)(?P=name)/.test('aa')");
-  }
-  catch(err) {
+    return eval('/(?P<name>a)(?P=name)/.test("aa")');
+  } catch (e) {
     return false;
   }
 }());
@@ -1213,8 +1220,7 @@ test(typeof Object.prototype.eval == 'function');
 test(function () {
   try {
     return eval('070 === 56');
-  }
-  catch(err) {
+  } catch (e) {
     return false;
   }
 }());
@@ -1358,7 +1364,8 @@ test('description' in new Error);
             <tr>
               <td><a href="http://wiki.ecmascript.org/doku.php?id=harmony:proxies">Proxy</a></td>
 <script>
-test(typeof Proxy !== 'undefined' && typeof Proxy.create == 'function');
+test(typeof Proxy !== 'undefined' &&
+    typeof Proxy.create == 'function');
 </script>
 
               <td class="no ie7">No</td>


### PR DESCRIPTION
With this commit a lot of the JS in `data-*.js` files is normalized. E.g. exceptions are always denoted `e`, always use semicolons and more. Hopefully I found everything.
