### PR TITLE
Non-standard: Remove features included in ES6

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2433,6 +2433,53 @@ exports.tests = [
   }
 },
 {
+  name: 'function "name" property',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname',
+  exec: function () {
+    return (function foo(){}).name == 'foo';
+  },
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   true,
+    firefox13:   true,
+    firefox16:   true,
+    firefox17:   true,
+    firefox18:   true,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      true,
+    chrome19dev: true,
+    chrome21dev: true,
+    chrome30:    true,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    true,
+    safari6:     true,
+    safari7:     true,
+    webkit:      true,
+    opera:       true,
+    konq49:      true,
+    rhino17:     true,
+    phantom:     true,
+    node:        true,
+    nodeharmony: true
+  }
+},
+{
   name: 'Function.prototype.toMethod',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod',
   exec: function f() {

--- a/data-es6.js
+++ b/data-es6.js
@@ -1909,6 +1909,64 @@ exports.tests = [
   }
 },
 {
+  name: 'Hoisted block-level function declaration',
+  annex_b: true,
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics',
+  exec: function () {
+    // Note: only available outside of strict mode.
+    try {
+      return !!Function(
+         'var passed = f() === 2 && g() === 4;'
+        +'if (true) { function f(){ return 1; } } else { function f(){ return 2; } }'
+        +'if (false){ function g(){ return 3; } } else { function g(){ return 4; } }'
+        +'return passed;'
+      )();
+    } catch (e) {
+      return false;
+    }
+  },
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   false,
+    chrome:      true,
+    chrome19dev: true,
+    chrome21dev: true,
+    chrome30:    true,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    true,
+    safari6:     true,
+    safari7:     true,
+    webkit:      true,
+    opera:       true,
+    konq49:      true,
+    rhino17:     false,
+    phantom:     true,
+    node:        true,
+    nodeharmony: true
+  }
+},
+{
   name: 'Destructuring',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
   exec: function () {

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -145,62 +145,6 @@ exports.browsers = {
 
 exports.tests = [
 {
-  name: 'function statement',
-  link: 'http://kangax.github.com/nfe/#function-statements',
-  exec: function () {
-    try {
-      eval('if (1) { function f(){ } } else { function f(){ } }');
-      return typeof f === 'function';
-    } catch (e) {
-      return false;
-    }
-  },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: {
-      val: true,
-      note_id: 'function-statements-strict-mode-firefox',
-      note_html: 'From Firefox 4 on, function statements in strict mode functions are only accepted at top level or immediately within another function.'
-    },
-    firefox5: {
-      val: true,
-      note_id: 'function-statements-strict-mode-firefox'
-    },
-    firefox6: {
-      val: true,
-      note_id: 'function-statements-strict-mode-firefox'
-    },
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: {
-      val: true,
-      note_id: 'besen-extensions',
-      note_html: "With 'Javascript-specific extensions' option enabled"
-    },
-    rhino: true,
-    phantom: true
-  },
-  separator: 'after'
-},
-{
   name: 'uneval',
   exec: function () {
     return typeof uneval == 'function';
@@ -270,41 +214,6 @@ exports.tests = [
     phantom: false
   },
   separator: 'after'
-},
-{
-  name: 'function "name" property',
-  exec: function () {
-    return (function foo(){}).name == 'foo';
-  },
-  res: {
-    ie7: false,
-    ie8: false,
-    ie9: false,
-    ie10: false,
-    ie11: false,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: false,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: false,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
 },
 {
   name: 'function "caller" property',
@@ -452,43 +361,6 @@ exports.tests = [
     phantom: false
   },
   separator: 'after'
-},
-{
-  name: '__proto__',
-  link: 'https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto',
-  exec: function () {
-    return ({}).__proto__ === Object.prototype &&
-      [].__proto__ === Array.prototype;
-  },
-  res: {
-    ie7: false,
-    ie8: false,
-    ie9: false,
-    ie10: false,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: false,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
 },
 {
   name: '__count__',
@@ -678,101 +550,6 @@ exports.tests = [
   separator: 'after'
 },
 {
-  name: 'const',
-  exec: function () {
-    try {
-      eval('const foobarbaz = 12');
-      return typeof foobarbaz === 'number';
-    } catch (e) {
-      return false;
-    }
-  },
-  res: {
-    ie7: false,
-    ie8: false,
-    ie9: false,
-    ie10: false,
-    ie11: false,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: false,
-    konq49: false,
-    besen: false,
-    rhino: false,
-    phantom: true
-  }
-},
-{
-  name: 'let',
-  exec: [
-    {
-      type: 'application/javascript;version=1.8',
-      script: function () {
-        test((function(){
-          try {
-            return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-          } catch (e) {
-            return false;
-          }
-        })());
-        __script_executed = true;
-      }
-    },
-    {
-      script: function () {
-        if (!__script_executed) {
-          test(false);
-          __script_executed = false;
-        }
-      }
-    }
-  ],
-  res: {
-    ie7: false,
-    ie8: false,
-    ie9: false,
-    ie10: false,
-    ie11: false,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: false,
-    safari4: false,
-    safari5: false,
-    safari7: false,
-    webkit: false,
-    chrome7: false,
-    opera10_10: false,
-    opera10_50: false,
-    opera15: false,
-    konq44: false,
-    konq49: false,
-    besen: false,
-    rhino: false,
-    phantom: false
-  }
-},
-{
   name: 'Array generics',
   exec: function () {
     return typeof Array.slice === 'function' && Array.slice('123').length === 3;
@@ -925,49 +702,6 @@ exports.tests = [
     phantom: false
   },
   separator: 'after'
-},
-{
-  name: 'RegExp "y" flag',
-  exec: function () {
-    try {
-      var re = new RegExp('\\w');
-      var re2 = new RegExp('\\w', 'y');
-      re.exec('xy');
-      re2.exec('xy');
-      return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-    } catch (e) {
-      return false;
-    }
-  },
-  res: {
-    ie7: false,
-    ie8: false,
-    ie9: false,
-    ie10: false,
-    ie11: false,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: false,
-    safari4: false,
-    safari5: false,
-    safari7: false,
-    webkit: false,
-    chrome7: false,
-    opera10_10: true,
-    opera10_50: false,
-    opera15: false,
-    konq44: false,
-    konq49: false,
-    besen: false,
-    rhino: false,
-    phantom: false
-  }
 },
 {
   name: 'RegExp "x" flag',
@@ -1166,39 +900,6 @@ exports.tests = [
   separator: 'after'
 },
 {
-  name: 'String.prototype.substr',
-  exec: function () { return typeof String.prototype.substr === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
-},
-{
   name: 'String.prototype.trimLeft',
   exec: function () { return typeof String.prototype.trimLeft === 'function' },
   res: {
@@ -1261,171 +962,6 @@ exports.tests = [
     konq49: true,
     besen: false,
     rhino: false,
-    phantom: true
-  }
-},
-{
-  name: 'String.prototype.anchor',
-  exec: function () { return typeof String.prototype.anchor === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
-},
-{
-  name: 'String.prototype.big',
-  exec: function () { return typeof String.prototype.big === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
-},
-{
-  name: 'String.prototype.blink',
-  exec: function () { return typeof String.prototype.blink === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
-},
-{
-  name: 'String.prototype.bold',
-  exec: function () { return typeof String.prototype.bold === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
-  }
-},
-{
-  name: 'String.prototype.link',
-  exec: function () { return typeof String.prototype.link === 'function' },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
     phantom: true
   }
 },
@@ -1593,46 +1129,6 @@ exports.tests = [
     besen: true,
     rhino: false,
     phantom: false
-  },
-  separator: 'after'
-},
-{
-  name: 'Octal literals',
-  exec: function () {
-    try {
-      return eval('070 === 56');
-    } catch (e) {
-      return false;
-    }
-  },
-  res: {
-    ie7: true,
-    ie8: true,
-    ie9: true,
-    ie10: true,
-    ie11: true,
-    firefox3: true,
-    firefox3_5: true,
-    firefox4: true,
-    firefox5: true,
-    firefox6: true,
-    firefox7: true,
-    firefox12: true,
-    firefox28: true,
-    safari3: true,
-    safari4: true,
-    safari5: true,
-    safari7: true,
-    webkit: true,
-    chrome7: true,
-    opera10_10: true,
-    opera10_50: true,
-    opera15: true,
-    konq44: true,
-    konq49: true,
-    besen: true,
-    rhino: true,
-    phantom: true
   },
   separator: 'after'
 },

--- a/es6/index.html
+++ b/es6/index.html
@@ -1699,6 +1699,62 @@ test(function () {
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
+          <td id="Hoisted_block-level_function_declaration"><span><a class="anchor" href="#Hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">Hoisted block-level function declaration</a></span></td>
+<script>
+test(function () {
+  // Note: only available outside of strict mode.
+  try {
+    return !!Function(
+       'var passed = f() === 2 && g() === 4;'
+      +'if (true) { function f(){ return 1; } } else { function f(){ return 2; } }'
+      +'if (false){ function g(){ return 3; } } else { function g(){ return 4; } }'
+      +'return passed;'
+    )();
+  } catch (e) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td class="no rhino17">No</td>
+          <td class="yes phantom">Yes</td>
+          <td class="yes node">Yes</td>
+          <td class="yes nodeharmony">Yes</td>
+        </tr>
+        <tr>
           <td id="Destructuring"><span><a class="anchor" href="#Destructuring">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:destructuring">Destructuring</a></span></td>
 <script>
 test(function () {

--- a/es6/index.html
+++ b/es6/index.html
@@ -2144,6 +2144,50 @@ test(typeof Object.setPrototypeOf === 'function');
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
+          <td id="function_name_property"><span><a class="anchor" href="#function_name_property">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function "name" property</a></span></td>
+<script>
+test((function foo(){}).name == 'foo');
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="yes firefox11 obsolete">Yes</td>
+          <td class="yes firefox13 obsolete">Yes</td>
+          <td class="yes firefox16 obsolete">Yes</td>
+          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td class="yes rhino17">Yes</td>
+          <td class="yes phantom">Yes</td>
+          <td class="yes node">Yes</td>
+          <td class="yes nodeharmony">Yes</td>
+        </tr>
+        <tr>
           <td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span></td>
 <script>
 test(function f() {

--- a/es6/index.html
+++ b/es6/index.html
@@ -1699,62 +1699,6 @@ test(function () {
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
-          <td id="Hoisted_block-level_function_declaration"><span><a class="anchor" href="#Hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">Hoisted block-level function declaration</a></span></td>
-<script>
-test(function () {
-  // Note: only available outside of strict mode.
-  try {
-    return !!Function(
-       'var passed = f() === 2 && g() === 4;'
-      +'if (true) { function f(){ return 1; } } else { function f(){ return 2; } }'
-      +'if (false){ function g(){ return 3; } } else { function g(){ return 4; } }'
-      +'return passed;'
-    )();
-  } catch (e) {
-    return false;
-  }
-}());
-</script>
-
-          <td class="no tr">No</td>
-          <td class="no ejs">No</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35">Yes</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes konq49">Yes</td>
-          <td class="no rhino17">No</td>
-          <td class="yes phantom">Yes</td>
-          <td class="yes node">Yes</td>
-          <td class="yes nodeharmony">Yes</td>
-        </tr>
-        <tr>
           <td id="Destructuring"><span><a class="anchor" href="#Destructuring">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:destructuring">Destructuring</a></span></td>
 <script>
 test(function () {
@@ -4905,6 +4849,62 @@ test(function () {
           <td class="yes opera">Yes</td>
           <td class="yes konq49">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>
+        </tr>
+        <tr>
+          <td id="Hoisted_block-level_function_declaration"><span><a class="anchor" href="#Hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">Hoisted block-level function declaration</a></span></td>
+<script>
+test(function () {
+  // Note: only available outside of strict mode.
+  try {
+    return !!Function(
+       'var passed = f() === 2 && g() === 4;'
+      +'if (true) { function f(){ return 1; } } else { function f(){ return 2; } }'
+      +'if (false){ function g(){ return 3; } } else { function g(){ return 4; } }'
+      +'return passed;'
+    )();
+  } catch (e) {
+    return false;
+  }
+}());
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="yes chrome obsolete">Yes</td>
+          <td class="yes chrome19dev obsolete">Yes</td>
+          <td class="yes chrome21dev obsolete">Yes</td>
+          <td class="yes chrome30 obsolete">Yes</td>
+          <td class="yes chrome33 obsolete">Yes</td>
+          <td class="yes chrome34 obsolete">Yes</td>
+          <td class="yes chrome35">Yes</td>
+          <td class="yes chrome37">Yes</td>
+          <td class="yes safari51 obsolete">Yes</td>
+          <td class="yes safari6">Yes</td>
+          <td class="yes safari7">Yes</td>
+          <td class="yes webkit">Yes</td>
+          <td class="yes opera">Yes</td>
+          <td class="yes konq49">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable rhino17">No</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable phantom">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable node">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable nodeharmony">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>ECMAScript 5 extensions compatibility table</title>
+    <title>ECMAScript extensions compatibility table</title>
 
     <link rel="stylesheet" href="../master.css">
 
@@ -101,50 +101,6 @@
         </thead>
         <tbody>
           <tr>
-            <td id="function_statement"><span><a class="anchor" href="#function_statement">&sect;</a><a href="http://kangax.github.com/nfe/#function-statements">function statement</a></span></td>
-<script>
-test(function () {
-  try {
-    eval('if (1) { function f(){ } } else { function f(){ } }');
-    return typeof f === 'function';
-  } catch (e) {
-    return false;
-  }
-}());
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes<a href="#function-statements-strict-mode-firefox-note"><sup>[1]</sup></a></td>
-            <td class="yes firefox5 obsolete">Yes<a href="#function-statements-strict-mode-firefox-note"><sup>[1]</sup></a></td>
-            <td class="yes firefox6 obsolete">Yes<a href="#function-statements-strict-mode-firefox-note"><sup>[1]</sup></a></td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes<a href="#besen-extensions-note"><sup>[2]</sup></a></td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="30" class="separator"></th>
-          </tr>
-          <tr>
             <td id="uneval"><span><a class="anchor" href="#uneval">&sect;</a>uneval</span></td>
 <script>
 test(typeof uneval == 'function');
@@ -214,40 +170,6 @@ test('toSource' in (function (){}) && 'toSource' in ({}));
           </tr>
           <tr>
             <th colspan="30" class="separator"></th>
-          </tr>
-          <tr>
-            <td id="function_name_property"><span><a class="anchor" href="#function_name_property">&sect;</a>function "name" property</span></td>
-<script>
-test((function foo(){}).name == 'foo');
-</script>
-
-            <td class="no ie7 obsolete">No</td>
-            <td class="no ie8 obsolete">No</td>
-            <td class="no ie9">No</td>
-            <td class="no ie10">No</td>
-            <td class="no ie11">No</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="no safari3 obsolete">No</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="no opera10_10 obsolete">No</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
           </tr>
           <tr>
             <td id="function_caller_property"><span><a class="anchor" href="#function_caller_property">&sect;</a>function "caller" property</span></td>
@@ -394,41 +316,6 @@ test(typeof Function.prototype.isGenerator == 'function');
           </tr>
           <tr>
             <th colspan="30" class="separator"></th>
-          </tr>
-          <tr>
-            <td id="__proto__"><span><a class="anchor" href="#__proto__">&sect;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/proto">__proto__</a></span></td>
-<script>
-test(({}).__proto__ === Object.prototype &&
-    [].__proto__ === Array.prototype);
-</script>
-
-            <td class="no ie7 obsolete">No</td>
-            <td class="no ie8 obsolete">No</td>
-            <td class="no ie9">No</td>
-            <td class="no ie10">No</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="no opera10_10 obsolete">No</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
           </tr>
           <tr>
             <td id="__count__"><span><a class="anchor" href="#__count__">&sect;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span></td>
@@ -612,94 +499,6 @@ test('__defineSetter__' in ({ }));
             <th colspan="30" class="separator"></th>
           </tr>
           <tr>
-            <td id="const"><span><a class="anchor" href="#const">&sect;</a>const</span></td>
-<script>
-test(function () {
-  try {
-    eval('const foobarbaz = 12');
-    return typeof foobarbaz === 'number';
-  } catch (e) {
-    return false;
-  }
-}());
-</script>
-
-            <td class="no ie7 obsolete">No</td>
-            <td class="no ie8 obsolete">No</td>
-            <td class="no ie9">No</td>
-            <td class="no ie10">No</td>
-            <td class="no ie11">No</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="no konq44 obsolete">No</td>
-            <td class="no konq49">No</td>
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="let"><span><a class="anchor" href="#let">&sect;</a>let</span></td>
-<script type="application/javascript;version=1.8">
-test((function(){
-  try {
-    return eval('(function(){ let foobarbaz2 = 123; return foobarbaz2 == 123; })()');
-  } catch (e) {
-    return false;
-  }
-})());
-__script_executed = true;
-</script>
-<script>
-if (!__script_executed) {
-  test(false);
-  __script_executed = false;
-}
-</script>
-
-            <td class="no ie7 obsolete">No</td>
-            <td class="no ie8 obsolete">No</td>
-            <td class="no ie9">No</td>
-            <td class="no ie10">No</td>
-            <td class="no ie11">No</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="no safari3 obsolete">No</td>
-            <td class="no safari4 obsolete">No</td>
-            <td class="no safari5 obsolete">No</td>
-            <td class="no safari7">No</td>
-            <td class="no webkit">No</td>
-            <td class="no chrome7 obsolete">No</td>
-            <td class="no opera10_10 obsolete">No</td>
-            <td class="no opera10_50 obsolete">No</td>
-            <td class="no opera15">No</td>
-            <td class="no konq44 obsolete">No</td>
-            <td class="no konq49">No</td>
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-            <td class="no phantom">No</td>
-          </tr>
-          <tr>
             <td id="Array_generics"><span><a class="anchor" href="#Array_generics">&sect;</a>Array generics</span></td>
 <script>
 test(typeof Array.slice === 'function' && Array.slice('123').length === 3);
@@ -855,50 +654,6 @@ test(function () {
           </tr>
           <tr>
             <th colspan="30" class="separator"></th>
-          </tr>
-          <tr>
-            <td id="RegExp_y_flag"><span><a class="anchor" href="#RegExp_y_flag">&sect;</a>RegExp "y" flag</span></td>
-<script>
-test(function () {
-  try {
-    var re = new RegExp('\\w');
-    var re2 = new RegExp('\\w', 'y');
-    re.exec('xy');
-    re2.exec('xy');
-    return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-  } catch (e) {
-    return false;
-  }
-}());
-</script>
-
-            <td class="no ie7 obsolete">No</td>
-            <td class="no ie8 obsolete">No</td>
-            <td class="no ie9">No</td>
-            <td class="no ie10">No</td>
-            <td class="no ie11">No</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="no safari3 obsolete">No</td>
-            <td class="no safari4 obsolete">No</td>
-            <td class="no safari5 obsolete">No</td>
-            <td class="no safari7">No</td>
-            <td class="no webkit">No</td>
-            <td class="no chrome7 obsolete">No</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="no opera10_50 obsolete">No</td>
-            <td class="no opera15">No</td>
-            <td class="no konq44 obsolete">No</td>
-            <td class="no konq49">No</td>
-            <td class="no besen">No</td>
-            <td class="no rhino">No</td>
-            <td class="no phantom">No</td>
           </tr>
           <tr>
             <td id="RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&sect;</a>RegExp "x" flag</span></td>
@@ -1104,40 +859,6 @@ test(function () {
             <th colspan="30" class="separator"></th>
           </tr>
           <tr>
-            <td id="String.prototype.substr"><span><a class="anchor" href="#String.prototype.substr">&sect;</a>String.prototype.substr</span></td>
-<script>
-test(typeof String.prototype.substr === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
             <td id="String.prototype.trimLeft"><span><a class="anchor" href="#String.prototype.trimLeft">&sect;</a>String.prototype.trimLeft</span></td>
 <script>
 test(typeof String.prototype.trimLeft === 'function');
@@ -1203,176 +924,6 @@ test(typeof String.prototype.trimRight === 'function');
             <td class="yes konq49">Yes</td>
             <td class="no besen">No</td>
             <td class="no rhino">No</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="String.prototype.anchor"><span><a class="anchor" href="#String.prototype.anchor">&sect;</a>String.prototype.anchor</span></td>
-<script>
-test(typeof String.prototype.anchor === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="String.prototype.big"><span><a class="anchor" href="#String.prototype.big">&sect;</a>String.prototype.big</span></td>
-<script>
-test(typeof String.prototype.big === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="String.prototype.blink"><span><a class="anchor" href="#String.prototype.blink">&sect;</a>String.prototype.blink</span></td>
-<script>
-test(typeof String.prototype.blink === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="String.prototype.bold"><span><a class="anchor" href="#String.prototype.bold">&sect;</a>String.prototype.bold</span></td>
-<script>
-test(typeof String.prototype.bold === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <td id="String.prototype.link"><span><a class="anchor" href="#String.prototype.link">&sect;</a>String.prototype.link</span></td>
-<script>
-test(typeof String.prototype.link === 'function');
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
           </tr>
           <tr>
@@ -1552,49 +1103,6 @@ test(typeof Object.prototype.eval == 'function');
             <th colspan="30" class="separator"></th>
           </tr>
           <tr>
-            <td id="Octal_literals"><span><a class="anchor" href="#Octal_literals">&sect;</a>Octal literals</span></td>
-<script>
-test(function () {
-  try {
-    return eval('070 === 56');
-  } catch (e) {
-    return false;
-  }
-}());
-</script>
-
-            <td class="yes ie7 obsolete">Yes</td>
-            <td class="yes ie8 obsolete">Yes</td>
-            <td class="yes ie9">Yes</td>
-            <td class="yes ie10">Yes</td>
-            <td class="yes ie11">Yes</td>
-            <td class="yes firefox3 obsolete">Yes</td>
-            <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4 obsolete">Yes</td>
-            <td class="yes firefox5 obsolete">Yes</td>
-            <td class="yes firefox6 obsolete">Yes</td>
-            <td class="yes firefox7 obsolete">Yes</td>
-            <td class="yes firefox12 obsolete">Yes</td>
-            <td class="yes firefox28">Yes</td>
-            <td class="yes safari3 obsolete">Yes</td>
-            <td class="yes safari4 obsolete">Yes</td>
-            <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari7">Yes</td>
-            <td class="yes webkit">Yes</td>
-            <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes opera10_10 obsolete">Yes</td>
-            <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera15">Yes</td>
-            <td class="yes konq44 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
-            <td class="yes besen">Yes</td>
-            <td class="yes rhino">Yes</td>
-            <td class="yes phantom">Yes</td>
-          </tr>
-          <tr>
-            <th colspan="30" class="separator"></th>
-          </tr>
-          <tr>
             <td id="error_stack"><span><a class="anchor" href="#error_stack">&sect;</a>error "stack"</span></td>
 <script>
 test('stack' in new Error);
@@ -1737,12 +1245,7 @@ test('description' in new Error);
       </table>
     </div>
     <div id="footnotes">
-      <p id="function-statements-strict-mode-firefox-note">
-        <sup>[1]</sup> From Firefox 4 on, function statements in strict mode functions are only accepted at top level or immediately within another function.
-      </p>
-      <p id="besen-extensions-note">
-        <sup>[2]</sup> With 'Javascript-specific extensions' option enabled
-      </p>
+      
     </div>
   </body>
 </html>

--- a/non-standard/skeleton.html
+++ b/non-standard/skeleton.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>ECMAScript 5 extensions compatibility table</title>
+    <title>ECMAScript extensions compatibility table</title>
 
     <link rel="stylesheet" href="../master.css">
 


### PR DESCRIPTION
This removes the following items from the non-standard table which are
now in ECMAScript 6:
- function statement
- function "name" property (this has been added to the ES6 table)
- `__proto__`
- const, let
- RegExp "y" flag
- most of the String HTML methods
- String#substr
- octal

Closes #150.
