### PR TITLE
Number.prototype.toInteger was removed from ES6

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2743,52 +2743,6 @@ exports.tests = [
   }
 },
 {
-  name: 'Number.toInteger',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:number.tointeger',
-  exec: function () {
-    return typeof Number.toInteger === 'function';
-  },
-  res: {
-    tr: false,
-    ejs: true,
-    ie10: false,
-    ie11: false,
-    firefox11: false,
-    firefox13: false,
-    firefox16: true,
-    firefox17: true,
-    firefox18: true,
-    firefox23: true,
-    firefox24: true,
-    firefox25: true,
-    firefox27: true,
-    firefox28: true,
-    firefox29: true,
-    firefox30: true,
-    firefox31: true,
-    firefox32: true,
-    chrome: false,
-    chrome19dev: false,
-    chrome21dev: false,
-    chrome30: false,
-    chrome33: false,
-    chrome34: false,
-    chrome35: false,
-    chrome37: false,
-    safari51: false,
-    safari6: false,
-    safari7: false,
-    webkit: false,
-    opera: false,
-    opera15: false,
-    konq49: false,
-    rhino17: false,
-    phantom: false,
-    node: false,
-    nodeharmony: false
-  }
-},
-{
   name: 'Number.EPSILON',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.epsilon',
   exec: function () {

--- a/es6/index.html
+++ b/es6/index.html
@@ -2536,49 +2536,6 @@ test(typeof Number.isNaN === 'function');
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
-          <td id="Number.toInteger"><span><a class="anchor" href="#Number.toInteger">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:number.tointeger">Number.toInteger</a></span></td>
-<script>
-test(typeof Number.toInteger === 'function');
-</script>
-
-          <td class="no tr">No</td>
-          <td class="yes ejs">Yes</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25">Yes</td>
-          <td class="yes firefox27">Yes</td>
-          <td class="yes firefox29">Yes</td>
-          <td class="yes firefox30">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30">No</td>
-          <td class="no chrome33">No</td>
-          <td class="no chrome34">No</td>
-          <td class="no chrome35">No</td>
-          <td class="no chrome37">No</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no safari7">No</td>
-          <td class="no webkit">No</td>
-          <td class="no opera">No</td>
-          <td class="no opera15">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no phantom">No</td>
-          <td class="no node">No</td>
-          <td class="no nodeharmony">No</td>
-        </tr>
-        <tr>
           <td id="Number.EPSILON"><span><a class="anchor" href="#Number.EPSILON">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.epsilon">Number.EPSILON</a></span></td>
 <script>
 test(typeof Number.EPSILON === 'number');


### PR DESCRIPTION
https://github.com/rwaldron/tc39-notes/blob/master/es6/2013-07/july-25.md#consensusresolution-2
Signed-off-by: Rick Waldron waldron.rick@gmail.com
