### PR TITLE
Tightened the arrow function tests, version 2

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -281,28 +281,27 @@ exports.tests = [
 {
   name: 'arrow functions',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
-  exec: function() {
-    try {
-      return !!Function(
-         // 0 parameters
-         'var a = () => 5;'
-        +'var passed = (a() === 5);'
-
-         // 1 parameter, no brackets
-        +'var b = x => x + "foo";'
-        +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
-
-         // multiple parameters
-        +'var c = (v, w, x, y, z) => v+w-x*y/z;'
-        +'passed &= (c(6, 5, 4, 3, 2) === 5);'
-        
-        +'return passed;'
-      )();
-    } catch (e) {
-      return false;
-    }
-    return true;
-  },
+  exec: function() {/*
+    // 0 parameters
+    var passed = (() => 5)() === 5;
+    
+    // 1 parameter, no brackets
+    var b = x => x + "foo";
+    passed &= (b("fee fie foe ") === "fee fie foe foo");
+    
+    // multiple parameters
+    var c = (v, w, x, y, z) => "" + v + w + x + y + z;
+    passed &= (c(6, 5, 4, 3, 2) === "65432");
+    
+    // arrows have a lexical "this" binding (14.2.17)
+    var d = { x : "bar", y : function() { return z => this.x + z; }}.y();
+    var e = { x : "baz", y : d };
+    passed &= d("ley") === "barley" && e.y("ley") === "barley";
+    
+    // arrows cannot be re-bound, but they can still be curried.
+    passed &= d.bind(e, "ley")() === "barley";
+    return passed;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -313,17 +312,21 @@ exports.tests = [
     firefox16:   false,
     firefox17:   false,
     firefox18:   false,
-    firefox23:   true,
-    firefox24:   true,
-    firefox25:   true,
-    firefox27:   true,
-    firefox28:   true,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
-    firefox34:   true,
+    firefox23:   {
+      val: true,
+      note_id: 'fx-arrow',
+      note_html: 'Firefox\'s arrows do not lexically bind <code>arguments</code>, and incorrectly allow line breaks between the arrow\'s parameters and the <code>=></code> token.'
+    },
+    firefox24:   { val: true, note_id: 'fx-arrow' },
+    firefox25:   { val: true, note_id: 'fx-arrow' },
+    firefox27:   { val: true, note_id: 'fx-arrow' },
+    firefox28:   { val: true, note_id: 'fx-arrow' },
+    firefox29:   { val: true, note_id: 'fx-arrow' },
+    firefox30:   { val: true, note_id: 'fx-arrow' },
+    firefox31:   { val: true, note_id: 'fx-arrow' },
+    firefox32:   { val: true, note_id: 'fx-arrow' },
+    firefox33:   { val: true, note_id: 'fx-arrow' },
+    firefox34:   { val: true, note_id: 'fx-arrow' },
     chrome:      false,
     chrome19dev: false,
     chrome21dev: false,
@@ -331,8 +334,8 @@ exports.tests = [
     chrome33:    false,
     chrome34:    false,
     chrome35:    false,
-    chrome37:    true,
-    chrome39:    true,
+    chrome37:    false,
+    chrome39:    false,
     safari51:    false,
     safari6:     false,
     safari7:     false,
@@ -345,68 +348,6 @@ exports.tests = [
     nodeharmony: false,
     ios7:        false,
     ios8:        false
-  }
-},
-{
-  name: 'lexical "this" in arrow functions',
-  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
-  exec: function() {
-    try {
-      return !!Function(
-         // arrows have a lexical "this" binding (14.2.17)
-         'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
-        +'var e = { x : "baz", y : d };'
-        +'var passed = d("ley") === "barley" && e.y("ley") === "barley";'
-
-         // arrows' lexical "this" cannot be re-bound,
-         // but they can still be curried.
-        +'passed &= d.bind(e, "ley")("man") === "barley";'
-        +'return passed;'
-      )();
-    } catch (e) {
-      return false;
-    }
-    return true;
-  },
-  res: {
-    tr:          true,
-    ejs:         true,
-    ie10:        false,
-    ie11:        false,
-    firefox11:   false,
-    firefox13:   false,
-    firefox16:   false,
-    firefox17:   false,
-    firefox18:   false,
-    firefox23:   true,
-    firefox24:   true,
-    firefox25:   true,
-    firefox27:   true,
-    firefox28:   true,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
-    firefox34:   true,
-    chrome:      false,
-    chrome19dev: false,
-    chrome21dev: false,
-    chrome30:    false,
-    chrome33:    false,
-    chrome34:    false,
-    chrome35:    false,
-    chrome37:    false,
-    safari51:    false,
-    safari6:     false,
-    safari7:     false,
-    webkit:      false,
-    opera:       false,
-    konq49:      false,
-    rhino17:     false,
-    phantom:     false,
-    node:        false,
-    nodeharmony: false
   }
 },
 {

--- a/data-es6.js
+++ b/data-es6.js
@@ -280,10 +280,24 @@ exports.tests = [
 },
 {
   name: 'arrow functions',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
   exec: function() {
     try {
-      eval('var a = () => 5;');
+      return !!Function(
+         // 0 parameters
+         'var a = () => 5;'
+        +'var passed = (a() === 5);'
+
+         // 1 parameter, no brackets
+        +'var b = x => x + "foo";'
+        +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
+
+         // multiple parameters
+        +'var c = (v, w, x, y, z) => v+w-x*y/z;'
+        +'passed &= (c(6, 5, 4, 3, 2) === 5);'
+        
+        +'return passed;'
+      )();
     } catch (e) {
       return false;
     }
@@ -331,6 +345,68 @@ exports.tests = [
     nodeharmony: false,
     ios7:        false,
     ios8:        false
+  }
+},
+{
+  name: 'lexical "this" in arrow functions',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
+  exec: function() {
+    try {
+      return !!Function(
+         // arrows have a lexical "this" binding (14.2.17)
+         'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
+        +'var e = { x : "baz", y : d };'
+        +'var passed = d("ley") === "barley" && e.y("ley") === "barley";'
+
+         // arrows' lexical "this" cannot be re-bound,
+         // but they can still be curried.
+        +'passed &= d.bind(e, "ley")("man") === "barley";'
+        +'return passed;'
+      )();
+    } catch (e) {
+      return false;
+    }
+    return true;
+  },
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false
   }
 },
 {

--- a/es6/index.html
+++ b/es6/index.html
@@ -169,10 +169,24 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax">arrow functions</a></span></td>
+          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 <script data-source="function () {
 try {
-  eval('var a = () => 5;');
+  return !!Function(
+     // 0 parameters
+     'var a = () => 5;'
+    +'var passed = (a() === 5);'
+
+     // 1 parameter, no brackets
+    +'var b = x => x + &quot;foo&quot;;'
+    +'passed &= (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);'
+
+     // multiple parameters
+    +'var c = (v, w, x, y, z) => v+w-x*y/z;'
+    +'passed &= (c(6, 5, 4, 3, 2) === 5);'
+    
+    +'return passed;'
+  )();
 } catch (e) {
   return false;
 }
@@ -180,7 +194,21 @@ return true;
   }">test(
 function () {
 try {
-  eval('var a = () => 5;');
+  return !!Function(
+     // 0 parameters
+     'var a = () => 5;'
+    +'var passed = (a() === 5);'
+
+     // 1 parameter, no brackets
+    +'var b = x => x + "foo";'
+    +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
+
+     // multiple parameters
+    +'var c = (v, w, x, y, z) => v+w-x*y/z;'
+    +'passed &= (c(6, 5, 4, 3, 2) === 5);'
+    
+    +'return passed;'
+  )();
 } catch (e) {
   return false;
 }
@@ -227,6 +255,83 @@ return true;
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="lexical_this_in_arrow_functions"><span><a class="anchor" href="#lexical_this_in_arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">lexical "this" in arrow functions</a></span></td>
+<script data-source="function () {
+try {
+  return !!Function(
+     // arrows have a lexical &quot;this&quot; binding (14.2.17)
+     'var d = { x : &quot;bar&quot;, y : function() { return z => this.x + z; }}.y();'
+    +'var e = { x : &quot;baz&quot;, y : d };'
+    +'var passed = d(&quot;ley&quot;) === &quot;barley&quot; && e.y(&quot;ley&quot;) === &quot;barley&quot;;'
+
+     // arrows' lexical &quot;this&quot; cannot be re-bound,
+     // but they can still be curried.
+    +'passed &= d.bind(e, &quot;ley&quot;)(&quot;man&quot;) === &quot;barley&quot;;'
+    +'return passed;'
+  )();
+} catch (e) {
+  return false;
+}
+return true;
+  }">test(
+function () {
+try {
+  return !!Function(
+     // arrows have a lexical "this" binding (14.2.17)
+     'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
+    +'var e = { x : "baz", y : d };'
+    +'var passed = d("ley") === "barley" && e.y("ley") === "barley";'
+
+     // arrows' lexical "this" cannot be re-bound,
+     // but they can still be curried.
+    +'passed &= d.bind(e, "ley")("man") === "barley";'
+    +'return passed;'
+  )();
+} catch (e) {
+  return false;
+}
+return true;
+  }())</script>
+
+          <td class="yes tr">Yes</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
         </tr>
         <tr>
           <td id="const"><span><a class="anchor" href="#const">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:const">const</a></span></td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -170,50 +170,29 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
         </tr>
         <tr>
           <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
-<script data-source="function () {
-try {
-  return !!Function(
-     // 0 parameters
-     'var a = () => 5;'
-    +'var passed = (a() === 5);'
+<script data-source="
+// 0 parameters
+var passed = (() => 5)() === 5;
 
-     // 1 parameter, no brackets
-    +'var b = x => x + &quot;foo&quot;;'
-    +'passed &= (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);'
+// 1 parameter, no brackets
+var b = x => x + &quot;foo&quot;;
+passed &= (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 
-     // multiple parameters
-    +'var c = (v, w, x, y, z) => v+w-x*y/z;'
-    +'passed &= (c(6, 5, 4, 3, 2) === 5);'
-    
-    +'return passed;'
-  )();
-} catch (e) {
-  return false;
-}
-return true;
-  }">test(
-function () {
-try {
-  return !!Function(
-     // 0 parameters
-     'var a = () => 5;'
-    +'var passed = (a() === 5);'
+// multiple parameters
+var c = (v, w, x, y, z) => &quot;&quot; + v + w + x + y + z;
+passed &= (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 
-     // 1 parameter, no brackets
-    +'var b = x => x + "foo";'
-    +'passed &= (b("fee fie foe ") === "fee fie foe foo");'
+// arrows have a lexical &quot;this&quot; binding (14.2.17)
+var d = { x : &quot;bar&quot;, y : function() { return z => this.x + z; }}.y();
+var e = { x : &quot;baz&quot;, y : d };
+passed &= d(&quot;ley&quot;) === &quot;barley&quot; && e.y(&quot;ley&quot;) === &quot;barley&quot;;
 
-     // multiple parameters
-    +'var c = (v, w, x, y, z) => v+w-x*y/z;'
-    +'passed &= (c(6, 5, 4, 3, 2) === 5);'
-    
-    +'return passed;'
-  )();
-} catch (e) {
-  return false;
-}
-return true;
-  }())</script>
+// arrows cannot be re-bound, but they can still be curried.
+passed &= d.bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
+return passed;
+  ">
+test(function(){try{return Function("\n// 0 parameters\nvar passed = (() => 5)() === 5;\n\n// 1 parameter, no brackets\nvar b = x => x + \"foo\";\npassed &= (b(\"fee fie foe \") === \"fee fie foe foo\");\n\n// multiple parameters\nvar c = (v, w, x, y, z) => \"\" + v + w + x + y + z;\npassed &= (c(6, 5, 4, 3, 2) === \"65432\");\n\n// arrows have a lexical \"this\" binding (14.2.17)\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }}.y();\nvar e = { x : \"baz\", y : d };\npassed &= d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n\n// arrows cannot be re-bound, but they can still be curried.\npassed &= d.bind(e, \"ley\")() === \"barley\";\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
@@ -224,16 +203,16 @@ return true;
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox24">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-arrow-note"><sup>[3]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -241,8 +220,8 @@ return true;
           <td class="no chrome33 obsolete">No</td>
           <td class="no chrome34 obsolete">No</td>
           <td class="no chrome35">No</td>
-          <td class="yes chrome37">Yes</td>
-          <td class="yes chrome39">Yes</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -255,83 +234,6 @@ return true;
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
-        </tr>
-        <tr>
-          <td id="lexical_this_in_arrow_functions"><span><a class="anchor" href="#lexical_this_in_arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">lexical "this" in arrow functions</a></span></td>
-<script data-source="function () {
-try {
-  return !!Function(
-     // arrows have a lexical &quot;this&quot; binding (14.2.17)
-     'var d = { x : &quot;bar&quot;, y : function() { return z => this.x + z; }}.y();'
-    +'var e = { x : &quot;baz&quot;, y : d };'
-    +'var passed = d(&quot;ley&quot;) === &quot;barley&quot; && e.y(&quot;ley&quot;) === &quot;barley&quot;;'
-
-     // arrows' lexical &quot;this&quot; cannot be re-bound,
-     // but they can still be curried.
-    +'passed &= d.bind(e, &quot;ley&quot;)(&quot;man&quot;) === &quot;barley&quot;;'
-    +'return passed;'
-  )();
-} catch (e) {
-  return false;
-}
-return true;
-  }">test(
-function () {
-try {
-  return !!Function(
-     // arrows have a lexical "this" binding (14.2.17)
-     'var d = { x : "bar", y : function() { return z => this.x + z; }}.y();'
-    +'var e = { x : "baz", y : d };'
-    +'var passed = d("ley") === "barley" && e.y("ley") === "barley";'
-
-     // arrows' lexical "this" cannot be re-bound,
-     // but they can still be curried.
-    +'passed &= d.bind(e, "ley")("man") === "barley";'
-    +'return passed;'
-  )();
-} catch (e) {
-  return false;
-}
-return true;
-  }())</script>
-
-          <td class="yes tr">Yes</td>
-          <td class="yes ejs">Yes</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30 obsolete">No</td>
-          <td class="no chrome33 obsolete">No</td>
-          <td class="no chrome34 obsolete">No</td>
-          <td class="no chrome35">No</td>
-          <td class="no chrome37">No</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no safari7">No</td>
-          <td class="no webkit">No</td>
-          <td class="no opera">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no phantom">No</td>
-          <td class="no node">No</td>
-          <td class="no nodeharmony">No</td>
         </tr>
         <tr>
           <td id="const"><span><a class="anchor" href="#const">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:const">const</a></span></td>
@@ -491,17 +393,17 @@ test(function(){try{return Function("\nvar passed = (function (a = 1, b = 2) { r
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox24">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox32">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox24">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-defaults-scope-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -685,7 +587,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-spreading-strings-note"><sup>[5]</sup></a></td>
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
@@ -1178,14 +1080,14 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n  ")()}
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
-          <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox32">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1227,14 +1129,14 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n  ")()}
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
-          <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox32">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#octal-to-string-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1504,8 +1406,8 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar pa
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
-          <td class="no ie10">No<a href="#ie-typedarray-note"><sup>[6]</sup></a></td>
-          <td class="no ie11">No<a href="#ie-typedarray-note"><sup>[6]</sup></a></td>
+          <td class="no ie10">No<a href="#ie-typedarray-note"><sup>[7]</sup></a></td>
+          <td class="no ie11">No<a href="#ie-typedarray-note"><sup>[7]</sup></a></td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -1621,7 +1523,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1639,23 +1541,23 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes firefox34">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome35">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome37">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome35">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome37">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="yes ios8">Yes</td>
         </tr>
@@ -1676,7 +1578,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1694,23 +1596,23 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes firefox34">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome35">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome37">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome35">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome37">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[8]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="yes ios8">Yes</td>
         </tr>
@@ -1730,41 +1632,41 @@ test(function(){try{return Function("\nvar key1 = {};\nvar weakmap = new WeakMap
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
-          <td class="yes firefox23 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox24">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox32">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox24">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome35">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome37">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome35">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome37">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes webkit">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="yes ios8">Yes</td>
         </tr>
@@ -1805,11 +1707,11 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
           <td class="no chrome30 obsolete">No</td>
-          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome35">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome37">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome35">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome37">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -1819,7 +1721,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[9]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -2036,7 +1938,7 @@ return true;
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[9]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[10]</sup></a></span></td>
 <script data-source="
 'use strict';
 {
@@ -4236,12 +4138,12 @@ return typeof Array.prototype.values === 'function';
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[10]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[11]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[12]</sup></a></td>
           <td class="no firefox29 obsolete">No</td>
           <td class="no firefox30 obsolete">No</td>
           <td class="no firefox31">No</td>
@@ -4804,7 +4706,7 @@ return typeof Math.imul === 'function';
           <td class="yes firefox34">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[12]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[13]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
           <td class="yes chrome34 obsolete">Yes</td>
@@ -5495,7 +5397,7 @@ return typeof Math.fround === 'function';
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[13]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[14]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
@@ -5578,7 +5480,7 @@ return typeof Math.cbrt === 'function';
           <th colspan="43" class="separator"></th>
         </tr>
         <tr>
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[14]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[15]</sup></a></span></td>
 <script data-source="function () {
 var passed = { __proto__ : [] } instanceof Array
   && !({ __proto__ : null } instanceof Object);
@@ -5623,8 +5525,8 @@ return passed;
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes<a href="#fx-proto-shorthand-note"><sup>[15]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proto-shorthand-note"><sup>[15]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proto-shorthand-note"><sup>[16]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proto-shorthand-note"><sup>[16]</sup></a></td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -5648,7 +5550,7 @@ return passed;
           <td class="yes ios8">Yes</td>
         </tr>
         <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[16]</sup></a></span></td>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[17]</sup></a></span></td>
 <script data-source="
 // Note: only available outside of strict mode.
 var passed = f() === 2 && g() === 4;
@@ -5889,47 +5791,50 @@ return typeof RegExp.prototype.compile === 'function';
       <p id="harmony-flag-note">
         <sup>[2]</sup> Have to be enabled via --harmony flag
       </p>
+      <p id="fx-arrow-note">
+        <sup>[3]</sup> Firefox's arrows do not lexically bind <code>arguments</code>, and incorrectly allow line breaks between the arrow's parameters and the <code>=></code> token.
+      </p>
       <p id="fx-defaults-scope-note">
-        <sup>[3]</sup> In Firefox, defaults can incorrectly refer to later parameters (<code>a=b, b</code>), themselves (<code>a=a</code>), and/or identifiers in the function body (<code>function(a=function(){ return b; }){ var b=true; ... }</code>)
+        <sup>[4]</sup> In Firefox, defaults can incorrectly refer to later parameters (<code>a=b, b</code>), themselves (<code>a=a</code>), and/or identifiers in the function body (<code>function(a=function(){ return b; }){ var b=true; ... }</code>)
       </p>
       <p id="fx-spreading-strings-note">
-        <sup>[4]</sup> Spreading strings in array literals, but not in calls, is supported from Firefox 16 up.
+        <sup>[5]</sup> Spreading strings in array literals, but not in calls, is supported from Firefox 16 up.
       </p>
       <p id="octal-to-string-note">
-        <sup>[5]</sup> Firefox doesn't support <code>Number("0o1")</code> and <code>Number("0b1")</code> evaluating to 1 instead of NaN.
+        <sup>[6]</sup> Firefox doesn't support <code>Number("0o1")</code> and <code>Number("0b1")</code> evaluating to 1 instead of NaN.
       </p>
       <p id="ie-typedarray-note">
-        <sup>[6]</sup> Internet Explorer supports every typed array class except <code>Uint8ClampedArray</code>.
+        <sup>[7]</sup> Internet Explorer supports every typed array class except <code>Uint8ClampedArray</code>.
       </p>
       <p id="map-constructor-note">
-        <sup>[7]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.
+        <sup>[8]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.
       </p>
       <p id="weakmap-constructor-note">
-        <sup>[8]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
+        <sup>[9]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
       </p>
       <p id="block-level-function-note">
-        <sup>[9]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[10]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[10]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[11]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[11]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[12]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[12]</sup> Available since Chrome 28
+        <sup>[13]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[13]</sup> Available since Firefox 26
+        <sup>[14]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[14]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[15]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
       <p id="fx-proto-shorthand-note">
-        <sup>[15]</sup> Firefox 33+ incorrectly regards both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
+        <sup>[16]</sup> Firefox 33+ incorrectly regards both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
       </p>
       <p id="hoisted-block-level-function-note">
-        <sup>[16]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
+        <sup>[17]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This is an alternative approach to #168. The discussion for that PR emphasised that the tightened test, while more thorough, was worrisomely monolithic and tended to obscure partial functionality. So, this PR simply does the following:
- Adds just the parameter checks to the basic "arrow functions" test
- Adds a separate test, "lexical "this" in arrow functions", which checks that arrows have a bound `this` that can't be re-bound. (Chrome 37 fails this test)

Unlike #168, this does not include the following "pedantic" checks, which, while important for conformance, are less important for the syntax's general day-to-day usage:
- Lexical `arguments`
- No line terminator between parameters and `=>`
- Absence of `prototype` property (throws on `new`), and empty `name` property

In the future, if/when tests can be formally divided into multiple checks, then these separate tests could be combined.
