### PR TITLE
Updated the default parameters test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -430,11 +430,18 @@ exports.tests = [
   }
 },
 {
-  name: 'default function params',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values',
+  name: 'default function parameters',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
   exec: function () {
     try {
-      return eval('(function (a = 5) { return a === 5; }())');
+      return !!Function(
+         'var passed = (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));'
+         // explicit undefined will defer to the default
+        +'passed    &= (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));'
+         // defaults can refer to previous parameters
+        +'passed    &= (function (a, b = a) { return b === 5; }(5));'
+        +'return passed;'
+        )();
     } catch (e) {
       return false;
     }
@@ -446,8 +453,8 @@ exports.tests = [
     ie11:        false,
     firefox11:   false,
     firefox13:   false,
-    firefox16:   true,
-    firefox17:   true,
+    firefox16:   false,
+    firefox17:   false,
     firefox18:   true,
     firefox23:   true,
     firefox24:   true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -324,11 +324,18 @@ if (!global.__let_script_executed) {
           <td class="yes nodeharmony">Yes</td>
         </tr>
         <tr>
-          <td id="default_function_params"><span><a class="anchor" href="#default_function_params">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values">default function params</a></span></td>
+          <td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 <script>
 test(function () {
   try {
-    return eval('(function (a = 5) { return a === 5; }())');
+    return !!Function(
+       'var passed = (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));'
+       // explicit undefined will defer to the default
+      +'passed    &= (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));'
+       // defaults can refer to previous parameters
+      +'passed    &= (function (a, b = a) { return b === 5; }(5));'
+      +'return passed;'
+      )();
   } catch (e) {
     return false;
   }
@@ -341,8 +348,8 @@ test(function () {
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
-          <td class="yes firefox16 obsolete">Yes</td>
-          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
           <td class="yes firefox24">Yes</td>


### PR DESCRIPTION
Added the following checks:
- Explicitly passing undefined defers to the default
- Later defaults may reference values of earlier parameters

This doesn't add the following "pedantic" checks:
- Earlier defaults may not reference values of later parameters
- Defaults may use the arguments object.
- Defaults affect the function length property.
