### PR TITLE
fixed a couple tests

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -591,11 +591,7 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:iterators',
   exec: function () {
     var obj = {
-      iterator: function() {
-        return {
-          next: function() { throw StopIteration }
-        }
-      }
+      next: function() { return {done:true,value:1} }
     };
     try {
       eval('for (var a of obj) {}');
@@ -618,8 +614,8 @@ exports.tests = [
     firefox26: true,
     chrome: false,
     chrome19dev: false,
-    chrome21dev: false,
-    chrome30: false,
+    chrome21dev: true,
+    chrome30: true,
     safari51: false,
     safari6: false,
     webkit: false,
@@ -652,8 +648,15 @@ exports.tests = [
     {
       script: function () {
         if (!__yield_script_executed) {
-          test(false);
-          __yield_script_executed = false;
+          test((function () {
+            try {
+              eval('(function* () { yield 5; }())');
+              return true;
+            } catch (e) {
+              return false;
+            }
+          }()));
+          __yield_script_executed = true;
         }
       }
     }
@@ -672,8 +675,8 @@ exports.tests = [
     firefox26: true,
     chrome: false,
     chrome19dev: false,
-    chrome21dev: false,
-    chrome30: false,
+    chrome21dev: true,
+    chrome30: true,
     safari51: false,
     safari6: false,
     webkit: false,
@@ -848,11 +851,15 @@ exports.tests = [
   name: 'WeakMaps',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:weak_maps',
   exec: function () {
-    return typeof WeakMap !== 'undefined' &&
-      typeof WeakMap.prototype.get === 'function' &&
-      typeof WeakMap.prototype.set === 'function' &&
-      typeof WeakMap.prototype.clear === 'function' &&
-      typeof WeakMap.prototype.has === 'function';
+    try {
+      var weakMap = new WeakMap();
+      var key = [1,2,3];
+      weakMap.set(key, 123);
+      return map.weakMap(key) && weakMap.get(key) === 123;
+    }
+    catch(err) {
+      return false;
+    }
   },
   res: {
     ie10: false,
@@ -868,8 +875,8 @@ exports.tests = [
     firefox26: true,
     chrome: false,
     chrome19dev: false,
-    chrome21dev: false,
-    chrome30: false,
+    chrome21dev: true,
+    chrome30: true,
     safari51: false,
     safari6: false,
     webkit: false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -6,7 +6,7 @@
     <script src="../ready.js"></script>
     <script src="../master.js"></script>
     <script>
-      var __yield_script_executed, __let_script_executed;
+      var __yield_script_executed = false, __let_script_executed = false;
     </script>
 </head>
 <body class="es6">
@@ -552,11 +552,7 @@ test(function () {
 <script>
 test(function () {
   var obj = {
-    iterator: function() {
-      return {
-        next: function() { throw StopIteration }
-      }
-    }
+      next: function() { return {done:true,value:1} }
   };
   try {
     eval('for (var a of obj) {}');
@@ -607,8 +603,15 @@ __yield_script_executed = true;
 </script>
 <script>
 if (!__yield_script_executed) {
-  test(false);
-  __yield_script_executed = false;
+  test((function () {
+    try {
+      eval('(function* () { yield 5; }())');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }()));
+  __yield_script_executed = true;
 }
 </script>
 
@@ -799,11 +802,17 @@ test(function () {
         <tr>
           <td id="WeakMaps"><span><a class="anchor" href="#WeakMaps">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:weak_maps">WeakMaps</a></span></td>
 <script>
-test(typeof WeakMap !== 'undefined' &&
-    typeof WeakMap.prototype.get === 'function' &&
-    typeof WeakMap.prototype.set === 'function' &&
-    typeof WeakMap.prototype.clear === 'function' &&
-    typeof WeakMap.prototype.has === 'function');
+test(function () {
+  try {
+    var weakMap = new WeakMap();
+    var key = [1,2,3];
+    weakMap.set(key, 123);
+    return weakMap.has(key) && weakMap.get(key) === 123;
+    }
+  catch(err) {
+    return false;
+  }
+}());
 </script>
 
           <td class="no ie10">No</td>


### PR DESCRIPTION
made a couple fixes to the tests
- the let test for non-mozilla browsers wasn't running because the variable being used to store the results of part 1 was undefined not falsey
- same with yield except I had to add an actual test (copy and paste) to the callback.
- iterable was using out of date syntax (source [this post](http://domenic.me/2013/09/06/es6-iterators-generators-and-iterables/) by @domenic)
- WeakMap now has a comparable test to Map based on its capabilities.
