### PR TITLE
Tightened the arrow functions test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -311,44 +311,44 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:const',
   exec: function () {
     try {
-	  return !!Function(
-		+'const foo = 123;'
-		+'var passed = (foo === 123);'
-		
-		 // bar is not hoisted outside of its block,
-		 // baz is not hoisted outside of the for-loop,
-		 // and qux is not defined until its let statement is executed.
-		 
-		+'{ const bar = 456; }'
-		+'for(const baz = 0; false;) {}'
-		+'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-		+'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
-		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
-		+'const qux = 789;'
-		
-		 // uninitialized const is a syntax error (13.2.1.1)
-		 
-		+'passed &= (function() {'
-		+'  try { Function("const a;")();} catch(e) { return true; }'
-		+'}());'
-		
-		 // duplicate consts are syntax errors (13.2.1.1)
-		 
-		+'passed &= (function() {'
-		+'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
-		+'}());'
+      return !!Function(
+        +'const foo = 123;'
+        +'var passed = (foo === 123);'
+        
+         // bar is not hoisted outside of its block,
+         // baz is not hoisted outside of the for-loop,
+         // and qux is not defined until its let statement is executed.
+         
+        +'{ const bar = 456; }'
+        +'for(const baz = 0; false;) {}'
+        +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+        +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+        +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+        +'const qux = 789;'
+        
+         // uninitialized const is a syntax error (13.2.1.1)
+         
+        +'passed &= (function() {'
+        +'  try { Function("const a;")();} catch(e) { return true; }'
+        +'}());'
+        
+         // duplicate consts are syntax errors (13.2.1.1)
+         
+        +'passed &= (function() {'
+        +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
+        +'}());'
 
-		 // redefining a const is a syntax error (12.14.1)
-		 
-		+'passed &= (function() {'
-		+'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
-		+'}());'
-		
-		+'return passed;'
-	  )();
-	} catch (e) {
-	  return false;
-	}
+         // redefining a const is a syntax error (12.14.1)
+         
+        +'passed &= (function() {'
+        +'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
+        +'}());'
+        
+        +'return passed;'
+      )();
+    } catch (e) {
+      return false;
+    }
   },
   res: {
     tr:          false,
@@ -396,46 +396,46 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:let',
   exec: function () {
     try {
-	  return !!Function(
-		+'let foo = 123;'
-		+'let passed = (foo === 123);'
-		
-		 // bar is not hoisted outside of its block,
-		 // baz is not hoisted outside of the for-loop,
-		 // and qux is not defined until its let statement is executed.
-		 
-		+'{ let bar = 456; }'
-		+'for(let baz = 0; false;) {}'
-		+'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-		+'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
-		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
-		+'let qux = 789;'
-		
-		 // duplicate lets are syntax errors (13.2.1.1)
-		 
-		+'passed &= (function() {'
-		+'  try { Function("let a; let a;")();} catch(e) { return true; }'
-		+'}());'
-		
-		 // for-loop iterations create new bindings (13.6.3.3)
-		 
-		+'let scopes = [];'
-		+'for(let i = 0; i <= 2; i++) {'
-		+'  scopes.push(function(){ return i; });'
-		+'}'
-		+'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
-		
-		+'scopes = [];'
-		+'for(let i in { a:1, b:1, c:1 }) {'
-		+'  scopes.push(function(){ return i; });'
-		+'}'
-		+'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
-		
-		+'return passed;'
-	  )();
-	} catch (e) {
-	  return false;
-	}
+      return !!Function(
+        +'let foo = 123;'
+        +'let passed = (foo === 123);'
+        
+         // bar is not hoisted outside of its block,
+         // baz is not hoisted outside of the for-loop,
+         // and qux is not defined until its let statement is executed.
+         
+        +'{ let bar = 456; }'
+        +'for(let baz = 0; false;) {}'
+        +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+        +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+        +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+        +'let qux = 789;'
+        
+         // duplicate lets are syntax errors (13.2.1.1)
+         
+        +'passed &= (function() {'
+        +'  try { Function("let a; let a;")();} catch(e) { return true; }'
+        +'}());'
+        
+         // for-loop iterations create new bindings (13.6.3.3)
+         
+        +'let scopes = [];'
+        +'for(let i = 0; i <= 2; i++) {'
+        +'  scopes.push(function(){ return i; });'
+        +'}'
+        +'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
+        
+        +'scopes = [];'
+        +'for(let i in { a:1, b:1, c:1 }) {'
+        +'  scopes.push(function(){ return i; });'
+        +'}'
+        +'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
+        
+        +'return passed;'
+      )();
+    } catch (e) {
+      return false;
+    }
   },
   res: {
     tr:          false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -315,28 +315,26 @@ exports.tests = [
          'const foo = 123;'
         +'var passed = (foo === 123);'
         
-         // bar is not hoisted outside of its block,
-         // and qux is not defined until its const statement is executed.
-         
+         // bar is not hoisted outside of its block
         +'{ const bar = 456; }'
         +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+
+         // qux is not defined until its const statement is executed,
+         // and accessing it prior to that will result in a ReferenceError.
         +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
         +'const qux = 789;'
         
          // uninitialized const is a syntax error (13.2.1.1)
-         
         +'passed &= (function() {'
         +'  try { Function("const a;")();} catch(e) { return true; }'
         +'}());'
         
          // duplicate consts are syntax errors (13.2.1.1)
-         
         +'passed &= (function() {'
         +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
         +'}());'
 
          // redefining a const is a syntax error (12.14.1)
-         
         +'passed &= (function() {'
         +'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
         +'}());'
@@ -397,25 +395,25 @@ exports.tests = [
          'let foo = 123;'
         +'let passed = (foo === 123);'
         
-         // bar is not hoisted outside of its block,
-         // baz is not hoisted outside of the for-loop,
-         // and qux is not defined until its let statement is executed.
-         
+         // bar is not hoisted outside of its block
         +'{ let bar = 456; }'
-        +'for(let baz = 0; false;) {}'
         +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+
+         // baz is not hoisted outside of the for-loop
+        +'for(let baz = 0; false;) {}'
         +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+
+         // qux is not defined until its let statement is executed,
+         // and accessing it prior to that will result in a ReferenceError.
         +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
         +'let qux = 789;'
         
          // duplicate lets are syntax errors (13.2.1.1)
-         
         +'passed &= (function() {'
         +'  try { Function("let a; let a;")();} catch(e) { return true; }'
         +'}());'
         
          // for-loop iterations create new bindings (13.6.3.3)
-         
         +'let scopes = [];'
         +'for(let i = 0; i <= 2; i++) {'
         +'  scopes.push(function(){ return i; });'

--- a/data-es6.js
+++ b/data-es6.js
@@ -259,14 +259,45 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax',
   exec: function() {
     try {
-      eval('var a = () => 5;');
+      var passed;
+      eval(
+         // 0 parameters
+         'var a = () => 5;'
+        +'passed = (a() === 5);'
+
+         // 1 parameter, no brackets
+        +'var b = x => x + "foo";'
+        +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
+
+         // multiple parameters
+        +'var c = (v, w, x, y, z) => v+w-x*y/z;'
+        +'passed &= (c(6, 5, 4, 3, 2) === 5);'
+
+         // arrows are anonymous non-constructors
+        +'passed &= (a.name === "") && !("prototype" in a);'
+        +'passed &= (function(){ try { new a; } catch(e) { return true; }}());'
+
+         // arrows have a lexical "this" binding (14.2.17)
+        +'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
+        +'var e = { x : "baz", y : d };'
+        +'passed &= d("ley") === "barley" && e.y("ley") === "barley";'
+
+         // arrows' lexical "this" cannot be re-bound,
+         // but they can still be curried.
+        +'passed &= d.bind(e, "ley")("man") === "barley";'
+
+         // arrows have a lexical 'arguments' binding (14.2.17)
+        +'var f = (function(x) { return y => arguments[0]; }("qux"));'
+        +'passed &= f("corge") === "qux";'
+      );
+      return passed;
     } catch (e) {
       return false;
     }
     return true;
   },
   res: {
-    tr:          true,
+    tr:          false,
     ejs:         true,
     ie10:        false,
     ie11:        false,
@@ -275,16 +306,16 @@ exports.tests = [
     firefox16:   false,
     firefox17:   false,
     firefox18:   false,
-    firefox23:   true,
-    firefox24:   true,
-    firefox25:   true,
-    firefox27:   true,
-    firefox28:   true,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
     chrome:      false,
     chrome19dev: false,
     chrome21dev: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -360,62 +360,75 @@ exports.tests = [
 {
   name: 'let',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:let',
-  exec: [
-    {
-      type: 'application/javascript;version=1.8',
-      script: function () {
-        test((function () {
-          try {
-            return eval('(function () { let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
-          } catch (e) {
-            return false;
-          }
-        }()));
-        global.__let_script_executed = true;
-      }
-    },
-    {
-      script: function () {
-        if (!global.__let_script_executed) {
-          test((function () {
-            try {
-              return eval('(function () { "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
-            } catch (e) {
-              return false;
-            }
-          }()));
-        }
-      }
-    }
-  ],
+  exec: function () {
+    try {
+	  return Function(
+		 'let foo = 123;'
+		+'let passed = (foo === 123);'
+		
+		 // bar is not hoisted outside of its block,
+		 // baz is not hoisted outside of the for-loop,
+		 // and qux is not defined until its let statement is executed.
+		 
+		+'{ let bar = 456; }'
+		+'for(let baz = 0; false;) {}'
+		+'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+		+'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+		+'let qux = 789;'
+		
+		 // duplicated lets are errors
+		 
+		+'passed &= (function(){ try { let a; let a; } catch(e) { return true; }}());'
+		
+		 // for-loop iterations create new bindings
+		 
+		+'let scopes = [];'
+		+'for(let i = 0; i <= 2; i++) {'
+		+'  scopes.push(function(){ return i; });'
+		+'}'
+		+'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
+		
+		+'scopes = [];'
+		+'for(let i in { a:1, b:1, c:1 }) {'
+		+'  scopes.push(function(){ return i; });'
+		+'}'
+		+'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
+		
+		+'return passed;'
+	  )();
+	} catch (e) {
+	  return false;
+	}
+  },
   res: {
-    tr:          true,
+    tr:          false,
     ejs:         true,
     ie10:        false,
     ie11:        true,
-    firefox11:   true,
-    firefox13:   true,
-    firefox16:   true,
-    firefox17:   true,
-    firefox18:   true,
-    firefox23:   true,
-    firefox24:   true,
-    firefox25:   true,
-    firefox27:   true,
-    firefox28:   true,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
     chrome:      false,
-    chrome19dev: true,
-    chrome21dev: true,
-    chrome30:    true,
-    chrome33:    true,
-    chrome34:    true,
-    chrome35:    true,
-    chrome37:    true,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
     safari51:    false,
     safari6:     false,
     safari7:     false,
@@ -426,7 +439,7 @@ exports.tests = [
     rhino17:     false,
     phantom:     false,
     node:        false,
-    nodeharmony: true
+    nodeharmony: false
   }
 },
 {

--- a/data-es6.js
+++ b/data-es6.js
@@ -312,17 +312,14 @@ exports.tests = [
   exec: function () {
     try {
       return !!Function(
-        +'const foo = 123;'
+         'const foo = 123;'
         +'var passed = (foo === 123);'
         
          // bar is not hoisted outside of its block,
-         // baz is not hoisted outside of the for-loop,
-         // and qux is not defined until its let statement is executed.
+         // and qux is not defined until its const statement is executed.
          
         +'{ const bar = 456; }'
-        +'for(const baz = 0; false;) {}'
         +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-        +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
         +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
         +'const qux = 789;'
         
@@ -397,7 +394,7 @@ exports.tests = [
   exec: function () {
     try {
       return !!Function(
-        +'let foo = 123;'
+         'let foo = 123;'
         +'let passed = (foo === 123);'
         
          // bar is not hoisted outside of its block,

--- a/data-es6.js
+++ b/data-es6.js
@@ -362,8 +362,9 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:let',
   exec: function () {
     try {
-	  return Function(
-		 'let foo = 123;'
+	  return !!Function(
+         '"use strict";'
+		+'let foo = 123;'
 		+'let passed = (foo === 123);'
 		
 		 // bar is not hoisted outside of its block,
@@ -377,9 +378,11 @@ exports.tests = [
 		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
 		+'let qux = 789;'
 		
-		 // duplicated lets are errors
+		 // duplicate lets are syntax errors
 		 
-		+'passed &= (function(){ try { let a; let a; } catch(e) { return true; }}());'
+		+'passed &= (function() {'
+		+'  try { Function("\'use strict\'; let a; let a;")();} catch(e) { return true; }'
+		+'}());'
 		
 		 // for-loop iterations create new bindings
 		 

--- a/data-es6.js
+++ b/data-es6.js
@@ -311,50 +311,84 @@ exports.tests = [
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:const',
   exec: function () {
     try {
-      return eval('(function () { const foobarbaz = 12; return typeof foobarbaz === "number"; }())');
-    } catch (e) {
-      return false;
-    }
+	  return !!Function(
+		+'const foo = 123;'
+		+'var passed = (foo === 123);'
+		
+		 // bar is not hoisted outside of its block,
+		 // baz is not hoisted outside of the for-loop,
+		 // and qux is not defined until its let statement is executed.
+		 
+		+'{ const bar = 456; }'
+		+'for(const baz = 0; false;) {}'
+		+'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+		+'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+		+'const qux = 789;'
+		
+		 // uninitialized const is a syntax error (13.2.1.1)
+		 
+		+'passed &= (function() {'
+		+'  try { Function("const a;")();} catch(e) { return true; }'
+		+'}());'
+		
+		 // duplicate consts are syntax errors (13.2.1.1)
+		 
+		+'passed &= (function() {'
+		+'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
+		+'}());'
+
+		 // redefining a const is a syntax error (12.14.1)
+		 
+		+'passed &= (function() {'
+		+'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
+		+'}());'
+		
+		+'return passed;'
+	  )();
+	} catch (e) {
+	  return false;
+	}
   },
   res: {
-    tr:          true,
+    tr:          false,
     ejs:         true,
     ie10:        false,
     ie11:        true,
     firefox11:   false,
     firefox13:   false,
-    firefox16:   true,
-    firefox17:   true,
-    firefox18:   true,
-    firefox23:   true,
-    firefox24:   true,
-    firefox25:   true,
-    firefox27:   true,
-    firefox28:   true,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
-    chrome:      true,
-    chrome19dev: true,
-    chrome21dev: true,
-    chrome30:    true,
-    chrome33:    true,
-    chrome34:    true,
-    chrome35:    true,
-    chrome37:    true,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
     safari51:    false,
-    safari6:     true,
-    safari7:     true,
-    webkit:      true,
-    opera:       true,
-    opera15:     true,
-    konq49:      true,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    opera15:     false,
+    konq49:      false,
     rhino17:     false,
-    phantom:     true,
-    node:        true,
-    nodeharmony: true
+    phantom:     false,
+    node:        false,
+    nodeharmony: false
   }
 },
 {
@@ -363,7 +397,6 @@ exports.tests = [
   exec: function () {
     try {
 	  return !!Function(
-         '"use strict";'
 		+'let foo = 123;'
 		+'let passed = (foo === 123);'
 		
@@ -378,13 +411,13 @@ exports.tests = [
 		+'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
 		+'let qux = 789;'
 		
-		 // duplicate lets are syntax errors
+		 // duplicate lets are syntax errors (13.2.1.1)
 		 
 		+'passed &= (function() {'
-		+'  try { Function("\'use strict\'; let a; let a;")();} catch(e) { return true; }'
+		+'  try { Function("let a; let a;")();} catch(e) { return true; }'
 		+'}());'
 		
-		 // for-loop iterations create new bindings
+		 // for-loop iterations create new bindings (13.6.3.3)
 		 
 		+'let scopes = [];'
 		+'for(let i = 0; i <= 2; i++) {'

--- a/data-es6.js
+++ b/data-es6.js
@@ -256,7 +256,7 @@ exports.tests = [
 },
 {
   name: 'arrow functions',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
   exec: function() {
     try {
       var passed;
@@ -289,6 +289,9 @@ exports.tests = [
          // arrows have a lexical 'arguments' binding (14.2.17)
         +'var f = (function(x) { return y => arguments[0]; }("qux"));'
         +'passed &= f("corge") === "qux";'
+        
+        // a line terminator between parameters and arrow is a syntax error
+        +'passed &= eval("try { var g = a \\n => 4; false; } catch(e) { true; }");'
       );
       return passed;
     } catch (e) {

--- a/es6/index.html
+++ b/es6/index.html
@@ -220,28 +220,26 @@ test(function () {
        'const foo = 123;'
       +'var passed = (foo === 123);'
       
-       // bar is not hoisted outside of its block,
-       // and qux is not defined until its const statement is executed.
-       
+       // bar is not hoisted outside of its block
       +'{ const bar = 456; }'
       +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+
+       // qux is not defined until its const statement is executed,
+       // and accessing it prior to that will result in a ReferenceError.
       +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
       +'const qux = 789;'
       
        // uninitialized const is a syntax error (13.2.1.1)
-       
       +'passed &= (function() {'
       +'  try { Function("const a;")();} catch(e) { return true; }'
       +'}());'
       
        // duplicate consts are syntax errors (13.2.1.1)
-       
       +'passed &= (function() {'
       +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
       +'}());'
 
        // redefining a const is a syntax error (12.14.1)
-       
       +'passed &= (function() {'
       +'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
       +'}());'
@@ -301,25 +299,25 @@ test(function () {
        'let foo = 123;'
       +'let passed = (foo === 123);'
       
-       // bar is not hoisted outside of its block,
-       // baz is not hoisted outside of the for-loop,
-       // and qux is not defined until its let statement is executed.
-       
+       // bar is not hoisted outside of its block
       +'{ let bar = 456; }'
-      +'for(let baz = 0; false;) {}'
       +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+
+       // baz is not hoisted outside of the for-loop
+      +'for(let baz = 0; false;) {}'
       +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+
+       // qux is not defined until its let statement is executed,
+       // and accessing it prior to that will result in a ReferenceError.
       +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
       +'let qux = 789;'
       
        // duplicate lets are syntax errors (13.2.1.1)
-       
       +'passed &= (function() {'
       +'  try { Function("let a; let a;")();} catch(e) { return true; }'
       +'}());'
       
        // for-loop iterations create new bindings (13.6.3.3)
-       
       +'let scopes = [];'
       +'for(let i = 0; i <= 2; i++) {'
       +'  scopes.push(function(){ return i; });'

--- a/es6/index.html
+++ b/es6/index.html
@@ -217,39 +217,39 @@ test(function () {
 test(function () {
   try {
     return !!Function(
-    +'const foo = 123;'
-    +'var passed = (foo === 123);'
-    
-     // bar is not hoisted outside of its block,
-     // baz is not hoisted outside of the for-loop,
-     // and qux is not defined until its let statement is executed.
-     
-    +'{ const bar = 456; }'
-    +'for(const baz = 0; false;) {}'
-    +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-    +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
-    +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
-    +'const qux = 789;'
-    
-     // uninitialized const is a syntax error (13.2.1.1)
-     
-    +'passed &= (function() {'
-    +'  try { Function("const a;")();} catch(e) { return true; }'
-    +'}());'
-    
-     // duplicate consts are syntax errors (13.2.1.1)
-     
-    +'passed &= (function() {'
-    +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
-    +'}());'
+      +'const foo = 123;'
+      +'var passed = (foo === 123);'
+      
+       // bar is not hoisted outside of its block,
+       // baz is not hoisted outside of the for-loop,
+       // and qux is not defined until its let statement is executed.
+       
+      +'{ const bar = 456; }'
+      +'for(const baz = 0; false;) {}'
+      +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+      +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+      +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+      +'const qux = 789;'
+      
+       // uninitialized const is a syntax error (13.2.1.1)
+       
+      +'passed &= (function() {'
+      +'  try { Function("const a;")();} catch(e) { return true; }'
+      +'}());'
+      
+       // duplicate consts are syntax errors (13.2.1.1)
+       
+      +'passed &= (function() {'
+      +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
+      +'}());'
 
-     // redefining a const is a syntax error (12.14.1)
-     
-    +'passed &= (function() {'
-    +'  try {Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
-    +'}());'
-    
-    +'return passed;'
+       // redefining a const is a syntax error (12.14.1)
+       
+      +'passed &= (function() {'
+      +'  try { Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
+      +'}());'
+      
+      +'return passed;'
     )();
   } catch (e) {
     return false;
@@ -257,43 +257,43 @@ test(function () {
 }());
 </script>
 
-          <td class="yes tr">Yes</td>
+          <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30">Yes</td>
-          <td class="yes chrome33">Yes</td>
-          <td class="yes chrome34">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30">No</td>
+          <td class="no chrome33">No</td>
+          <td class="no chrome34">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
           <td class="no safari51 obsolete">No</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes opera15">Yes</td>
-          <td class="yes konq49">Yes</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no opera15">No</td>
+          <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
-          <td class="yes phantom">Yes</td>
-          <td class="yes node">Yes</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
         </tr>
         <tr>
           <td id="let"><span><a class="anchor" href="#let">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:let">let</a></span></td>
@@ -301,41 +301,41 @@ test(function () {
 test(function () {
   try {
     return !!Function(
-    +'let foo = 123;'
-    +'let passed = (foo === 123);'
-    
-     // bar is not hoisted outside of its block,
-     // baz is not hoisted outside of the for-loop,
-     // and qux is not defined until its let statement is executed.
-     
-    +'{ let bar = 456; }'
-    +'for(let baz = 0; false;) {}'
-    +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-    +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
-    +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
-    +'let qux = 789;'
-    
-     // duplicate lets are syntax errors (13.2.1.1)
-     
-    +'passed &= (function() {'
-    +'  try { Function("let a; let a;")();} catch(e) { return true; }'
-    +'}());'
-    
-     // for-loop iterations create new bindings (13.6.3.3)
-     
-    +'let scopes = [];'
-    +'for(let i = 0; i <= 2; i++) {'
-    +'  scopes.push(function(){ return i; });'
-    +'}'
-    +'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
-    
-    +'scopes = [];'
-    +'for(let i in { a:1, b:1, c:1 }) {'
-    +'  scopes.push(function(){ return i; });'
-    +'}'
-    +'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
-    
-    +'return passed;'
+      +'let foo = 123;'
+      +'let passed = (foo === 123);'
+      
+       // bar is not hoisted outside of its block,
+       // baz is not hoisted outside of the for-loop,
+       // and qux is not defined until its let statement is executed.
+       
+      +'{ let bar = 456; }'
+      +'for(let baz = 0; false;) {}'
+      +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+      +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+      +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+      +'let qux = 789;'
+      
+       // duplicate lets are syntax errors (13.2.1.1)
+       
+      +'passed &= (function() {'
+      +'  try { Function("let a; let a;")();} catch(e) { return true; }'
+      +'}());'
+      
+       // for-loop iterations create new bindings (13.6.3.3)
+       
+      +'let scopes = [];'
+      +'for(let i = 0; i <= 2; i++) {'
+      +'  scopes.push(function(){ return i; });'
+      +'}'
+      +'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
+      
+      +'scopes = [];'
+      +'for(let i in { a:1, b:1, c:1 }) {'
+      +'  scopes.push(function(){ return i; });'
+      +'}'
+      +'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
+      
+      +'return passed;'
     )();
   } catch (e) {
     return false;

--- a/es6/index.html
+++ b/es6/index.html
@@ -161,7 +161,7 @@ test(function () {
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax">arrow functions</a></span></td>
+          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 <script>
 test(function () {
   try {
@@ -195,6 +195,9 @@ test(function () {
        // arrows have a lexical 'arguments' binding (14.2.17)
       +'var f = (function(x) { return y => arguments[0]; }("qux"));'
       +'passed &= f("corge") === "qux";'
+      
+      // a line terminator between parameters and arrow is a syntax error
+      +'passed &= eval("try { var g = a \\n => 4; false; } catch(e) { true; }");'
     );
     return passed;
   } catch (e) {

--- a/es6/index.html
+++ b/es6/index.html
@@ -263,54 +263,76 @@ test(function () {
         </tr>
         <tr>
           <td id="let"><span><a class="anchor" href="#let">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:let">let</a></span></td>
-<script type="application/javascript;version=1.8">
-test((function () {
+<script>
+test(function () {
   try {
-    return eval('(function () { let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
+    return Function(
+     'let foo = 123;'
+    +'let passed = (foo === 123);'
+    
+     // bar is not hoisted outside of its block,
+     // baz is not hoisted outside of the for-loop,
+     // and qux is not defined until its let statement is executed.
+     
+    +'{ let bar = 456; }'
+    +'for(let baz = 0; false;) {}'
+    +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+    +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+    +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+    +'let qux = 789;'
+    
+     // duplicated lets are errors
+     
+    +'passed &= (function(){ try { let a; let a; } catch(e) { return true; }}());'
+    
+     // for-loop iterations create new bindings
+     
+    +'let scopes = [];'
+    +'for(let i = 0; i <= 2; i++) {'
+    +'  scopes.push(function(){ return i; });'
+    +'}'
+    +'passed &= (scopes[0]() === 0 && scopes[1]() === 1 && scopes[2]() === 2);'
+    
+    +'scopes = [];'
+    +'for(let i in { a:1, b:1, c:1 }) {'
+    +'  scopes.push(function(){ return i; });'
+    +'}'
+    +'passed &= (scopes[0]() === "a" && scopes[1]() === "b" && scopes[2]() === "c");'
+    
+    +'return passed;'
+    )();
   } catch (e) {
     return false;
   }
-}()));
-global.__let_script_executed = true;
-</script>
-<script>
-if (!global.__let_script_executed) {
-  test((function () {
-    try {
-      return eval('(function () { "use strict"; __let_script_executed = true; let foobarbaz2 = 123; return foobarbaz2 == 123; }())');
-    } catch (e) {
-      return false;
-    }
-  }()));
-}
+}());
 </script>
 
-          <td class="yes tr">Yes</td>
+          <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="yes firefox11 obsolete">Yes</td>
-          <td class="yes firefox13 obsolete">Yes</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
           <td class="no chrome obsolete">No</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30">Yes</td>
-          <td class="yes chrome33">Yes</td>
-          <td class="yes chrome34">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30">No</td>
+          <td class="no chrome33">No</td>
+          <td class="no chrome34">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -321,7 +343,7 @@ if (!global.__let_script_executed) {
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td class="no nodeharmony">No</td>
         </tr>
         <tr>
           <td id="default_function_params"><span><a class="anchor" href="#default_function_params">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values">default function params</a></span></td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -165,7 +165,38 @@ test(function () {
 <script>
 test(function () {
   try {
-    eval('var a = () => 5;');
+    var passed;
+    eval(
+       // 0 parameters
+       'var a = () => 5;'
+      +'passed = (a() === 5);'
+
+       // 1 parameter, no brackets
+      +'var b = x => x + "foo";'
+      +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
+
+       // multiple parameters
+      +'var c = (v, w, x, y, z) => v+w-x*y/z;'
+      +'passed &= (c(6, 5, 4, 3, 2) === 5);'
+
+       // arrows are anonymous non-constructors
+      +'passed &= (a.name === "") && !("prototype" in a);'
+      +'passed &= (function(){ try { new a; } catch(e) { return true; }}());'
+
+       // arrows have a lexical "this" binding (14.2.17)
+      +'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
+      +'var e = { x : "baz", y : d };'
+      +'passed &= d("ley") === "barley" && e.y("ley") === "barley";'
+
+       // arrows' lexical "this" cannot be re-bound,
+       // but they can still be curried.
+      +'passed &= d.bind(e, "ley")("man") === "barley";'
+
+       // arrows have a lexical 'arguments' binding (14.2.17)
+      +'var f = (function(x) { return y => arguments[0]; }("qux"));'
+      +'passed &= f("corge") === "qux";'
+    );
+    return passed;
   } catch (e) {
     return false;
   }
@@ -173,7 +204,7 @@ test(function () {
 }());
 </script>
 
-          <td class="yes tr">Yes</td>
+          <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -182,15 +213,15 @@ test(function () {
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -266,8 +266,9 @@ test(function () {
 <script>
 test(function () {
   try {
-    return Function(
-     'let foo = 123;'
+    return !!Function(
+       '"use strict";'
+    +'let foo = 123;'
     +'let passed = (foo === 123);'
     
      // bar is not hoisted outside of its block,
@@ -281,9 +282,11 @@ test(function () {
     +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
     +'let qux = 789;'
     
-     // duplicated lets are errors
+     // duplicate lets are syntax errors
      
-    +'passed &= (function(){ try { let a; let a; } catch(e) { return true; }}());'
+    +'passed &= (function() {'
+    +'  try { Function("\'use strict\'; let a; let a;")();} catch(e) { return true; }'
+    +'}());'
     
      // for-loop iterations create new bindings
      

--- a/es6/index.html
+++ b/es6/index.html
@@ -217,17 +217,14 @@ test(function () {
 test(function () {
   try {
     return !!Function(
-      +'const foo = 123;'
+       'const foo = 123;'
       +'var passed = (foo === 123);'
       
        // bar is not hoisted outside of its block,
-       // baz is not hoisted outside of the for-loop,
-       // and qux is not defined until its let statement is executed.
+       // and qux is not defined until its const statement is executed.
        
       +'{ const bar = 456; }'
-      +'for(const baz = 0; false;) {}'
       +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
-      +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
       +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
       +'const qux = 789;'
       
@@ -301,7 +298,7 @@ test(function () {
 test(function () {
   try {
     return !!Function(
-      +'let foo = 123;'
+       'let foo = 123;'
       +'let passed = (foo === 123);'
       
        // bar is not hoisted outside of its block,

--- a/es6/index.html
+++ b/es6/index.html
@@ -216,7 +216,41 @@ test(function () {
 <script>
 test(function () {
   try {
-    return eval('(function () { const foobarbaz = 12; return typeof foobarbaz === "number"; }())');
+    return !!Function(
+    +'const foo = 123;'
+    +'var passed = (foo === 123);'
+    
+     // bar is not hoisted outside of its block,
+     // baz is not hoisted outside of the for-loop,
+     // and qux is not defined until its let statement is executed.
+     
+    +'{ const bar = 456; }'
+    +'for(const baz = 0; false;) {}'
+    +'passed &= (function(){ try { bar; } catch(e) { return true; }}());'
+    +'passed &= (function(){ try { baz; } catch(e) { return true; }}());'
+    +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
+    +'const qux = 789;'
+    
+     // uninitialized const is a syntax error (13.2.1.1)
+     
+    +'passed &= (function() {'
+    +'  try { Function("const a;")();} catch(e) { return true; }'
+    +'}());'
+    
+     // duplicate consts are syntax errors (13.2.1.1)
+     
+    +'passed &= (function() {'
+    +'  try { Function("const a = 1; const a = 2;")();} catch(e) { return true; }'
+    +'}());'
+
+     // redefining a const is a syntax error (12.14.1)
+     
+    +'passed &= (function() {'
+    +'  try {Function("const a = 1; a = 2;")(); } catch(e) { return true; }'
+    +'}());'
+    
+    +'return passed;'
+    )();
   } catch (e) {
     return false;
   }
@@ -267,7 +301,6 @@ test(function () {
 test(function () {
   try {
     return !!Function(
-       '"use strict";'
     +'let foo = 123;'
     +'let passed = (foo === 123);'
     
@@ -282,13 +315,13 @@ test(function () {
     +'passed &= (function(){ try { qux; } catch(e) { return true; }}());'
     +'let qux = 789;'
     
-     // duplicate lets are syntax errors
+     // duplicate lets are syntax errors (13.2.1.1)
      
     +'passed &= (function() {'
-    +'  try { Function("\'use strict\'; let a; let a;")();} catch(e) { return true; }'
+    +'  try { Function("let a; let a;")();} catch(e) { return true; }'
     +'}());'
     
-     // for-loop iterations create new bindings
+     // for-loop iterations create new bindings (13.6.3.3)
      
     +'let scopes = [];'
     +'for(let i = 0; i <= 2; i++) {'


### PR DESCRIPTION
The arrow test now checks:
- 1 parameter with no brackets
- multiple parameters
- absence of `prototype` and inability to be used with `new` (Traceur fails this check)
- lexical `this` binding
- lexical `arguments` binding (Firefox fails this check)

This last bullet-point gives me pause, though - I think it isn't too useful or helpful to the reader to report Firefox/Traceur failing support when the "core functionality" (which I regard as basic syntax + lexical `this`) is present, but of course it would be quite incorrect to give them a "Yes". So, I feel that after this is accepted, it should be a priority to implement "partial support" test results, differentiating core functionality checks from full support checks.

Note: I accidentally based this branch off #164, so you ought to merge that before considering this.
