### PR TITLE
Add test case for destructuring

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -935,6 +935,43 @@ exports.tests = [
   }
 },
 {
+  name: 'Destructuring',
+  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
+  exec: function () {
+    'use strict';
+    try {
+      eval('var [a] = [5];');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+  res: {
+    ie10: false,
+    ie11: false,
+    firefox11: true,
+    firefox13: true,
+    firefox16: true,
+    firefox17: true,
+    firefox18: true,
+    firefox23: true,
+    firefox24: true,
+    firefox25: true,
+    chrome: false,
+    chrome19dev: false,
+    chrome21dev: false,
+    safari51: false,
+    safari6: false,
+    webkit: false,
+    opera: false,
+    opera15: false,
+    konq49: false,
+    rhino17: false,
+    node08: false,
+    node08harmony: false
+  }
+},
+{
   name: 'Object.assign',
   link: "http://people.mozilla.org/~jorendorff/es6-draft.html#sec-15.2.3.17",
   exec: function () {

--- a/es6/index.html
+++ b/es6/index.html
@@ -893,6 +893,43 @@ test(function () {
           <td class="yes node08harmony">Yes</td>
         </tr>
         <tr>
+          <td id="Destructuring"><span><a class="anchor" href="#Destructuring">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:destructuring">Destructuring</a></span></td>
+<script>
+test(function () {
+  'use strict';
+  try {
+    eval('var [a] = [5];');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="yes firefox11">Yes</td>
+          <td class="yes firefox13">Yes</td>
+          <td class="yes firefox16">Yes</td>
+          <td class="yes firefox17">Yes</td>
+          <td class="yes firefox18">Yes</td>
+          <td class="yes firefox23">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25">Yes</td>
+          <td class="no chrome">No</td>
+          <td class="no chrome19dev">No</td>
+          <td class="no chrome21dev">No</td>
+          <td class="no safari51">No</td>
+          <td class="no safari6">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no opera15">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node08">No</td>
+          <td class="no node08harmony">No</td>
+        </tr>
+        <tr>
           <td id="Object.assign"><span><a class="anchor" href="#Object.assign">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-15.2.3.17">Object.assign</a></span></td>
 <script>
 test(typeof Object.assign === 'function');


### PR DESCRIPTION
This PR adds a test case for destructuring (currently supported on FF2+ only).

I wasn't sure if there's a specific order for rules, so I just placed it randomly after Block-level function declaration.
This closes #37.
