### PR TITLE
List annex B features as optional on non-browsers

### DIFF
--- a/build.js
+++ b/build.js
@@ -94,7 +94,10 @@ function dataToHtml(browsers, tests) {
     // each browser for this test
     for (browserId in browsers) {
       val = t.res[browserId];
-      if (val == null) {
+      if (browsers[browserId].nonbrowser && t.annex_b && !val) {
+        body.push('\t<td class="not-applicable ' + browserTableClass(browserId, browsers[browserId]) + '">n/a</td>');
+      }
+      else if (val == null) {
         body.push('\t<td class="' + browserTableClass(browserId, browsers[browserId]) + '"></td>');
       } else {
         body.push(

--- a/build.js
+++ b/build.js
@@ -94,8 +94,9 @@ function dataToHtml(browsers, tests) {
     // each browser for this test
     for (browserId in browsers) {
       val = t.res[browserId];
-      if (browsers[browserId].nonbrowser && t.annex_b && !val) {
-        body.push('\t<td class="not-applicable ' + browserTableClass(browserId, browsers[browserId]) + '">n/a</td>');
+      if (browsers[browserId].nonbrowser && t.annex_b) {
+        body.push('\t<td title="This feature is optional on non-browser platforms." class="not-applicable '
+          + browserTableClass(browserId, browsers[browserId]) + '">' + boolToString(val) + '</td>');
       }
       else if (val == null) {
         body.push('\t<td class="' + browserTableClass(browserId, browsers[browserId]) + '"></td>');

--- a/data-es6.js
+++ b/data-es6.js
@@ -188,7 +188,8 @@ exports.browsers = {
   },
   phantom: {
     full: 'PhantomJS 1.9.7 AppleWebKit/534.34',
-    short: 'PH'
+    short: 'PH',
+    nonbrowser: true,
   },
   node: {
     full: 'Node 0.10',

--- a/data-es6.js
+++ b/data-es6.js
@@ -5310,3 +5310,7 @@ exports.tests = [
   separator: 'after'
 }
 ];
+
+//Shift annex B features to the bottom
+exports.tests = exports.tests.filter(function(e) { return !e.annex_b })
+        .concat(exports.tests.filter(function(e) { return  e.annex_b }));

--- a/data-es6.js
+++ b/data-es6.js
@@ -8,12 +8,14 @@ exports.browsers = {
   tr: {
     full: 'Traceur compiler',
     short: 'Traceur',
-    obsolete: false // always up-to-date version
+    obsolete: false, // always up-to-date version
+    nonbrowser: true
   },
   ejs: {
     full: 'Echo JS',
     short: 'EJS',
-    obsolete: false // always up-to-date version
+    obsolete: false, // always up-to-date version
+    nonbrowser: true
   },
   ie10: {
     full: 'Internet Explorer',
@@ -181,7 +183,8 @@ exports.browsers = {
   },
   rhino17: {
     full: 'Rhino 1.7',
-    short: 'RH'
+    short: 'RH',
+    nonbrowser: true
   },
   phantom: {
     full: 'PhantomJS 1.9.7 AppleWebKit/534.34',
@@ -190,12 +193,14 @@ exports.browsers = {
   node: {
     full: 'Node 0.10',
     short: 'Node',
-    obsolete: false // current version
+    obsolete: false, // current version
+    nonbrowser: true
   },
   nodeharmony: {
     full: 'Node 0.11.13 harmony',
     short: 'Node harmony',
     obsolete: false, // current version
+    nonbrowser: true,
     note_id: 'harmony-flag',
     note_html: 'Have to be enabled via --harmony flag'
   }
@@ -904,6 +909,7 @@ exports.tests = [
 },
 {
   name: '__proto__ in object literals',
+  annex_b: true,
   note_id: 'proto-in-object-literals',
   note_html: 'Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers',
@@ -2371,6 +2377,7 @@ exports.tests = [
 },
 {
   name: 'Object.prototype.__proto__',
+  annex_b: true,
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__',
   exec: function () {
     var a = {},
@@ -2802,6 +2809,7 @@ exports.tests = [
 },
 {
   name: 'String.prototype HTML methods',
+  annex_b: true,
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor',
   exec: function () {
     var i, names = ["anchor", "big", "bold", "fixed", "fontcolor", "fontsize",
@@ -3636,6 +3644,7 @@ exports.tests = [
 },
 {
   name: 'RegExp.prototype.compile',
+  annex_b: true,
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile',
   exec: function () {
     return typeof RegExp.prototype.compile === 'function';

--- a/es6/index.html
+++ b/es6/index.html
@@ -784,61 +784,6 @@ test(function () {
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[4]</sup></a></span></td>
-<script>
-test(function () {
-  var passed = { __proto__ : [] } instanceof Array;
-  // If computed properties are supported, the following
-  // check must also be passed.
-  var a = "__proto__";
-  try {
-    return eval("passed && !({ [a] : [] } instanceof Array)");
-  }
-  catch(e) {
-    return passed;
-  }
-}());
-</script>
-
-          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
-          <td class="no ie10">No</td>
-          <td class="yes ie11">Yes</td>
-          <td class="yes firefox11 obsolete">Yes</td>
-          <td class="yes firefox13 obsolete">Yes</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes konq49">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
-        </tr>
-        <tr>
           <td id="modules"><span><a class="anchor" href="#modules">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:modules">modules</a></span></td>
 <script>
 test(function () {
@@ -1804,7 +1749,7 @@ test(function () {
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes webkit">Yes<a href="#fx-destructuring-note"><sup>[5]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#fx-destructuring-note"><sup>[4]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
@@ -2199,60 +2144,6 @@ test(typeof Object.setPrototypeOf === 'function');
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
-          <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
-<script>
-test(function () {
-  var a = {},
-      desc = Object.getOwnPropertyDescriptor
-          && Object.getOwnPropertyDescriptor(Object.prototype,"__proto__");
-  return !!(desc
-      && "get" in desc
-      && "set" in desc
-      && desc.configurable
-      && !desc.enumerable
-      && Object.create(a).__proto__ === a);
-}());
-</script>
-
-          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
-          <td class="no ie10">No</td>
-          <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="no konq49">No</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">No</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable node">No</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
-        </tr>
-        <tr>
           <td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span></td>
 <script>
 test(function f() {
@@ -2605,59 +2496,6 @@ test(typeof String.prototype.contains === 'function');
           <td class="no phantom">No</td>
           <td class="no node">No</td>
           <td class="yes nodeharmony">Yes</td>
-        </tr>
-        <tr>
-          <td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor">String.prototype HTML methods</a></span></td>
-<script>
-test(function () {
-  var i, names = ["anchor", "big", "bold", "fixed", "fontcolor", "fontsize",
-    "italics", "link", "small", "strike", "sub", "sup"];
-  for (i = 0; i < names.length; i++) {
-    if (typeof String.prototype[names[i]] !== 'function') {
-      return false;
-    }
-  }
-  return true;
-}());
-</script>
-
-          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">Yes</td>
-          <td class="yes ie10">Yes</td>
-          <td class="yes ie11">Yes</td>
-          <td class="yes firefox11 obsolete">Yes</td>
-          <td class="yes firefox13 obsolete">Yes</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes konq49">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
         </tr>
         <tr>
           <td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span></td>
@@ -3415,50 +3253,6 @@ test(typeof RegExp.prototype.split === 'function');
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span></td>
-<script>
-test(typeof RegExp.prototype.compile === 'function');
-</script>
-
-          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
-          <td class="yes ie10">Yes</td>
-          <td class="yes ie11">Yes</td>
-          <td class="yes firefox11 obsolete">Yes</td>
-          <td class="yes firefox13 obsolete">Yes</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes konq49">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
-        </tr>
-        <tr>
           <td id="Array.from"><span><a class="anchor" href="#Array.from">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from">Array.from</a></span></td>
 <script>
 test(typeof Array.from === 'function');
@@ -3779,12 +3573,12 @@ test(typeof Array.prototype.values === 'function');
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[5]</sup></a></td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[7]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[6]</sup></a></td>
           <td class="no firefox29 obsolete">No</td>
           <td class="no firefox30 obsolete">No</td>
           <td class="no firefox31">No</td>
@@ -4280,7 +4074,7 @@ test(typeof Math.imul === 'function');
           <td class="yes firefox34">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[7]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
           <td class="yes chrome34 obsolete">Yes</td>
@@ -4887,7 +4681,7 @@ test(typeof Math.fround === 'function');
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[8]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
@@ -4960,6 +4754,212 @@ test(typeof Math.cbrt === 'function');
         <tr>
           <th colspan="40" class="separator"></th>
         </tr>
+        <tr>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[9]</sup></a></span></td>
+<script>
+test(function () {
+  var passed = { __proto__ : [] } instanceof Array;
+  // If computed properties are supported, the following
+  // check must also be passed.
+  var a = "__proto__";
+  try {
+    return eval("passed && !({ [a] : [] } instanceof Array)");
+  }
+  catch(e) {
+    return passed;
+  }
+}());
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="yes ie11">Yes</td>
+          <td class="yes firefox11 obsolete">Yes</td>
+          <td class="yes firefox13 obsolete">Yes</td>
+          <td class="yes firefox16 obsolete">Yes</td>
+          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
+        </tr>
+        <tr>
+          <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
+<script>
+test(function () {
+  var a = {},
+      desc = Object.getOwnPropertyDescriptor
+          && Object.getOwnPropertyDescriptor(Object.prototype,"__proto__");
+  return !!(desc
+      && "get" in desc
+      && "set" in desc
+      && desc.configurable
+      && !desc.enumerable
+      && Object.create(a).__proto__ === a);
+}());
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="yes ie11">Yes</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="no konq49">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
+        </tr>
+        <tr>
+          <td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor">String.prototype HTML methods</a></span></td>
+<script>
+test(function () {
+  var i, names = ["anchor", "big", "bold", "fixed", "fontcolor", "fontsize",
+    "italics", "link", "small", "strike", "sub", "sup"];
+  for (i = 0; i < names.length; i++) {
+    if (typeof String.prototype[names[i]] !== 'function') {
+      return false;
+    }
+  }
+  return true;
+}());
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">Yes</td>
+          <td class="yes ie10">Yes</td>
+          <td class="yes ie11">Yes</td>
+          <td class="yes firefox11 obsolete">Yes</td>
+          <td class="yes firefox13 obsolete">Yes</td>
+          <td class="yes firefox16 obsolete">Yes</td>
+          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
+        </tr>
+        <tr>
+          <td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span></td>
+<script>
+test(typeof RegExp.prototype.compile === 'function');
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td class="yes ie10">Yes</td>
+          <td class="yes ie11">Yes</td>
+          <td class="yes firefox11 obsolete">Yes</td>
+          <td class="yes firefox13 obsolete">Yes</td>
+          <td class="yes firefox16 obsolete">Yes</td>
+          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
+        </tr>
       </tbody>
     </table>
     <div id="footnotes">
@@ -4972,23 +4972,23 @@ test(typeof Math.cbrt === 'function');
       <p id="fx-spreading-strings-note">
         <sup>[3]</sup> Spreading strings in array literals, but not in calls, is supported from Firefox 16 up.
       </p>
-      <p id="proto-in-object-literals-note">
-        <sup>[4]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
       <p id="fx-destructuring-note">
-        <sup>[5]</sup> As of WebKit r170830, WebKit fails to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
+        <sup>[4]</sup> As of WebKit r170830, WebKit fails to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[6]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[5]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[7]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[6]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[8]</sup> Available since Chrome 28
+        <sup>[7]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[9]</sup> Available since Firefox 26
+        <sup>[8]</sup> Available since Firefox 26
+      </p>
+      <p id="proto-in-object-literals-note">
+        <sup>[9]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
     </div>
   </div>

--- a/es6/index.html
+++ b/es6/index.html
@@ -800,8 +800,8 @@ test(function () {
 }());
 </script>
 
-          <td class="yes tr">Yes</td>
-          <td class="not-applicable ejs">n/a</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -833,10 +833,10 @@ test(function () {
           <td class="yes webkit">Yes</td>
           <td class="yes opera">Yes</td>
           <td class="yes konq49">Yes</td>
-          <td class="yes rhino17">Yes</td>
-          <td class="yes phantom">Yes</td>
-          <td class="yes node">Yes</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
         </tr>
         <tr>
           <td id="modules"><span><a class="anchor" href="#modules">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:modules">modules</a></span></td>
@@ -2214,8 +2214,8 @@ test(function () {
 }());
 </script>
 
-          <td class="not-applicable tr">n/a</td>
-          <td class="not-applicable ejs">n/a</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2247,10 +2247,10 @@ test(function () {
           <td class="yes webkit">Yes</td>
           <td class="yes opera">Yes</td>
           <td class="no konq49">No</td>
-          <td class="yes rhino17">Yes</td>
-          <td class="no phantom">No</td>
-          <td class="not-applicable node">n/a</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
         </tr>
         <tr>
           <td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span></td>
@@ -2621,8 +2621,8 @@ test(function () {
 }());
 </script>
 
-          <td class="yes tr">Yes</td>
-          <td class="yes ejs">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">Yes</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -2654,10 +2654,10 @@ test(function () {
           <td class="yes webkit">Yes</td>
           <td class="yes opera">Yes</td>
           <td class="yes konq49">Yes</td>
-          <td class="yes rhino17">Yes</td>
-          <td class="yes phantom">Yes</td>
-          <td class="yes node">Yes</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
         </tr>
         <tr>
           <td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span></td>
@@ -3420,8 +3420,8 @@ test(typeof RegExp.prototype.split === 'function');
 test(typeof RegExp.prototype.compile === 'function');
 </script>
 
-          <td class="yes tr">Yes</td>
-          <td class="not-applicable ejs">n/a</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -3453,10 +3453,10 @@ test(typeof RegExp.prototype.compile === 'function');
           <td class="yes webkit">Yes</td>
           <td class="yes opera">Yes</td>
           <td class="yes konq49">Yes</td>
-          <td class="yes rhino17">Yes</td>
-          <td class="yes phantom">Yes</td>
-          <td class="yes node">Yes</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
         </tr>
         <tr>
           <td id="Array.from"><span><a class="anchor" href="#Array.from">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from">Array.from</a></span></td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -801,7 +801,7 @@ test(function () {
 </script>
 
           <td class="yes tr">Yes</td>
-          <td class="no ejs">No</td>
+          <td class="not-applicable ejs">n/a</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -2214,8 +2214,8 @@ test(function () {
 }());
 </script>
 
-          <td class="no tr">No</td>
-          <td class="no ejs">No</td>
+          <td class="not-applicable tr">n/a</td>
+          <td class="not-applicable ejs">n/a</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2249,7 +2249,7 @@ test(function () {
           <td class="no konq49">No</td>
           <td class="yes rhino17">Yes</td>
           <td class="no phantom">No</td>
-          <td class="no node">No</td>
+          <td class="not-applicable node">n/a</td>
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
@@ -3421,7 +3421,7 @@ test(typeof RegExp.prototype.compile === 'function');
 </script>
 
           <td class="yes tr">Yes</td>
-          <td class="no ejs">No</td>
+          <td class="not-applicable ejs">n/a</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>

--- a/master.css
+++ b/master.css
@@ -21,6 +21,7 @@ table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacit
 #table-wrapper tr:hover td.no,  #table-wrapper td.hover.no  { background: hsl(  0,  83%,  40%); }
 #table-wrapper tr:hover td.yes.obsolete, #table-wrapper td.hover.yes.obsolete { background: hsl(120,  24%,  37%); }
 #table-wrapper tr:hover td.no.obsolete,  #table-wrapper td.hover.no.obsolete  { background: hsl(  0,  33%,  50%); }
+#table-wrapper tr:hover td.not-applicable, #table-wrapper td.hover.not-applicable { background: hsl(120,  14%,  47%); }
 
 #body { padding-left: 1em; position: relative; min-width: 1250px; }
 
@@ -36,13 +37,14 @@ table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacit
 #footnotes { margin-left: 1.75em; margin-bottom: 1em; font-size: 0.9em; }
 
 .yes a, .no a { color: #fff; font-family: 'Open Sans', sans-serif;  }
-.yes, .no { text-align: center; font-family: 'Open Sans', sans-serif;
+.yes, .no, .not-applicable { text-align: center; font-family: 'Open Sans', sans-serif;
             font-size: 0.8em; padding: 0.25em 0.5em; color: #fff; }
 
 .yes          { background: hsl(120,  43%,  47%); }
 .no           { background: hsl(  0,  87%,  50%); }
 .yes.obsolete { background: hsl(120,  28%,  61%); }
 .no.obsolete  { background: hsl(  0,  72%,  65%); }
+.not-applicable          { background: hsl(120,  14%,  67%); }
 
 .test-name { width: 260px; }
 .warning { background: #ffc; display: inline-block; margin: 0 0 2em 0; padding: 0.25em; }

--- a/master.css
+++ b/master.css
@@ -44,7 +44,7 @@ table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacit
 .no           { background: hsl(  0,  87%,  50%); }
 .yes.obsolete { background: hsl(120,  28%,  61%); }
 .no.obsolete  { background: hsl(  0,  72%,  65%); }
-.not-applicable          { background: hsl(120,  14%,  67%); }
+.not-applicable { background: hsl(120,  14%,  67%); cursor: help; }
 
 .test-name { width: 260px; }
 .warning { background: #ffc; display: inline-block; margin: 0 0 2em 0; padding: 0.25em; }

--- a/master.js
+++ b/master.js
@@ -181,19 +181,20 @@ domready(function() {
   var numFeaturesPerColumn = window.numFeaturesPerColumn = { };
 
   var table = document.getElementById('table-wrapper');
-  var totalResultsInColum = table.rows.length - table.getElementsByClassName('separator').length - 1 /* header */;
 
   // count number of features for each column/browser
   for (var i = 1, len = table.rows.length; i < len; i++) {
     for (var j = 1, jlen = table.rows[i].cells.length; j < jlen; j++) {
 
       if (j === 2) continue;
-
-      if (typeof numFeaturesPerColumn[j] === 'undefined') {
-        numFeaturesPerColumn[j] = 0;
+      if (numFeaturesPerColumn[j] === undefined) {
+        numFeaturesPerColumn[j] = [0,0];
       }
       if (table.rows[i].cells[j].className.indexOf('yes') > -1) {
-        numFeaturesPerColumn[j]++;
+        numFeaturesPerColumn[j][0]++;
+      }
+      if (table.rows[i].cells[j].className.indexOf('not-applicable') == -1) {
+        numFeaturesPerColumn[j][1]++;
       }
     }
   }
@@ -201,10 +202,13 @@ domready(function() {
   // store number of features for each column/browser and numeric index
   for (var i = 0, len = table.rows.length; i < len; i++) {
     for (var j = 0, jlen = table.rows[i].cells.length; j < jlen; j++) {
-      var num = numFeaturesPerColumn[j];
+      if (numFeaturesPerColumn[j] === undefined) continue;
+      
+      var num = numFeaturesPerColumn[j][0];
+      var totalResultsInColum = numFeaturesPerColumn[j][1];
       var cell = table.rows[i].cells[j];
 
-      cell.setAttribute('data-features', num);
+      cell.setAttribute('data-features', num/totalResultsInColum);
       cell.setAttribute('data-num', j);
 
       if (cell.tagName.toLowerCase() === 'th' && typeof num === 'number') {
@@ -225,8 +229,8 @@ domready(function() {
       var sortByFeatures = this.checked;
 
       var comparator = sortByFeatures ? function(a, b) {
-        var numFeaturesPerA = parseInt(a.getAttribute('data-features'), 10);
-        var numFeaturesPerB = parseInt(b.getAttribute('data-features'), 10);
+        var numFeaturesPerA = parseFloat(a.getAttribute('data-features'), 10);
+        var numFeaturesPerB = parseFloat(b.getAttribute('data-features'), 10);
 
         return numFeaturesPerB - numFeaturesPerA;
       } : function(a, b) {


### PR DESCRIPTION
Related to the discussion in #178, which asserts that the red colour for "No" entries in the Traceur/EJS/etc. columns is misleading for Annex B features.... here's a proposal that changes Annex B rows so that the results for non-browsers are de-emphasised, signifying that they are optional. The cells are drawn in gray, and a title attribute states that "This feature is optional on non-browser platforms."

![](http://i.imgur.com/DKfsZBi.png)

They still say "Yes" and "No", purely to allow the data to remain, but it isn't expressed as important to ES6 compatibility.
