### PR TITLE
Symbols

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1864,6 +1864,55 @@ exports.tests = [
   }
 },
 {
+  name: 'Symbol',
+  link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor',
+  exec: function() {
+    try {
+      var object = {};
+      var symbol = Symbol();
+      var value = Math.random();
+      object[symbol] = value;
+      return object[symbol] === value && 
+             Object.keys(object).length === 0 && 
+             Object.getOwnPropertyNames(object).length === 0;
+    }
+    catch(e) {
+      return false;
+    }
+  },
+  res: {
+    tr: false,
+    ie10: false,
+    ie11: false,
+    firefox11: false,
+    firefox13: false,
+    firefox16: false,
+    firefox17: false,
+    firefox18: false,
+    firefox23: false,
+    firefox24: false,
+    firefox25: false,
+    firefox27: false,
+    firefox28: false,
+    firefox29: false,
+    chrome: false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30: false,
+    chrome33: true,
+    safari51: false,
+    safari6: false,
+    safari7: false,
+    webkit: false,
+    opera: false,
+    opera15: false,
+    konq49: false,
+    rhino17: false,
+    node: false,
+    nodeharmony: false
+  }
+},
+{
   name: 'Unicode code point escapes',
   exec: function () {
     try {

--- a/es6/index.html
+++ b/es6/index.html
@@ -1715,6 +1715,53 @@ test(typeof String.prototype.toArray === 'function');
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
+          <td id="Symbol"><span><a class="anchor" href="#symbol">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
+<script>
+test(function () {
+  try {
+    var object = {};
+    var symbol = Symbol();
+    var value = Math.random();
+    object[symbol] = value;
+    return object[symbol] === value && 
+           Object.keys(object).length === 0 && 
+           Object.getOwnPropertyNames(object).length === 0;
+  }
+  catch(e) {
+    return false;
+  }
+}());
+</script>
+          <td class="no tr">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25">No</td>
+          <td class="no firefox27">No</td>
+          <td class="no firefox29">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30">No</td>
+          <td class="yes chrome33">Yes</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no opera15">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+        </tr>
+        <tr>
           <td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a>Unicode code point escapes</span></td>
 <script>
 test(function () {

--- a/es6/index.html
+++ b/es6/index.html
@@ -1715,7 +1715,7 @@ test(typeof String.prototype.toArray === 'function');
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="Symbol"><span><a class="anchor" href="#symbol">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
+          <td id="Symbol"><span><a class="anchor" href="#Symbol">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
 <script>
 test(function () {
   try {
@@ -1732,6 +1732,7 @@ test(function () {
   }
 }());
 </script>
+
           <td class="no tr">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>


### PR DESCRIPTION
only, Chrome 33

Traceur is trying to polyflill symbols , seems, but Object.keys().length is not zero, although Object.getOwnPropertyNames is redefined to skip string, which are "symbols" in Traceur
