### PR TITLE
Rename "generator expressions" to "generator comprehensions"; fix iterator test.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -549,7 +549,7 @@ exports.tests = [
   }
 },
 {
-  name: 'Generator expressions',
+  name: 'Generator comprehensions',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:generator_expressions',
   exec: function () {
     try {

--- a/data-es6.js
+++ b/data-es6.js
@@ -590,12 +590,18 @@ exports.tests = [
   name: 'Iterators',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:iterators',
   exec: function () {
-    var obj = {
-      next: function() { return {done:true,value:1} }
+    if (typeof Symbol !== 'function' || typeof Symbol.iterator !== 'symbol') {
+      return false;
+    }
+
+    var iterator = {
+      next: function () { return { done: true, value: 1 }; }
     };
+    var iterable = {};
+    iterable[Symbol.iterator] = iterator;
+
     try {
-      eval('for (var a of obj) {}');
-      return true;
+      eval('for (var a of iterable) { return a === 1; }');
     } catch (e) {
       return false;
     }
@@ -606,16 +612,16 @@ exports.tests = [
     firefox11: false,
     firefox13: false,
     firefox16: false,
-    firefox17: true,
-    firefox18: true,
-    firefox23: true,
-    firefox24: true,
-    firefox25: true,
-    firefox26: true,
+    firefox17: false,
+    firefox18: false,
+    firefox23: false,
+    firefox24: false,
+    firefox25: false,
+    firefox26: false,
     chrome: false,
     chrome19dev: false,
-    chrome21dev: true,
-    chrome30: true,
+    chrome21dev: false,
+    chrome30: false,
     safari51: false,
     safari6: false,
     webkit: false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -551,12 +551,18 @@ test(function () {
           <td id="Iterators"><span><a class="anchor" href="#Iterators">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:iterators">Iterators</a></span></td>
 <script>
 test(function () {
-  var obj = {
-    next: function() { return {done:true,value:1} }
+  if (typeof Symbol !== 'function' || typeof Symbol.iterator !== 'symbol') {
+    return false;
+  }
+
+  var iterator = {
+    next: function () { return { done: true, value: 1 }; }
   };
+  var iterable = {};
+  iterable[Symbol.iterator] = iterator;
+
   try {
-    eval('for (var a of obj) {}');
-    return true;
+    eval('for (var a of iterable) { return a === 1; }');
   } catch (e) {
     return false;
   }
@@ -568,16 +574,16 @@ test(function () {
           <td class="no firefox11">No</td>
           <td class="no firefox13">No</td>
           <td class="no firefox16">No</td>
-          <td class="yes firefox17">Yes</td>
-          <td class="yes firefox18">Yes</td>
-          <td class="yes firefox23">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25">Yes</td>
-          <td class="yes firefox26">Yes</td>
+          <td class="no firefox17">No</td>
+          <td class="no firefox18">No</td>
+          <td class="no firefox23">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25">No</td>
+          <td class="no firefox26">No</td>
           <td class="no chrome">No</td>
           <td class="no chrome19dev">No</td>
-          <td class="yes chrome21dev">Yes</td>
-          <td class="yes chrome30">Yes</td>
+          <td class="no chrome21dev">No</td>
+          <td class="no chrome30">No</td>
           <td class="no safari51">No</td>
           <td class="no safari6">No</td>
           <td class="no webkit">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -510,7 +510,7 @@ test(function () {
           <td class="no node08harmony">No</td>
         </tr>
         <tr>
-          <td id="Generator expressions"><span><a class="anchor" href="#Generator expressions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generator_expressions">Generator expressions</a></span></td>
+          <td id="Generator comprehensions"><span><a class="anchor" href="#Generator comprehensions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generator_expressions">Generator comprehensions</a></span></td>
 <script>
 test(function () {
   try {


### PR DESCRIPTION
Fixes #55.

The `Symbol.iterator` property is new as of last Thursday's TC39 meeting; minutes for that should be published soon.
