### PR TITLE
Fixed an ES5 strict test that crashes in Chrome

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -1647,7 +1647,7 @@ exports.tests = [
 },
 {
   name: 'Strict mode',
-  link: 'http://kangax.github.com/es5-compat-table/strict-mode/',
+  link: '../strict-mode/',
   exec: function () {
     "use strict";
     return !this;

--- a/es5/index.html
+++ b/es5/index.html
@@ -1339,7 +1339,7 @@ test(function () {
             <td class="no ejs">No</td>
           </tr>
           <tr>
-            <td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&sect;</a><a href="http://kangax.github.com/es5-compat-table/strict-mode/">Strict mode</a></span></td>
+            <td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&sect;</a><a href="../strict-mode/">Strict mode</a></span></td>
 <script>
 test(function () {
   "use strict";

--- a/strict-mode/index.html
+++ b/strict-mode/index.html
@@ -218,7 +218,7 @@
       (function(){
         var error;
         try {
-          (function f() { f = 123; })();
+          eval("(function f() { f = 123; })()");
         }
         catch (err) { error = err; }
         print('<span class="test"><code>(function f() { f = 123; })()<\/code> is a TypeError<\/span>' + colorResult(error instanceof TypeError));


### PR DESCRIPTION
The test `(function f() { f = 123; })()` actually throws a SyntaxError on evaluation (`SyntaxError: Assignment to constant variable`), not a TypeError on execution, in the current Chrome. I'm really not sure which is fully correct for either the ES5 or ES6 specs. Nevertheless, I've changed that line to be `eval`ed so that the entire script doesn't crash.

Also, the link to the strict mode page on the ES5 test page is fixed.
