### PR TITLE
Row selection improvements: no iteration, easier to click link

### DIFF
--- a/build.js
+++ b/build.js
@@ -82,7 +82,7 @@ function dataToHtml(browsers, tests) {
     name, id;
   for (i = 0; i < tests.length; i++) {
     t = tests[i];
-    id = t.name.replace(/\s/g, '_');
+    id = t.name.replace(/^[\s<>&"]+|[\s<>&"]+$/g, '').replace(/[\s<>&"]+/g, '_');
     name = t.link ? ('<a href="' + t.link + '">' + t.name + '</a>') : t.name;
     body.push(
       '<tr>',

--- a/build.js
+++ b/build.js
@@ -82,7 +82,7 @@ function dataToHtml(browsers, tests) {
     name, id;
   for (i = 0; i < tests.length; i++) {
     t = tests[i];
-    id = t.name;
+    id = t.name.replace(/\s/g, '_');
     name = t.link ? ('<a href="' + t.link + '">' + t.name + '</a>') : t.name;
     body.push(
       '<tr>',

--- a/es6/index.html
+++ b/es6/index.html
@@ -679,7 +679,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="RegExp_"y"_flag"><span><a class="anchor" href="#RegExp_"y"_flag">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag">RegExp "y" flag</a></span></td>
+          <td id="RegExp_y_flag"><span><a class="anchor" href="#RegExp_y_flag">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag">RegExp "y" flag</a></span></td>
 <script>
 test(function () {
   try {

--- a/es6/index.html
+++ b/es6/index.html
@@ -80,7 +80,7 @@
       </thead>
       <tbody>
         <tr>
-          <td id="arrow functions"><span><a class="anchor" href="#arrow functions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax">arrow functions</a></span></td>
+          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax">arrow functions</a></span></td>
 <script>
 test(function () {
   try {
@@ -249,7 +249,7 @@ test(function () {
           <td class="yes node08harmony">Yes</td>
         </tr>
         <tr>
-          <td id="default function params"><span><a class="anchor" href="#default function params">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values">default function params</a></span></td>
+          <td id="default_function_params"><span><a class="anchor" href="#default_function_params">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values">default function params</a></span></td>
 <script>
 test(function () {
   try {
@@ -286,7 +286,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="rest parameters"><span><a class="anchor" href="#rest parameters">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters">rest parameters</a></span></td>
+          <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters">rest parameters</a></span></td>
 <script>
 test(function () {
   try {
@@ -323,7 +323,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="spread call (...) operator"><span><a class="anchor" href="#spread call (...) operator">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread call (...) operator</a></span></td>
+          <td id="spread_call_(...)_operator"><span><a class="anchor" href="#spread_call_(...)_operator">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread call (...) operator</a></span></td>
 <script>
 test(function () {
   try {
@@ -360,7 +360,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="spread array (...) operator"><span><a class="anchor" href="#spread array (...) operator">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread array (...) operator</a></span></td>
+          <td id="spread_array_(...)_operator"><span><a class="anchor" href="#spread_array_(...)_operator">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:spread">spread array (...) operator</a></span></td>
 <script>
 test(function () {
   try {
@@ -435,7 +435,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="For..of loops"><span><a class="anchor" href="#For..of loops">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:iterators">For..of loops</a></span></td>
+          <td id="For..of_loops"><span><a class="anchor" href="#For..of_loops">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:iterators">For..of loops</a></span></td>
 <script>
 test(function () {
   try {
@@ -472,7 +472,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Array comprehensions"><span><a class="anchor" href="#Array comprehensions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span></td>
+          <td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span></td>
 <script>
 test(function () {
   try {
@@ -510,7 +510,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Generator expressions"><span><a class="anchor" href="#Generator expressions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generator_expressions">Generator expressions</a></span></td>
+          <td id="Generator_expressions"><span><a class="anchor" href="#Generator_expressions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generator_expressions">Generator expressions</a></span></td>
 <script>
 test(function () {
   try {
@@ -589,7 +589,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Generators (yield)"><span><a class="anchor" href="#Generators (yield)">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generators">Generators (yield)</a></span></td>
+          <td id="Generators_(yield)"><span><a class="anchor" href="#Generators_(yield)">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generators">Generators (yield)</a></span></td>
 <script type="application/javascript;version=1.8">
 test((function () {
   try {
@@ -641,7 +641,7 @@ if (!__yield_script_executed) {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Template Strings"><span><a class="anchor" href="#Template Strings">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:quasis">Template Strings</a></span></td>
+          <td id="Template_Strings"><span><a class="anchor" href="#Template_Strings">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:quasis">Template Strings</a></span></td>
 <script>
 test(function () {
   try {
@@ -679,7 +679,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="RegExp "y" flag"><span><a class="anchor" href="#RegExp "y" flag">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag">RegExp "y" flag</a></span></td>
+          <td id="RegExp_"y"_flag"><span><a class="anchor" href="#RegExp_"y"_flag">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag">RegExp "y" flag</a></span></td>
 <script>
 test(function () {
   try {
@@ -879,7 +879,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Structs (binary data storage)"><span><a class="anchor" href="#Structs (binary data storage)">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:binary_data">Structs (binary data storage)</a></span></td>
+          <td id="Structs_(binary_data_storage)"><span><a class="anchor" href="#Structs_(binary_data_storage)">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:binary_data">Structs (binary data storage)</a></span></td>
 <script>
 test(typeof StructType !== 'undefined');
 </script>
@@ -910,7 +910,7 @@ test(typeof StructType !== 'undefined');
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Block-level function declaration"><span><a class="anchor" href="#Block-level function declaration">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:block_functions">Block-level function declaration</a></span></td>
+          <td id="Block-level_function_declaration"><span><a class="anchor" href="#Block-level_function_declaration">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:block_functions">Block-level function declaration</a></span></td>
 <script>
 test(function () {
   'use strict';
@@ -1421,7 +1421,7 @@ test(typeof String.prototype.toArray === 'function');
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Unicode code point escapes"><span><a class="anchor" href="#Unicode code point escapes">&sect;</a>Unicode code point escapes</span></td>
+          <td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a>Unicode code point escapes</span></td>
 <script>
 test(function () {
   try {

--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ test(typeof Array.prototype.reduceRight == 'function');
             <th colspan="29" class="separator"></th>
           </tr>
           <tr>
-            <td id="Getter in property initializer"><span><a class="anchor" href="#Getter in property initializer">&sect;</a>Getter in property initializer</span></td>
+            <td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&sect;</a>Getter in property initializer</span></td>
 <script>
 test(function () {
   try {
@@ -1068,7 +1068,7 @@ test(function () {
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td id="Setter in property initializer"><span><a class="anchor" href="#Setter in property initializer">&sect;</a>Setter in property initializer</span></td>
+            <td id="Setter_in_property_initializer"><span><a class="anchor" href="#Setter_in_property_initializer">&sect;</a>Setter in property initializer</span></td>
 <script>
 test(function () {
   try {
@@ -1112,7 +1112,7 @@ test(function () {
             <th colspan="29" class="separator"></th>
           </tr>
           <tr>
-            <td id="Property access on strings"><span><a class="anchor" href="#Property access on strings">&sect;</a>Property access on strings<a href="#property-access-on-strings-note"><sup>[5]</sup></a></span></td>
+            <td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&sect;</a>Property access on strings<a href="#property-access-on-strings-note"><sup>[5]</sup></a></span></td>
 <script>
 test("foobar"[3] === "b");
 </script>
@@ -1145,7 +1145,7 @@ test("foobar"[3] === "b");
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td id="Reserved words as property names"><span><a class="anchor" href="#Reserved words as property names">&sect;</a>Reserved words as property names<a href="#reserved-words-note"><sup>[6]</sup></a></span></td>
+            <td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&sect;</a>Reserved words as property names<a href="#reserved-words-note"><sup>[6]</sup></a></span></td>
 <script>
 test(function () {
   try {
@@ -1189,7 +1189,7 @@ test(function () {
             <th colspan="29" class="separator"></th>
           </tr>
           <tr>
-            <td id="Zero-width chars in identifiers"><span><a class="anchor" href="#Zero-width chars in identifiers">&sect;</a>Zero-width chars in identifiers</span></td>
+            <td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&sect;</a>Zero-width chars in identifiers</span></td>
 <script>
 test(function () {
   try {
@@ -1226,7 +1226,7 @@ test(function () {
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td id="Immutable undefined"><span><a class="anchor" href="#Immutable undefined">&sect;</a>Immutable undefined</span></td>
+            <td id="Immutable_undefined"><span><a class="anchor" href="#Immutable_undefined">&sect;</a>Immutable undefined</span></td>
 <script>
 test(function () {
   var result;
@@ -1268,7 +1268,7 @@ test(function () {
             <td class="yes rhino">Yes</td>
           </tr>
           <tr>
-            <td id="Strict mode"><span><a class="anchor" href="#Strict mode">&sect;</a><a href="http://kangax.github.com/es5-compat-table/strict-mode/">Strict mode</a></span></td>
+            <td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&sect;</a><a href="http://kangax.github.com/es5-compat-table/strict-mode/">Strict mode</a></span></td>
 <script>
 test(function () {
   "use strict";

--- a/master.css
+++ b/master.css
@@ -2,16 +2,16 @@ body { font-family: Garamond, "Hoefler Text", "Times New Roman", Times, serif; m
 th { text-align: center; padding-left: 1em; padding-right: 1em; padding-bottom: 1em ; }
 td { background: #eee; padding-left: 5px; margin-left: -10px; }
 td span { position: relative; display: inline-block; }
-td:hover .anchor { display: block; }
-td .anchor { display: none; position: absolute; top: -5px; left: -22px; text-decoration: none; padding: 5px; }
+td:hover .anchor, td .anchor:focus { color: #00c; }
+td .anchor { display: block; position: absolute; top: -5px; left: -22px; text-decoration: none; padding: 5px; color: #fff; }
 td:first-child { min-width: 285px; }
 th a { text-decoration: none; }
 table { margin-bottom: 2em; }
 p { margin-bottom: 0.5em; margin-top: 0; }
 code { font-family: "Courier New", Courier, monospace; }
 
-tr.selected td { padding-top: 30px; padding-bottom: 30px; }
-tr.dimmed td { opacity: 0.4; }
+table.one-selected td { opacity: 0.4;}
+tr.selected td { padding-top: 30px; padding-bottom: 30px; opacity: 1; }
 
 #body { padding-left: 1em; position: relative; min-width: 1250px; }
 

--- a/master.js
+++ b/master.js
@@ -71,37 +71,40 @@ domready(function() {
     };
   }
 
-  function highlightSelected() {
-    var hash = document.location.hash.slice(1);
-    var trs = document.getElementsByTagName('tr');
-    for (var i = 0, len = trs.length; i < len; i++) {
-      if (trs[i].cells[0].id === hash) {
-        trs[i].className = 'selected';
-      }
-      else {
-        if (hash) {
-          trs[i].className = 'dimmed';
-        }
-        else {
-          trs[i].className = '';
-        }
+  var last_highlighted;
+  var table = document.getElementsByTagName('table')[0];
+  function highlightSelected(tr) {
+    if (tr === undefined) {
+      // actually finds the <td>
+      tr = document.getElementById(location.hash.slice(1));
+      if (tr) {
+        tr = tr.parentNode;
       }
     }
+    table.className = tr ? 'one-selected' : '';
+    if (last_highlighted) {
+      last_highlighted.className = '';
+    }
+    if (tr) {
+      tr.className = 'selected';
+    }
+    last_highlighted = tr;
   }
 
-  if (document.location.hash) {
+  if (location.hash) {
     highlightSelected();
   }
   document.onclick = function(e) {
     if (e.target.className === 'anchor') {
-      setTimeout(highlightSelected, 10);
+      // <tr><td><span><a>
+      highlightSelected(e.target.parentNode.parentNode.parentNode);
     }
     else {
-      document.location.hash = '';
-      setTimeout(highlightSelected, 10);
+      location.hash = '';
+      highlightSelected(false);
     }
   };
   window.onhashchange = function() {
-    setTimeout(highlightSelected, 10);
+    highlightSelected();
   };
 });

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -167,7 +167,7 @@ test(typeof uneval == 'function');
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id=""toSource"_method"><span><a class="anchor" href="#"toSource"_method">&sect;</a>"toSource" method</span></td>
+              <td id="toSource_method"><span><a class="anchor" href="#toSource_method">&sect;</a>"toSource" method</span></td>
 <script>
 test('toSource' in (function (){}) && 'toSource' in ({}));
 </script>
@@ -201,7 +201,7 @@ test('toSource' in (function (){}) && 'toSource' in ({}));
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="function_"name"_property"><span><a class="anchor" href="#function_"name"_property">&sect;</a>function "name" property</span></td>
+              <td id="function_name_property"><span><a class="anchor" href="#function_name_property">&sect;</a>function "name" property</span></td>
 <script>
 test((function foo(){}).name == 'foo');
 </script>
@@ -232,7 +232,7 @@ test((function foo(){}).name == 'foo');
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="function_"caller"_property"><span><a class="anchor" href="#function_"caller"_property">&sect;</a>function "caller" property</span></td>
+              <td id="function_caller_property"><span><a class="anchor" href="#function_caller_property">&sect;</a>function "caller" property</span></td>
 <script>
 test('caller' in (function(){}));
 </script>
@@ -263,7 +263,7 @@ test('caller' in (function(){}));
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="function_"arity"_property"><span><a class="anchor" href="#function_"arity"_property">&sect;</a>function "arity" property</span></td>
+              <td id="function_arity_property"><span><a class="anchor" href="#function_arity_property">&sect;</a>function "arity" property</span></td>
 <script>
 test((function (){}).arity === 0 &&
     (function (x){}).arity === 1 &&
@@ -296,7 +296,7 @@ test((function (){}).arity === 0 &&
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="function_"arguments"_property"><span><a class="anchor" href="#function_"arguments"_property">&sect;</a>function "arguments" property</span></td>
+              <td id="function_arguments_property"><span><a class="anchor" href="#function_arguments_property">&sect;</a>function "arguments" property</span></td>
 <script>
 test(function () {
   function f(a, b) {
@@ -791,7 +791,7 @@ test(function () {
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="RegExp_"y"_flag"><span><a class="anchor" href="#RegExp_"y"_flag">&sect;</a>RegExp "y" flag</span></td>
+              <td id="RegExp_y_flag"><span><a class="anchor" href="#RegExp_y_flag">&sect;</a>RegExp "y" flag</span></td>
 <script>
 test(function () {
   try {
@@ -832,7 +832,7 @@ test(function () {
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="RegExp_"x"_flag"><span><a class="anchor" href="#RegExp_"x"_flag">&sect;</a>RegExp "x" flag</span></td>
+              <td id="RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&sect;</a>RegExp "x" flag</span></td>
 <script>
 test(function () {
   try {
@@ -872,7 +872,7 @@ test(function () {
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="RegExp_"lastMatch""><span><a class="anchor" href="#RegExp_"lastMatch"">&sect;</a>RegExp "lastMatch"</span></td>
+              <td id="RegExp_lastMatch"><span><a class="anchor" href="#RegExp_lastMatch">&sect;</a>RegExp "lastMatch"</span></td>
 <script>
 test(function () {
   var re = /\w/;
@@ -1438,7 +1438,7 @@ test(function () {
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="error_"stack""><span><a class="anchor" href="#error_"stack"">&sect;</a>error "stack"</span></td>
+              <td id="error_stack"><span><a class="anchor" href="#error_stack">&sect;</a>error "stack"</span></td>
 <script>
 test('stack' in new Error);
 </script>
@@ -1469,7 +1469,7 @@ test('stack' in new Error);
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="error_"lineNumber""><span><a class="anchor" href="#error_"lineNumber"">&sect;</a>error "lineNumber"</span></td>
+              <td id="error_lineNumber"><span><a class="anchor" href="#error_lineNumber">&sect;</a>error "lineNumber"</span></td>
 <script>
 test('lineNumber' in new Error);
 </script>
@@ -1500,7 +1500,7 @@ test('lineNumber' in new Error);
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="error_"fileName""><span><a class="anchor" href="#error_"fileName"">&sect;</a>error "fileName"</span></td>
+              <td id="error_fileName"><span><a class="anchor" href="#error_fileName">&sect;</a>error "fileName"</span></td>
 <script>
 test('fileName' in new Error);
 </script>
@@ -1531,7 +1531,7 @@ test('fileName' in new Error);
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="error_"description""><span><a class="anchor" href="#error_"description"">&sect;</a>error "description"</span></td>
+              <td id="error_description"><span><a class="anchor" href="#error_description">&sect;</a>error "description"</span></td>
 <script>
 test('description' in new Error);
 </script>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -95,7 +95,7 @@
         </thead>
         <tbody>
             <tr>
-              <td id="function statement"><span><a class="anchor" href="#function statement">&sect;</a><a href="http://kangax.github.com/nfe/#function-statements">function statement</a></span></td>
+              <td id="function_statement"><span><a class="anchor" href="#function_statement">&sect;</a><a href="http://kangax.github.com/nfe/#function-statements">function statement</a></span></td>
 <script>
 test(function () {
   try {
@@ -167,7 +167,7 @@ test(typeof uneval == 'function');
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id=""toSource" method"><span><a class="anchor" href="#"toSource" method">&sect;</a>"toSource" method</span></td>
+              <td id=""toSource"_method"><span><a class="anchor" href="#"toSource"_method">&sect;</a>"toSource" method</span></td>
 <script>
 test('toSource' in (function (){}) && 'toSource' in ({}));
 </script>
@@ -201,7 +201,7 @@ test('toSource' in (function (){}) && 'toSource' in ({}));
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="function "name" property"><span><a class="anchor" href="#function "name" property">&sect;</a>function "name" property</span></td>
+              <td id="function_"name"_property"><span><a class="anchor" href="#function_"name"_property">&sect;</a>function "name" property</span></td>
 <script>
 test((function foo(){}).name == 'foo');
 </script>
@@ -232,7 +232,7 @@ test((function foo(){}).name == 'foo');
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="function "caller" property"><span><a class="anchor" href="#function "caller" property">&sect;</a>function "caller" property</span></td>
+              <td id="function_"caller"_property"><span><a class="anchor" href="#function_"caller"_property">&sect;</a>function "caller" property</span></td>
 <script>
 test('caller' in (function(){}));
 </script>
@@ -263,7 +263,7 @@ test('caller' in (function(){}));
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="function "arity" property"><span><a class="anchor" href="#function "arity" property">&sect;</a>function "arity" property</span></td>
+              <td id="function_"arity"_property"><span><a class="anchor" href="#function_"arity"_property">&sect;</a>function "arity" property</span></td>
 <script>
 test((function (){}).arity === 0 &&
     (function (x){}).arity === 1 &&
@@ -296,7 +296,7 @@ test((function (){}).arity === 0 &&
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="function "arguments" property"><span><a class="anchor" href="#function "arguments" property">&sect;</a>function "arguments" property</span></td>
+              <td id="function_"arguments"_property"><span><a class="anchor" href="#function_"arguments"_property">&sect;</a>function "arguments" property</span></td>
 <script>
 test(function () {
   function f(a, b) {
@@ -646,7 +646,7 @@ if (!__script_executed) {
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="Array generics"><span><a class="anchor" href="#Array generics">&sect;</a>Array generics</span></td>
+              <td id="Array_generics"><span><a class="anchor" href="#Array_generics">&sect;</a>Array generics</span></td>
 <script>
 test(typeof Array.slice === 'function' && Array.slice('123').length === 3);
 </script>
@@ -677,7 +677,7 @@ test(typeof Array.slice === 'function' && Array.slice('123').length === 3);
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="Expression closures"><span><a class="anchor" href="#Expression closures">&sect;</a>Expression closures</span></td>
+              <td id="Expression_closures"><span><a class="anchor" href="#Expression_closures">&sect;</a>Expression closures</span></td>
 <script>
 test(function () {
   try {
@@ -751,7 +751,7 @@ test(function () {
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="Sharp variables"><span><a class="anchor" href="#Sharp variables">&sect;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span></td>
+              <td id="Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&sect;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span></td>
 <script>
 test(function () {
   try {
@@ -791,7 +791,7 @@ test(function () {
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="RegExp "y" flag"><span><a class="anchor" href="#RegExp "y" flag">&sect;</a>RegExp "y" flag</span></td>
+              <td id="RegExp_"y"_flag"><span><a class="anchor" href="#RegExp_"y"_flag">&sect;</a>RegExp "y" flag</span></td>
 <script>
 test(function () {
   try {
@@ -832,7 +832,7 @@ test(function () {
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="RegExp "x" flag"><span><a class="anchor" href="#RegExp "x" flag">&sect;</a>RegExp "x" flag</span></td>
+              <td id="RegExp_"x"_flag"><span><a class="anchor" href="#RegExp_"x"_flag">&sect;</a>RegExp "x" flag</span></td>
 <script>
 test(function () {
   try {
@@ -872,7 +872,7 @@ test(function () {
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="RegExp "lastMatch""><span><a class="anchor" href="#RegExp "lastMatch"">&sect;</a>RegExp "lastMatch"</span></td>
+              <td id="RegExp_"lastMatch""><span><a class="anchor" href="#RegExp_"lastMatch"">&sect;</a>RegExp "lastMatch"</span></td>
 <script>
 test(function () {
   var re = /\w/;
@@ -943,7 +943,7 @@ test(function () {
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="Callable RegExp"><span><a class="anchor" href="#Callable RegExp">&sect;</a>Callable RegExp</span></td>
+              <td id="Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&sect;</a>Callable RegExp</span></td>
 <script>
 test(function () {
   try {
@@ -980,7 +980,7 @@ test(function () {
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="RegExp named groups"><span><a class="anchor" href="#RegExp named groups">&sect;</a>RegExp named groups</span></td>
+              <td id="RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&sect;</a>RegExp named groups</span></td>
 <script>
 test(function () {
   try {
@@ -1398,7 +1398,7 @@ test(typeof Object.prototype.eval == 'function');
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="Octal literals"><span><a class="anchor" href="#Octal literals">&sect;</a>Octal literals</span></td>
+              <td id="Octal_literals"><span><a class="anchor" href="#Octal_literals">&sect;</a>Octal literals</span></td>
 <script>
 test(function () {
   try {
@@ -1438,7 +1438,7 @@ test(function () {
               <th colspan="27" class="separator"></th>
             </tr>
             <tr>
-              <td id="error "stack""><span><a class="anchor" href="#error "stack"">&sect;</a>error "stack"</span></td>
+              <td id="error_"stack""><span><a class="anchor" href="#error_"stack"">&sect;</a>error "stack"</span></td>
 <script>
 test('stack' in new Error);
 </script>
@@ -1469,7 +1469,7 @@ test('stack' in new Error);
               <td class="no rhino">No</td>
             </tr>
             <tr>
-              <td id="error "lineNumber""><span><a class="anchor" href="#error "lineNumber"">&sect;</a>error "lineNumber"</span></td>
+              <td id="error_"lineNumber""><span><a class="anchor" href="#error_"lineNumber"">&sect;</a>error "lineNumber"</span></td>
 <script>
 test('lineNumber' in new Error);
 </script>
@@ -1500,7 +1500,7 @@ test('lineNumber' in new Error);
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="error "fileName""><span><a class="anchor" href="#error "fileName"">&sect;</a>error "fileName"</span></td>
+              <td id="error_"fileName""><span><a class="anchor" href="#error_"fileName"">&sect;</a>error "fileName"</span></td>
 <script>
 test('fileName' in new Error);
 </script>
@@ -1531,7 +1531,7 @@ test('fileName' in new Error);
               <td class="yes rhino">Yes</td>
             </tr>
             <tr>
-              <td id="error "description""><span><a class="anchor" href="#error "description"">&sect;</a>error "description"</span></td>
+              <td id="error_"description""><span><a class="anchor" href="#error_"description"">&sect;</a>error "description"</span></td>
 <script>
 test('description' in new Error);
 </script>


### PR DESCRIPTION
Three improvements to selecting a row in this commit:
- Don't iterate over all the rows upon selection
- Previously you had to hover the table cell first and then go left to click the link. Now you can hover them directly or tab to them (if your browser supports tabbing links).
- IDs cannot contain space characters, so I changed those to `_`
