### PR TITLE
add es6 support by jsdc

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1502,7 +1502,7 @@ exports.tests = [
     phantom: false,
     node: false,
     nodeharmony: true,
-    jsdc: false
+    jsdc: true
   }
 },
 {

--- a/data-es6.js
+++ b/data-es6.js
@@ -15,6 +15,11 @@ exports.browsers = {
     short: 'EJS',
     obsolete: false // always up-to-date version
   },
+  jsdc: {
+    full: 'Javascript Downcast',
+    short: 'Jsdc',
+    obsolete: false // always up-to-date version
+  },
   ie10: {
     full: 'Internet Explorer',
     short: 'IE 10',
@@ -244,7 +249,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -294,7 +300,8 @@ exports.tests = [
     rhino17: false,
     phantom: true,
     node: true,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: true
   }
 },
 {
@@ -365,7 +372,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: true
   }
 },
 {
@@ -415,7 +423,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -465,7 +474,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -515,7 +525,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -565,7 +576,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -623,7 +635,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -675,7 +688,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -726,7 +740,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -776,7 +791,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -827,7 +843,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -878,7 +895,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -928,7 +946,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1002,7 +1021,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: true
   }
 },
 {
@@ -1053,7 +1073,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -1107,7 +1128,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1158,7 +1180,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1211,7 +1234,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1264,7 +1288,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1318,7 +1343,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1371,7 +1397,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1422,7 +1449,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1473,7 +1501,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1525,7 +1554,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -1572,7 +1602,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1618,7 +1649,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1664,7 +1696,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: true,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1710,7 +1743,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1760,7 +1794,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1810,7 +1845,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -1856,7 +1892,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1902,7 +1939,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1948,7 +1986,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -1994,7 +2033,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2051,7 +2091,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2100,7 +2141,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: true
   }
 },
 {
@@ -2146,7 +2188,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2192,7 +2235,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2238,7 +2282,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2284,7 +2329,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2330,7 +2376,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2376,7 +2423,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: true,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2422,7 +2470,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2468,7 +2517,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2514,7 +2564,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: true,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2560,7 +2611,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2606,7 +2658,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2652,7 +2705,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2698,7 +2752,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2748,7 +2803,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2794,7 +2850,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -2840,7 +2897,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2886,7 +2944,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2932,7 +2991,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -2978,7 +3038,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3024,7 +3085,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3070,7 +3132,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3116,7 +3179,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3162,7 +3226,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3208,7 +3273,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3254,7 +3320,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3300,7 +3367,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3346,7 +3414,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -3396,7 +3465,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3441,7 +3511,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   },
   separator: 'after'
 },
@@ -3488,7 +3559,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 },
 {
@@ -3533,7 +3605,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: true
+    nodeharmony: true,
+    jsdc: false
   }
 },
 {
@@ -3579,7 +3652,8 @@ exports.tests = [
     rhino17: false,
     phantom: false,
     node: false,
-    nodeharmony: false
+    nodeharmony: false,
+    jsdc: false
   }
 }
 ];

--- a/es6/index.html
+++ b/es6/index.html
@@ -71,6 +71,7 @@
           <th></th>
           <th class="tr"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></th>
           <th class="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">EJS</abbr></th>
+          <th class="jsdc"><a href="#jsdc" class="browser-name"><abbr title="Javascript Downcast">Jsdc</abbr></th>
           <th class="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></th>
           <th class="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></th>
           <th class="firefox11 obsolete"><a href="#firefox11" class="browser-name"><abbr title="Firefox">FF 11-12</abbr></th>
@@ -123,6 +124,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -172,6 +174,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -233,6 +236,7 @@ if (!global.__let_script_executed) {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -282,6 +286,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -331,6 +336,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -380,6 +386,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -429,6 +436,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -486,6 +494,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -537,6 +546,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -587,6 +597,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -636,6 +647,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -686,6 +698,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -736,6 +749,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -785,6 +799,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -849,6 +864,7 @@ if (!global.__yield_script_executed) {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -899,6 +915,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -952,6 +969,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -1002,6 +1020,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1054,6 +1073,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1106,6 +1126,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1159,6 +1180,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1211,6 +1233,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1261,6 +1284,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1311,6 +1335,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1362,6 +1387,7 @@ test(function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -1406,6 +1432,7 @@ test(typeof Promise !== 'undefined' &&
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1449,6 +1476,7 @@ test(typeof Object.assign === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1492,6 +1520,7 @@ test(typeof Object.is === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1535,6 +1564,7 @@ test(typeof Object.setPrototypeOf === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1578,6 +1608,7 @@ test(typeof String.fromCodePoint === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1621,6 +1652,7 @@ test(typeof String.prototype.codePointAt === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1664,6 +1696,7 @@ test(typeof String.prototype.repeat === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1707,6 +1740,7 @@ test(typeof String.prototype.startsWith === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1750,6 +1784,7 @@ test(typeof String.prototype.endsWith === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1793,6 +1828,7 @@ test(typeof String.prototype.contains === 'function');
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1849,6 +1885,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1898,6 +1935,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1941,6 +1979,7 @@ test(typeof Array.from === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1984,6 +2023,7 @@ test(typeof Array.of === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2027,6 +2067,7 @@ test(typeof Array.prototype.find === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2070,6 +2111,7 @@ test(typeof Array.prototype.findIndex === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2113,6 +2155,7 @@ test(typeof Array.prototype.fill === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2156,6 +2199,7 @@ test(typeof Number.isFinite === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2199,6 +2243,7 @@ test(typeof Number.isInteger === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2242,6 +2287,7 @@ test(typeof Number.isSafeInteger === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2285,6 +2331,7 @@ test(typeof Number.isNaN === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2328,6 +2375,7 @@ test(typeof Number.EPSILON === 'number');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2371,6 +2419,7 @@ test(typeof Number.MIN_SAFE_INTEGER === 'number');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2414,6 +2463,7 @@ test(typeof Number.MAX_SAFE_INTEGER === 'number');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2457,6 +2507,7 @@ test(typeof Math.clz32 === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2500,6 +2551,7 @@ test(typeof Math.imul === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2543,6 +2595,7 @@ test(typeof Math.sign === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2586,6 +2639,7 @@ test(typeof Math.log10 === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2629,6 +2683,7 @@ test(typeof Math.log2 === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2672,6 +2727,7 @@ test(typeof Math.log1p === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2715,6 +2771,7 @@ test(typeof Math.expm1 === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2758,6 +2815,7 @@ test(typeof Math.cosh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2801,6 +2859,7 @@ test(typeof Math.sinh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2844,6 +2903,7 @@ test(typeof Math.tanh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2887,6 +2947,7 @@ test(typeof Math.acosh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2930,6 +2991,7 @@ test(typeof Math.asinh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2973,6 +3035,7 @@ test(typeof Math.atanh === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3016,6 +3079,7 @@ test(typeof Math.hypot === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3059,6 +3123,7 @@ test(typeof Math.trunc === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3102,6 +3167,7 @@ test(typeof Math.fround === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3145,6 +3211,7 @@ test(typeof Math.cbrt === 'function');
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3181,7 +3248,7 @@ test(typeof Math.cbrt === 'function');
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <th colspan="39" class="separator"></th>
+          <th colspan="40" class="separator"></th>
         </tr>
         <tr>
           <td id="Typed_Objects_(_b_ES7_/b_proposal)"><span><a class="anchor" href="#Typed_Objects_(_b_ES7_/b_proposal)">&sect;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed Objects (<b>ES7</b> proposal)</a></span></td>
@@ -3191,6 +3258,7 @@ test(typeof StructType !== 'undefined');
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3234,6 +3302,7 @@ test(typeof Object.observe === 'function');
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3277,6 +3346,7 @@ test(typeof Object.getOwnPropertyDescriptors === 'function');
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no jsdc">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -1335,7 +1335,7 @@ test(function () {
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
-          <td class="no jsdc">No</td>
+          <td class="yes jsdc">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>


### PR DESCRIPTION
Hi there, I have write a program `jsdc` to compiler es6 to es5, it can works on both node.js and browser.

Features:
- Recognise and ignore es5 syntax
- Keep global variables
- The number of rows of code is consistent
- No preset script
- As simple as possible

Could u put this on your es6-compat-table? Thx!
- github: https://github.com/army8735/jsdc
- demo: http://army8735.me/jsdc/demo/
