### PR TITLE
No one supports the latest Proxy spec yet

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -755,8 +755,8 @@ exports.tests = [
   name: 'Proxies',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:direct_proxies',
   exec: function () {
-    return typeof Proxy === "object" &&
-           new Proxy({}, { get: function () { return 5; } }).foo === 5;
+    return typeof Proxy === "function" &&
+           Proxy({}, { get: function () { return 5; } }).foo === 5;
   },
   res: {
     ie10: false,
@@ -764,11 +764,11 @@ exports.tests = [
     firefox13: false,
     firefox16: false,
     firefox17: false,
-    firefox18: true,
-    firefox23: true,
+    firefox18: false,
+    firefox23: false,
     chrome: false,
     chrome19dev: false,
-    chrome21dev: true,
+    chrome21dev: false,
     safari51: false,
     safari6: false,
     webkit: false,


### PR DESCRIPTION
Turns out I was wrong, Firefox 18+ implemented direct proxies as constructors. (?)
Chrome only implemented the old spec.
