### PR TITLE
Fixed HTML error

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -334,7 +334,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="<del title="Temporarily disabled due to Chrome crash">Modules</del>"><span><a class="anchor" href="#<del title="Temporarily disabled due to Chrome crash">Modules</del>">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:modules"><del title="Temporarily disabled due to Chrome crash">Modules</del></a></span></td>
+          <td id="Modules"><span><a class="anchor" href="#Modules">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:modules"><del title="Temporarily disabled due to Chrome crash">Modules</del></a></span></td>
 <script>
 test(function () {
   try {


### PR DESCRIPTION
There was a small, but annoying, little problem I couldn't leave unfixed any longer ;p
HTML `<del>` tag was used within an HTML attribute causing the html to "break". This fix removes that HTML tag.
