### PR TITLE
Global symbol registry is wrong

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -2722,7 +2722,7 @@ test(function () {
 <script>
 test(function () {
   try {
-    var symbol = Symbol('foo');
+    var symbol = Symbol.for('foo');
     return Symbol.for('foo') === symbol &&
            Symbol.keyFor(symbol) === 'foo';
   }


### PR DESCRIPTION
Symbol("foo") doesn't put the symbol into the global registry. The author probably meant Symbol.for here.
