### PR TITLE
Remove Object.mixin test & results.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1198,41 +1198,6 @@ exports.tests = [
   }
 },
 {
-  name: 'Object.mixin',
-  link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-19.1.2.15',
-  exec: function () {
-    return typeof Object.mixin === 'function';
-  },
-  res: {
-    tr: true,
-    ie10: false,
-    ie11: false,
-    firefox11: false,
-    firefox13: false,
-    firefox16: false,
-    firefox17: false,
-    firefox18: false,
-    firefox23: false,
-    firefox24: false,
-    firefox25: false,
-    firefox27: false,
-    firefox28: false,
-    chrome: false,
-    chrome19dev: false,
-    chrome21dev: false,
-    chrome30: false,
-    safari51: false,
-    safari6: false,
-    webkit: false,
-    opera: false,
-    opera15: false,
-    konq49: false,
-    rhino17: false,
-    node: false,
-    nodeharmony: false
-  }
-},
-{
   name: 'Object.getOwnPropertyDescriptors',
   exec: function () {
     return typeof Object.getOwnPropertyDescriptors === 'function';

--- a/es6/index.html
+++ b/es6/index.html
@@ -1128,39 +1128,6 @@ test(typeof Object.assign === 'function');
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="Object.mixin"><span><a class="anchor" href="#Object.mixin">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-19.1.2.15">Object.mixin</a></span></td>
-<script>
-test(typeof Object.mixin === 'function');
-</script>
-
-          <td class="yes tr">Yes</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
-          <td class="no firefox25">No</td>
-          <td class="no firefox27">No</td>
-          <td class="no firefox28">No</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30">No</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no webkit">No</td>
-          <td class="no opera">No</td>
-          <td class="no opera15">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no node">No</td>
-          <td class="no nodeharmony">No</td>
-        </tr>
-        <tr>
           <td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&sect;</a>Object.getOwnPropertyDescriptors</span></td>
 <script>
 test(typeof Object.getOwnPropertyDescriptors === 'function');


### PR DESCRIPTION
[Object.mixin has been dropped from ES6](https://github.com/rwaldron/tc39-notes/blob/master/es6/2013-11/nov-20.md#consensusresolution-2).

Both data-es6.js and the generated /es6/index.html have been updated.
