### PR TITLE
Added Konqueror 4.13 to ES5, plus minor changes

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -60,7 +60,7 @@ exports.browsers = {
   safari51: {
     full: 'Safari 5.1',
     short: 'SF 5.1',
-    obsolete: false
+    obsolete: true
   },
   safari6: {
     full: 'Safari 6.0, Safari 7.0',
@@ -91,11 +91,11 @@ exports.browsers = {
   chrome13: {
     full: 'Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)',
     short: 'CH 13-16',
-    obsolete: false
+    obsolete: true
   },
   chrome19: {
-    full: 'Chrome 19 (19.0.1084.56 stable)',
-    short: 'CH 19+',
+    full: 'Chrome 19 (19.0.1084.56 stable), Opera 15+',
+    short: 'CH 19+, OP 15+',
     obsolete: false
   },
 
@@ -112,11 +112,11 @@ exports.browsers = {
   opera12: {
     full: 'Opera 12 (build 1065)',
     short: 'OP 12',
-    obsolete: false
+    obsolete: true
   },
   opera12_10: {
-    full: 'Opera 12.10 (build 1652), Opera 15.0',
-    short: 'OP 12.10, 15',
+    full: 'Opera 12.15',
+    short: 'OP 12.10',
     obsolete: false
   },
 
@@ -128,6 +128,11 @@ exports.browsers = {
   konq49: {
     full: 'Konqueror 4.9',
     short: 'Konq 4.9',
+    obsolete: true
+  },
+  konq413: {
+    full: 'Konqueror 4.13',
+    short: 'Konq 4.13',
     obsolete: false
   },
 
@@ -193,6 +198,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -225,14 +231,11 @@ exports.tests = [
     safari5: {
       val: true,
       note_id: 'define-property-webkit',
-      note_html: 'In some versions of WebKit <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.'
+      note_html: 'In some versions of Safari 5, <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.'
     },
     safari51: true,
     safari6: true,
-    webkit: {
-      val: true,
-      note_id: 'define-property-webkit'
-    },
+    webkit: true,
 
     chrome5: true,
     chrome6: true,
@@ -247,6 +250,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -289,6 +293,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -331,6 +336,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -373,6 +379,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -415,6 +422,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -457,6 +465,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -499,6 +508,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -541,6 +551,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -583,6 +594,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -625,6 +637,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -672,6 +685,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -714,6 +728,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -757,6 +772,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -799,6 +815,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -841,6 +858,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -883,6 +901,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -929,6 +948,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -971,6 +991,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1014,6 +1035,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1056,6 +1078,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1098,6 +1121,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1140,6 +1164,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1182,6 +1207,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1224,6 +1250,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1266,6 +1293,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1308,6 +1336,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1350,6 +1379,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1397,6 +1427,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1445,6 +1476,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1455,8 +1487,6 @@ exports.tests = [
 },
 {
   name: 'Property access on strings',
-  note_id: 'property-access-on-strings',
-  note_html: 'For example: <code>"foobar"[3] === "b"</code>',
   exec: function () {
     return "foobar"[3] === "b";
   },
@@ -1490,6 +1520,7 @@ exports.tests = [
 
     konq43: true,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1499,8 +1530,6 @@ exports.tests = [
 },
 {
   name: 'Reserved words as property names',
-  note_id: 'reserved-words',
-  note_html: 'For example: <code>({ if: 1 })</code>',
   exec: function () {
     try {
       var obj = { };
@@ -1540,6 +1569,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: true,
 
     besen: true,
     rhino: false,
@@ -1589,6 +1619,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: false,
 
     besen: true,
     rhino: true,
@@ -1638,6 +1669,7 @@ exports.tests = [
 
     konq43: false,
     konq49: true,
+    konq413: true,
 
     besen: true,
     rhino: true,
@@ -1686,6 +1718,7 @@ exports.tests = [
 
     konq43: false,
     konq49: false,
+    konq413: false,
 
     besen: true,
     rhino: false,

--- a/data-es5.js
+++ b/data-es5.js
@@ -58,9 +58,9 @@ exports.browsers = {
     obsolete: true
   },
   safari51: {
-    full: 'Safari 5.1',
-    short: 'SF 5.1',
-    obsolete: true
+    full: 'Safari 5.1.4',
+    short: 'SF 5.1.4',
+    obsolete: false
   },
   safari6: {
     full: 'Safari 6.0, Safari 7.0',
@@ -927,11 +927,7 @@ exports.tests = [
     safari3: false,
     safari4: false,
     safari5: false,
-    safari51: {
-      val: false,
-      note_id: 'safari-bind',
-      note_html: '<code>Function.prototype.bind</code> is now supported in Safari 5.1.4'
-    },
+    safari51: true,
     safari6: true,
     webkit: true,
 

--- a/es5/index.html
+++ b/es5/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="../master.css" type="text/css">
     <script src="../ready.js"></script>
     <script src="../master.js"></script>
-
   </head>
   <body>
     <div id="header">
@@ -20,8 +19,8 @@
 
         <p class="also-see">
           Also see compatibility tables for
-          <a href="../es6"><strong>ES6</strong></a> or
-          <a href="../non-standard"><strong>non-standard</strong></a>
+          <a href="../es6">ES6</a>, <a href="../es7">ES7</a>, or
+          <a href="../non-standard">non-standard</a>
           features
         </p>
 
@@ -52,7 +51,7 @@
         not functionality or full conformance.</p>
 
       <label for="show-obsolete">Show obsolete browsers?</label>
-      <input id="show-obsolete" type="checkbox" checked>
+      <input id="show-obsolete" type="checkbox">
 
       <table id="table-wrapper">
         <colgroup>
@@ -77,20 +76,21 @@
             <th class="safari3 obsolete"><a href="#safari3" class="browser-name"><abbr title="Safari 3.2">SF 3.2</abbr></th>
             <th class="safari4 obsolete"><a href="#safari4" class="browser-name"><abbr title="Safari 4.0.5">SF 4</abbr></th>
             <th class="safari5 obsolete"><a href="#safari5" class="browser-name"><abbr title="Safari 5.0.5">SF 5</abbr></th>
-            <th class="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1">SF 5.1</abbr></th>
+            <th class="safari51 obsolete"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1">SF 5.1</abbr></th>
             <th class="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari 6.0, Safari 7.0">SF 6,7</abbr></th>
             <th class="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r120398 (June 20, 2012)">WebKit</abbr></th>
             <th class="chrome5 obsolete"><a href="#chrome5" class="browser-name"><abbr title="Chrome 5 (5.0.375.127)">CH 5</abbr></th>
             <th class="chrome6 obsolete"><a href="#chrome6" class="browser-name"><abbr title="Chrome 6 (6.0.472.55)">CH 6</abbr></th>
             <th class="chrome7 obsolete"><a href="#chrome7" class="browser-name"><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev), Chrome 10, Chrome 11, Chrome 12 (12.0.742.91)">CH 7-12</abbr></th>
-            <th class="chrome13"><a href="#chrome13" class="browser-name"><abbr title="Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)">CH 13-16</abbr></th>
-            <th class="chrome19"><a href="#chrome19" class="browser-name"><abbr title="Chrome 19 (19.0.1084.56 stable)">CH 19+</abbr></th>
+            <th class="chrome13 obsolete"><a href="#chrome13" class="browser-name"><abbr title="Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)">CH 13-16</abbr></th>
+            <th class="chrome19"><a href="#chrome19" class="browser-name"><abbr title="Chrome 19 (19.0.1084.56 stable), Opera 15+">CH 19+, OP 15+</abbr></th>
             <th class="opera10_10 obsolete"><a href="#opera10_10" class="browser-name"><abbr title="Opera 10.10">OP 10.1</abbr></th>
             <th class="opera10_50 obsolete"><a href="#opera10_50" class="browser-name"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156), Opera 11.10 (build 2048), Opera 11.11 (build 2109), Opera 11.50 (build 1074)">OP 10.50-11.50</abbr></th>
-            <th class="opera12"><a href="#opera12" class="browser-name"><abbr title="Opera 12 (build 1065)">OP 12</abbr></th>
-            <th class="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10 (build 1652), Opera 15.0">OP 12.10, 15</abbr></th>
+            <th class="opera12 obsolete"><a href="#opera12" class="browser-name"><abbr title="Opera 12 (build 1065)">OP 12</abbr></th>
+            <th class="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.15">OP 12.10</abbr></th>
             <th class="konq43 obsolete"><a href="#konq43" class="browser-name"><abbr title="Konqueror 4.3">Konq 4.3</abbr></th>
-            <th class="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></th>
+            <th class="konq49 obsolete"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.9">Konq 4.9</abbr></th>
+            <th class="konq413"><a href="#konq413" class="browser-name"><abbr title="Konqueror 4.13">Konq 4.13</abbr></th>
             <th class="besen"><a href="#besen" class="browser-name"><abbr title="Bero's EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
             <th class="rhino"><a href="#rhino" class="browser-name"><abbr title="Rhino 1.7 release 3 PRERELEASE 2010 01 14">Rhino 1.7</abbr></th>
             <th class="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">Phantom</abbr></th>
@@ -114,20 +114,21 @@ test(typeof Object.create == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -149,20 +150,21 @@ test(typeof Object.defineProperty == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
-            <td class="yes webkit">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
+            <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -184,20 +186,21 @@ test(typeof Object.defineProperties == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -219,20 +222,21 @@ test(typeof Object.getPrototypeOf == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -254,20 +258,21 @@ test(typeof Object.keys == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -289,20 +294,21 @@ test(typeof Object.seal == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -324,20 +330,21 @@ test(typeof Object.freeze == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -359,20 +366,21 @@ test(typeof Object.preventExtensions == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -394,20 +402,21 @@ test(typeof Object.isSealed == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -429,20 +438,21 @@ test(typeof Object.isFrozen == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -464,20 +474,21 @@ test(typeof Object.isExtensible == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -499,20 +510,21 @@ test(typeof Object.getOwnPropertyDescriptor == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -534,27 +546,28 @@ test(typeof Object.getOwnPropertyNames == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="31" class="separator"></th>
+            <th colspan="32" class="separator"></th>
           </tr>
           <tr>
             <td id="Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&sect;</a>Date.prototype.toISOString</span></td>
@@ -572,20 +585,21 @@ test(typeof Date.prototype.toISOString == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -607,20 +621,21 @@ test(typeof Date.now == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -642,20 +657,21 @@ test(typeof Array.isArray == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -677,20 +693,21 @@ test(typeof JSON == 'object');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -712,20 +729,21 @@ test(typeof Function.prototype.bind == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="no safari51">No<a href="#safari-bind-note"><sup>[4]</sup></a></td>
+            <td class="no safari51 obsolete">No<a href="#safari-bind-note"><sup>[4]</sup></a></td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="no phantom">No</td>
@@ -747,27 +765,28 @@ test(typeof String.prototype.trim == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="31" class="separator"></th>
+            <th colspan="32" class="separator"></th>
           </tr>
           <tr>
             <td id="Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&sect;</a>Array.prototype.indexOf</span></td>
@@ -785,20 +804,21 @@ test(typeof Array.prototype.indexOf == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -820,20 +840,21 @@ test(typeof Array.prototype.lastIndexOf == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -855,20 +876,21 @@ test(typeof Array.prototype.every == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -890,20 +912,21 @@ test(typeof Array.prototype.some == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -925,20 +948,21 @@ test(typeof Array.prototype.forEach == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -960,20 +984,21 @@ test(typeof Array.prototype.map == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -995,20 +1020,21 @@ test(typeof Array.prototype.filter == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -1030,20 +1056,21 @@ test(typeof Array.prototype.reduce == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -1065,27 +1092,28 @@ test(typeof Array.prototype.reduceRight == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="31" class="separator"></th>
+            <th colspan="32" class="separator"></th>
           </tr>
           <tr>
             <td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&sect;</a>Getter in property initializer</span></td>
@@ -1109,20 +1137,21 @@ test(function () {
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -1152,30 +1181,31 @@ test(function () {
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="31" class="separator"></th>
+            <th colspan="32" class="separator"></th>
           </tr>
           <tr>
-            <td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&sect;</a>Property access on strings<a href="#property-access-on-strings-note"><sup>[5]</sup></a></span></td>
+            <td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&sect;</a>Property access on strings</span></td>
 <script>
 test("foobar"[3] === "b");
 </script>
@@ -1190,27 +1220,28 @@ test("foobar"[3] === "b");
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="yes konq43 obsolete">Yes</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&sect;</a>Reserved words as property names<a href="#reserved-words-note"><sup>[6]</sup></a></span></td>
+            <td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&sect;</a>Reserved words as property names</span></td>
 <script>
 test(function () {
   try {
@@ -1233,27 +1264,28 @@ test(function () {
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="yes chrome7 obsolete">Yes</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="no rhino">No</td>
             <td class="yes phantom">Yes</td>
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="31" class="separator"></th>
+            <th colspan="32" class="separator"></th>
           </tr>
           <tr>
             <td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&sect;</a>Zero-width chars in identifiers</span></td>
@@ -1271,24 +1303,25 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[7]</sup></a></td>
+            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[5]</sup></a></td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="no safari51">No</td>
+            <td class="no safari51 obsolete">No</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
-            <td class="no chrome13">No</td>
+            <td class="no chrome13 obsolete">No</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="no opera12">No</td>
+            <td class="no opera12 obsolete">No</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="no konq413">No</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="no phantom">No</td>
@@ -1319,20 +1352,21 @@ test(function () {
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
-            <td class="no chrome13">No</td>
+            <td class="no chrome13 obsolete">No</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="yes konq49">Yes</td>
+            <td class="yes konq49 obsolete">Yes</td>
+            <td class="yes konq413">Yes</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
             <td class="yes phantom">Yes</td>
@@ -1350,27 +1384,28 @@ test(function () {
             <td class="no ie7 obsolete">No</td>
             <td class="no ie8 obsolete">No</td>
             <td class="no ie9">No</td>
-            <td class="yes ie10">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+            <td class="yes ie10">Yes<a href="#strict-mode-ie10-note"><sup>[6]</sup></a></td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
             <td class="yes firefox4">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
-            <td class="yes chrome13">Yes</td>
+            <td class="yes chrome13 obsolete">Yes</td>
             <td class="yes chrome19">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
-            <td class="yes opera12">Yes</td>
+            <td class="yes opera12 obsolete">Yes</td>
             <td class="yes opera12_10">Yes</td>
             <td class="no konq43 obsolete">No</td>
-            <td class="no konq49">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="no konq413">No</td>
             <td class="yes besen">Yes</td>
             <td class="no rhino">No</td>
             <td class="yes phantom">Yes</td>
@@ -1384,7 +1419,7 @@ test(function () {
         <sup>[1]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).
       </p>
       <p id="define-property-webkit-note">
-        <sup>[2]</sup> In some versions of WebKit <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.
+        <sup>[2]</sup> In some versions of Safari 5, <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.
       </p>
       <p id="get-own-property-descriptor-ie-note">
         <sup>[3]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).
@@ -1392,17 +1427,11 @@ test(function () {
       <p id="safari-bind-note">
         <sup>[4]</sup> <code>Function.prototype.bind</code> is now supported in Safari 5.1.4
       </p>
-      <p id="property-access-on-strings-note">
-        <sup>[5]</sup> For example: <code>"foobar"[3] === "b"</code>
-      </p>
-      <p id="reserved-words-note">
-        <sup>[6]</sup> For example: <code>({ if: 1 })</code>
-      </p>
       <p id="zero-width-char-note">
-        <sup>[7]</sup> Firefox 4 &amp; 5 fail this test
+        <sup>[5]</sup> Firefox 4 &amp; 5 fail this test
       </p>
       <p id="strict-mode-ie10-note">
-        <sup>[8]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
+        <sup>[6]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
       </p>
     </div>
   </body>

--- a/es5/index.html
+++ b/es5/index.html
@@ -76,7 +76,7 @@
             <th class="safari3 obsolete"><a href="#safari3" class="browser-name"><abbr title="Safari 3.2">SF 3.2</abbr></th>
             <th class="safari4 obsolete"><a href="#safari4" class="browser-name"><abbr title="Safari 4.0.5">SF 4</abbr></th>
             <th class="safari5 obsolete"><a href="#safari5" class="browser-name"><abbr title="Safari 5.0.5">SF 5</abbr></th>
-            <th class="safari51 obsolete"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1">SF 5.1</abbr></th>
+            <th class="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1.4">SF 5.1.4</abbr></th>
             <th class="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari 6.0, Safari 7.0">SF 6,7</abbr></th>
             <th class="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r120398 (June 20, 2012)">WebKit</abbr></th>
             <th class="chrome5 obsolete"><a href="#chrome5" class="browser-name"><abbr title="Chrome 5 (5.0.375.127)">CH 5</abbr></th>
@@ -114,7 +114,7 @@ test(typeof Object.create == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -150,7 +150,7 @@ test(typeof Object.defineProperty == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -186,7 +186,7 @@ test(typeof Object.defineProperties == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -222,7 +222,7 @@ test(typeof Object.getPrototypeOf == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -258,7 +258,7 @@ test(typeof Object.keys == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -294,7 +294,7 @@ test(typeof Object.seal == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -330,7 +330,7 @@ test(typeof Object.freeze == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -366,7 +366,7 @@ test(typeof Object.preventExtensions == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -402,7 +402,7 @@ test(typeof Object.isSealed == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -438,7 +438,7 @@ test(typeof Object.isFrozen == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -474,7 +474,7 @@ test(typeof Object.isExtensible == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -510,7 +510,7 @@ test(typeof Object.getOwnPropertyDescriptor == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -546,7 +546,7 @@ test(typeof Object.getOwnPropertyNames == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -585,7 +585,7 @@ test(typeof Date.prototype.toISOString == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -621,7 +621,7 @@ test(typeof Date.now == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -657,7 +657,7 @@ test(typeof Array.isArray == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -693,7 +693,7 @@ test(typeof JSON == 'object');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -729,7 +729,7 @@ test(typeof Function.prototype.bind == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="no safari51 obsolete">No<a href="#safari-bind-note"><sup>[4]</sup></a></td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -765,7 +765,7 @@ test(typeof String.prototype.trim == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -804,7 +804,7 @@ test(typeof Array.prototype.indexOf == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -840,7 +840,7 @@ test(typeof Array.prototype.lastIndexOf == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -876,7 +876,7 @@ test(typeof Array.prototype.every == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -912,7 +912,7 @@ test(typeof Array.prototype.some == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -948,7 +948,7 @@ test(typeof Array.prototype.forEach == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -984,7 +984,7 @@ test(typeof Array.prototype.map == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1020,7 +1020,7 @@ test(typeof Array.prototype.filter == 'function');
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1056,7 +1056,7 @@ test(typeof Array.prototype.reduce == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1092,7 +1092,7 @@ test(typeof Array.prototype.reduceRight == 'function');
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1137,7 +1137,7 @@ test(function () {
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1181,7 +1181,7 @@ test(function () {
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1220,7 +1220,7 @@ test("foobar"[3] === "b");
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
@@ -1264,7 +1264,7 @@ test(function () {
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -1303,11 +1303,11 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[5]</sup></a></td>
+            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[4]</sup></a></td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="no safari51 obsolete">No</td>
+            <td class="no safari51">No</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -1352,7 +1352,7 @@ test(function () {
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -1384,14 +1384,14 @@ test(function () {
             <td class="no ie7 obsolete">No</td>
             <td class="no ie8 obsolete">No</td>
             <td class="no ie9">No</td>
-            <td class="yes ie10">Yes<a href="#strict-mode-ie10-note"><sup>[6]</sup></a></td>
+            <td class="yes ie10">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
             <td class="yes firefox4">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51 obsolete">Yes</td>
+            <td class="yes safari51">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
@@ -1424,14 +1424,11 @@ test(function () {
       <p id="get-own-property-descriptor-ie-note">
         <sup>[3]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).
       </p>
-      <p id="safari-bind-note">
-        <sup>[4]</sup> <code>Function.prototype.bind</code> is now supported in Safari 5.1.4
-      </p>
       <p id="zero-width-char-note">
-        <sup>[5]</sup> Firefox 4 &amp; 5 fail this test
+        <sup>[4]</sup> Firefox 4 &amp; 5 fail this test
       </p>
       <p id="strict-mode-ie10-note">
-        <sup>[6]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
+        <sup>[5]</sup> IE10 PP2 has a bug with strict mode which makes the following expression "fail", even though strict mode is more or less supported: <code>(function(){ "use strict"; return !this })()</code>
       </p>
     </div>
   </body>

--- a/es5/skeleton.html
+++ b/es5/skeleton.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="../master.css" type="text/css">
     <script src="../ready.js"></script>
     <script src="../master.js"></script>
-
   </head>
   <body>
     <div id="header">
@@ -20,8 +19,8 @@
 
         <p class="also-see">
           Also see compatibility tables for
-          <a href="../es6"><strong>ES6</strong></a> or
-          <a href="../non-standard"><strong>non-standard</strong></a>
+          <a href="../es6">ES6</a>, <a href="../es7">ES7</a>, or
+          <a href="../non-standard">non-standard</a>
           features
         </p>
 
@@ -52,7 +51,7 @@
         not functionality or full conformance.</p>
 
       <label for="show-obsolete">Show obsolete browsers?</label>
-      <input id="show-obsolete" type="checkbox" checked>
+      <input id="show-obsolete" type="checkbox">
 
       <table id="table-wrapper">
         <colgroup>

--- a/es6/index.html
+++ b/es6/index.html
@@ -21,11 +21,11 @@
       </a>
 
       <p class="also-see">
-        Also see compatibility tables for
-        <a href="../es5"><strong>ES5</strong></a> or
-        <a href="../non-standard"><strong>non-standard</strong></a>
-        features
-      </p>
+          Also see compatibility tables for
+          <a href="../es5">ES5</a>, <a href="../es7">ES7</a>, or
+          <a href="../non-standard">non-standard</a>
+          features
+        </p>
 
       <span style="font-size:0.8em;float:right;font-weight:normal;">
         <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://kangax.github.com/es5-compat-table/non-standard"></a>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -21,11 +21,11 @@
       </a>
 
       <p class="also-see">
-        Also see compatibility tables for
-        <a href="../es5"><strong>ES5</strong></a> or
-        <a href="../non-standard"><strong>non-standard</strong></a>
-        features
-      </p>
+          Also see compatibility tables for
+          <a href="../es5">ES5</a>, <a href="../es7">ES7</a>, or
+          <a href="../non-standard">non-standard</a>
+          features
+        </p>
 
       <span style="font-size:0.8em;float:right;font-weight:normal;">
         <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://kangax.github.com/es5-compat-table/non-standard"></a>

--- a/master.css
+++ b/master.css
@@ -59,7 +59,7 @@ label[for="show-obsolete"] { background: #eef; padding: 5px; margin-left: 10px; 
 label[for="sort"] { margin-left: 20px; background: #fee; padding: 5px; margin-right: -30px; padding-right: 30px; }
 
 .also-see { font-size: 14px; display: inline-block; background:#ddf; padding: 12px; position:absolute;top:0;left:50%;margin-left:-174px; color: #333; font-family: 'Open Sans', sans-serif; }
-.also-see a { color: blue !important; text-decoration: underline !important; }
+.also-see a { font-weight: bold; color: blue !important; text-decoration: underline !important; }
 
 .info { color: #eee; float: right; margin-right: 5px; background: #999; display: inline-block;
   width: 15px; height: 15px; line-height: 15px; text-align: center; border-radius: 20px;


### PR DESCRIPTION
In addition to adding KQ:
- Removed the "For example" footnotes (on the basis that the example test code contained the example, too).
- Removed the define-property-webkit note from WebKit (but not from Safari 5).
- Renamed the Opera and Chrome rows to reflect the fact of Opera 15+ being Chromium-based rather than Opera 12-based.
- Added ES7 hyperlinks to the ES5 and ES6 pages.
- Set "Show obsolete browsers" off by default. The obsolete browsers are all multiple years old now - their relevance has diminished.
