### PR TITLE
Added tests for each Proxy handler

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1938,16 +1938,140 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Proxy',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:direct_proxies',
-  exec: function () {
-    try {
-      return typeof Proxy !== "undefined" &&
-           new Proxy({}, { get: function () { return 5; } }).foo === 5;
-    }
-    catch(err) { }
-    return false;
-  },
+  name: 'Proxy "get" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver',
+  exec: function () {/*
+    var proxied = { };
+    var proxy = new Proxy(proxied, {
+      get: function (t, k, r) {
+        return t === proxied && k === "foo" && r === proxy && 5;
+      }
+    });
+    return proxy.foo === 5;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   {
+      val: true,
+      note_id: 'fx-proxy-get',
+      note_html: 'Firefox doesn\'t allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy\'s "get" handler via the prototype chain, unless the proxied object actually does possess the named property.'
+    },
+    firefox23:   { val: true, note_id: 'fx-proxy-get' },
+    firefox24:   { val: true, note_id: 'fx-proxy-get' },
+    firefox25:   { val: true, note_id: 'fx-proxy-get' },
+    firefox27:   { val: true, note_id: 'fx-proxy-get' },
+    firefox28:   { val: true, note_id: 'fx-proxy-get' },
+    firefox29:   { val: true, note_id: 'fx-proxy-get' },
+    firefox30:   { val: true, note_id: 'fx-proxy-get' },
+    firefox31:   { val: true, note_id: 'fx-proxy-get' },
+    firefox32:   { val: true, note_id: 'fx-proxy-get' },
+    firefox33:   { val: true, note_id: 'fx-proxy-get' },
+    firefox34:   { val: true, note_id: 'fx-proxy-get' },
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "set" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver',
+  exec: function () {/*
+    var proxied = { };
+    var passed = false;
+    var proxy = new Proxy(proxied, {
+      set: function (t, k, v, r) {
+        passed = t === proxied && k + v === "foobar" && r === proxy;
+      }
+    });
+    proxy.foo = "bar";
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   {
+      val: true,
+      note_id: 'fx-proxy-set',
+      note_html: 'Firefox doesn\'t allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy\'s "set" handler via the prototype chain.'
+    },
+    firefox23:   { val: true, note_id: 'fx-proxy-set' },
+    firefox24:   { val: true, note_id: 'fx-proxy-set' },
+    firefox25:   { val: true, note_id: 'fx-proxy-set' },
+    firefox27:   { val: true, note_id: 'fx-proxy-set' },
+    firefox28:   { val: true, note_id: 'fx-proxy-set' },
+    firefox29:   { val: true, note_id: 'fx-proxy-set' },
+    firefox30:   { val: true, note_id: 'fx-proxy-set' },
+    firefox31:   { val: true, note_id: 'fx-proxy-set' },
+    firefox32:   { val: true, note_id: 'fx-proxy-set' },
+    firefox33:   { val: true, note_id: 'fx-proxy-set' },
+    firefox34:   { val: true, note_id: 'fx-proxy-set' },
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "has" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    "foo" in new Proxy(proxied, {
+      has: function (t, k) {
+        passed = t === proxied && k === "foo";
+      }
+    });
+    return passed;
+  */},
   res: {
     tr:          false,
     ejs:         true,
@@ -1993,12 +2117,736 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
+  name: 'Proxy "deleteProperty" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-delete-p',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    delete new Proxy(proxied, {
+      deleteProperty: function (t, k) {
+        passed = t === proxied && k === "foo";
+      }
+    }).foo;
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   true,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "getOwnPropertyDescriptor" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p',
+  exec: function () {/*
+    var proxied = {};
+    var fakeDesc = { value: "foo", configurable: true };
+    var returnedDesc = Object.getOwnPropertyDescriptor(
+      new Proxy(proxied, {
+        getOwnPropertyDescriptor: function (t, k) {
+          return t === proxied && k === "foo" && fakeDesc;
+        }
+      }),
+      "foo"
+    );
+    return (returnedDesc.value     === fakeDesc.value
+      && returnedDesc.configurable === fakeDesc.configurable
+      && returnedDesc.writable     === false
+      && returnedDesc.enumerable   === false);
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:    {
+      val: false,
+      note_id: 'fx-proxy-getown',
+      note_html: 'From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible'
+    },
+    firefox23:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox24:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox25:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox27:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox28:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox29:   { val: false, note_id: 'fx-proxy-getown' },
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "defineProperty" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    Object.defineProperty(
+      new Proxy(proxied, {
+        defineProperty: function (t, k, d) {
+          passed = t === proxied && k === "foo" && d.value === 5;
+        }
+      }),
+      "foo",
+      { value: 5 }
+    );
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   true,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "getPrototypeOf" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof',
+  exec: function () {/*
+    var proxied = {};
+    var fakeProto = {};
+    var proxy = new Proxy(proxied, {
+      getPrototypeOf: function (t) {
+        return t === proxied && fakeProto;
+      }
+    });
+    return Object.getPrototypeOf(proxy) === fakeProto;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   false,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "setPrototypeOf" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof',
+  exec: function () {/*
+    var proxied = {};
+    var newProto = {};
+    var passed = false;
+    Object.setPrototypeOf(
+      new Proxy(proxied, {
+        setPrototypeOf: function (t, p) {
+          passed = t === proxied && p === newProto;
+        }
+      }),
+      newProto
+    );
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   false,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "isExtensible" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-isextensible',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    Object.isExtensible(
+      new Proxy(proxied, {
+        isExtensible: function (t) {
+          passed = t === proxied; return true;
+        }
+      })
+    );
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy "preventExtensions" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-preventextensions',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    Object.preventExtensions(
+      new Proxy(proxied, {
+        preventExtensions: function (t) {
+          passed = t === proxied;
+          return Object.preventExtensions(proxied);
+        }
+      })
+    );
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false,
+  }
+},
+{
+  name: 'Proxy "enumerate" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-enumerate',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    for (var i in
+      new Proxy(proxied, {
+        enumerate: function (t) {
+          passed = t === proxied;
+          return {
+            next: function(){ return { done: true, value: null };}
+          };
+        }
+      })
+    ) { }
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   false,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false,
+  }
+},
+{
+  name: 'Proxy "ownKeys" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys',
+  exec: function () {/*
+    var proxied = {};
+    var passed = false;
+    Object.keys(
+      new Proxy(proxied, {
+        ownKeys: function (t) {
+          passed = t === proxied; return [];
+        }
+      })
+    );
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   {
+      val: false,
+      note_id: 'fx-proxy-ownkeys',
+      note_html: 'Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler'
+    },
+    firefox23:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox24:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox25:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox27:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox28:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox29:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox30:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox31:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox32:   { val: false, note_id: 'fx-proxy-ownkeys' },
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false,
+  }
+},
+{
+  name: 'Proxy "apply" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist',
+  exec: function () {/*
+    var proxied = function(){};
+    var passed = false;
+    var host = {
+      method: new Proxy(proxied, { 
+        apply: function (t, thisArg, args) { console.log(arguments);
+          passed = t === proxied && thisArg === host && args + "" === "foo,bar";
+        }
+      })
+    };
+    host.method("foo", "bar");
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   true,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false,
+  }
+},
+{
+  name: 'Proxy "construct" handler',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-construct-internal-method',
+  exec: function () {/*
+    var proxied = function(){};
+    var passed = false;
+    new new Proxy(proxied, {
+      construct: function (t, args) {
+        passed = t === proxied && args + "" === "foo,bar";
+        return {};
+      }
+    })("foo","bar");
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   true,
+    firefox23:   true,
+    firefox24:   true,
+    firefox25:   true,
+    firefox27:   true,
+    firefox28:   true,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
+  name: 'Proxy.revocable',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy.revocable',
+  exec: function () {/*
+    var obj = Proxy.revocable({}, { get: function() { return 5; } });
+    var passed = (obj.proxy.foo === 5);
+    obj.revoke();
+    try {
+      obj.proxy.foo;
+    } catch(e) {
+      passed &= e instanceof TypeError;
+    }
+    return passed;
+  */},
+  res: {
+    tr:          false,
+    ejs:         false,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    chrome39:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false,
+    ios7:        false,
+    ios8:        false
+  }
+},
+{
   name: 'Reflect',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection',
   exec: function () {
     var i, names =
-      ["apply","construct","defineProperty","deleteProperty","getOwnPropertyDescriptor",
-      "getPrototypeOf","has","isExtensible","set","setPrototypeOf"];
+      ["apply","construct","defineProperty","deleteProperty","enumerate","get",
+      "getOwnPropertyDescriptor","getPrototypeOf","has","isExtensible","ownKeys",
+      "preventExtensions","set","setPrototypeOf"];
 
     if (typeof Reflect !== "object") {
       return false;

--- a/es6/index.html
+++ b/es6/index.html
@@ -1719,23 +1719,131 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="Proxy"><span><a class="anchor" href="#Proxy">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:direct_proxies">Proxy</a></span></td>
-<script data-source="function () {
-try {
-  return typeof Proxy !== &quot;undefined&quot; &&
-       new Proxy({}, { get: function () { return 5; } }).foo === 5;
-}
-catch(err) { }
-return false;
-  }">test(
-function () {
-try {
-  return typeof Proxy !== "undefined" &&
-       new Proxy({}, { get: function () { return 5; } }).foo === 5;
-}
-catch(err) { }
-return false;
-  }())</script>
+          <td id="Proxy_get_handler"><span><a class="anchor" href="#Proxy_get_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver">Proxy "get" handler</a></span></td>
+<script data-source="
+var proxied = { };
+var proxy = new Proxy(proxied, {
+  get: function (t, k, r) {
+    return t === proxied && k === &quot;foo&quot; && r === proxy && 5;
+  }
+});
+return proxy.foo === 5;
+  ">
+test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox24">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_set_handler"><span><a class="anchor" href="#Proxy_set_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver">Proxy "set" handler</a></span></td>
+<script data-source="
+var proxied = { };
+var passed = false;
+var proxy = new Proxy(proxied, {
+  set: function (t, k, v, r) {
+    passed = t === proxied && k + v === &quot;foobar&quot; && r === proxy;
+  }
+});
+proxy.foo = &quot;bar&quot;;
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox24">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox32">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[10]</sup></a></td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_has_handler"><span><a class="anchor" href="#Proxy_has_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p">Proxy "has" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+&quot;foo&quot; in new Proxy(proxied, {
+  has: function (t, k) {
+    passed = t === proxied && k === &quot;foo&quot;;
+  }
+});
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
@@ -1779,11 +1887,715 @@ return false;
           <td class="no ios8">No</td>
         </tr>
         <tr>
+          <td id="Proxy_deleteProperty_handler"><span><a class="anchor" href="#Proxy_deleteProperty_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-delete-p">Proxy "deleteProperty" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+delete new Proxy(proxied, {
+  deleteProperty: function (t, k) {
+    passed = t === proxied && k === &quot;foo&quot;;
+  }
+}).foo;
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\ndelete new Proxy(proxied, {\n  deleteProperty: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}).foo;\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_getOwnPropertyDescriptor_handler"><span><a class="anchor" href="#Proxy_getOwnPropertyDescriptor_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p">Proxy "getOwnPropertyDescriptor" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var fakeDesc = { value: &quot;foo&quot;, configurable: true };
+var returnedDesc = Object.getOwnPropertyDescriptor(
+  new Proxy(proxied, {
+    getOwnPropertyDescriptor: function (t, k) {
+      return t === proxied && k === &quot;foo&quot; && fakeDesc;
+    }
+  }),
+  &quot;foo&quot;
+);
+return (returnedDesc.value     === fakeDesc.value
+  && returnedDesc.configurable === fakeDesc.configurable
+  && returnedDesc.writable     === false
+  && returnedDesc.enumerable   === false);
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="no firefox24">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[11]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_defineProperty_handler"><span><a class="anchor" href="#Proxy_defineProperty_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc">Proxy "defineProperty" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+Object.defineProperty(
+  new Proxy(proxied, {
+    defineProperty: function (t, k, d) {
+      passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+    }
+  }),
+  &quot;foo&quot;,
+  { value: 5 }
+);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }),\n  \"foo\",\n  { value: 5 }\n);\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_getPrototypeOf_handler"><span><a class="anchor" href="#Proxy_getPrototypeOf_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof">Proxy "getPrototypeOf" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var fakeProto = {};
+var proxy = new Proxy(proxied, {
+  getPrototypeOf: function (t) {
+    return t === proxied && fakeProto;
+  }
+});
+return Object.getPrototypeOf(proxy) === fakeProto;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_setPrototypeOf_handler"><span><a class="anchor" href="#Proxy_setPrototypeOf_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof">Proxy "setPrototypeOf" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var newProto = {};
+var passed = false;
+Object.setPrototypeOf(
+  new Proxy(proxied, {
+    setPrototypeOf: function (t, p) {
+      passed = t === proxied && p === newProto;
+    }
+  }),
+  newProto
+);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n    }\n  }),\n  newProto\n);\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_isExtensible_handler"><span><a class="anchor" href="#Proxy_isExtensible_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-isextensible">Proxy "isExtensible" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+Object.isExtensible(
+  new Proxy(proxied, {
+    isExtensible: function (t) {
+      passed = t === proxied; return true;
+    }
+  })
+);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_preventExtensions_handler"><span><a class="anchor" href="#Proxy_preventExtensions_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-preventextensions">Proxy "preventExtensions" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+Object.preventExtensions(
+  new Proxy(proxied, {
+    preventExtensions: function (t) {
+      passed = t === proxied;
+      return Object.preventExtensions(proxied);
+    }
+  })
+);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_enumerate_handler"><span><a class="anchor" href="#Proxy_enumerate_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-enumerate">Proxy "enumerate" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+for (var i in
+  new Proxy(proxied, {
+    enumerate: function (t) {
+      passed = t === proxied;
+      return {
+        next: function(){ return { done: true, value: null };}
+      };
+    }
+  })
+) { }
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_ownKeys_handler"><span><a class="anchor" href="#Proxy_ownKeys_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy "ownKeys" handler</a></span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+Object.keys(
+  new Proxy(proxied, {
+    ownKeys: function (t) {
+      passed = t === proxied; return [];
+    }
+  })
+);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="no firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[12]</sup></a></td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_apply_handler"><span><a class="anchor" href="#Proxy_apply_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist">Proxy "apply" handler</a></span></td>
+<script data-source="
+var proxied = function(){};
+var passed = false;
+var host = {
+  method: new Proxy(proxied, { 
+    apply: function (t, thisArg, args) { console.log(arguments);
+      passed = t === proxied && thisArg === host && args + &quot;&quot; === &quot;foo,bar&quot;;
+    }
+  })
+};
+host.method(&quot;foo&quot;, &quot;bar&quot;);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, { \n    apply: function (t, thisArg, args) { console.log(arguments);\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy_construct_handler"><span><a class="anchor" href="#Proxy_construct_handler">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-construct-internal-method">Proxy "construct" handler</a></span></td>
+<script data-source="
+var proxied = function(){};
+var passed = false;
+new new Proxy(proxied, {
+  construct: function (t, args) {
+    passed = t === proxied && args + &quot;&quot; === &quot;foo,bar&quot;;
+    return {};
+  }
+})(&quot;foo&quot;,&quot;bar&quot;);
+return passed;
+  ">
+test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
+          <td id="Proxy.revocable"><span><a class="anchor" href="#Proxy.revocable">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy.revocable">Proxy.revocable</a></span></td>
+<script data-source="
+var obj = Proxy.revocable({}, { get: function() { return 5; } });
+var passed = (obj.proxy.foo === 5);
+obj.revoke();
+try {
+  obj.proxy.foo;
+} catch(e) {
+  passed &= e instanceof TypeError;
+}
+return passed;
+  ">
+test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no ejs">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
+        <tr>
           <td id="Reflect"><span><a class="anchor" href="#Reflect">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
 <script data-source="function () {
 var i, names =
-  [&quot;apply&quot;,&quot;construct&quot;,&quot;defineProperty&quot;,&quot;deleteProperty&quot;,&quot;getOwnPropertyDescriptor&quot;,
-  &quot;getPrototypeOf&quot;,&quot;has&quot;,&quot;isExtensible&quot;,&quot;set&quot;,&quot;setPrototypeOf&quot;];
+  [&quot;apply&quot;,&quot;construct&quot;,&quot;defineProperty&quot;,&quot;deleteProperty&quot;,&quot;enumerate&quot;,&quot;get&quot;,
+  &quot;getOwnPropertyDescriptor&quot;,&quot;getPrototypeOf&quot;,&quot;has&quot;,&quot;isExtensible&quot;,&quot;ownKeys&quot;,
+  &quot;preventExtensions&quot;,&quot;set&quot;,&quot;setPrototypeOf&quot;];
 
 if (typeof Reflect !== &quot;object&quot;) {
   return false;
@@ -1797,8 +2609,9 @@ return true;
   }">test(
 function () {
 var i, names =
-  ["apply","construct","defineProperty","deleteProperty","getOwnPropertyDescriptor",
-  "getPrototypeOf","has","isExtensible","set","setPrototypeOf"];
+  ["apply","construct","defineProperty","deleteProperty","enumerate","get",
+  "getOwnPropertyDescriptor","getPrototypeOf","has","isExtensible","ownKeys",
+  "preventExtensions","set","setPrototypeOf"];
 
 if (typeof Reflect !== "object") {
   return false;
@@ -1931,7 +2744,7 @@ return true;
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[9]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[13]</sup></a></span></td>
 <script data-source="
 'use strict';
 {
@@ -4131,12 +4944,12 @@ return typeof Array.prototype.values === 'function';
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[10]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[11]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
           <td class="no firefox29 obsolete">No</td>
           <td class="no firefox30 obsolete">No</td>
           <td class="no firefox31">No</td>
@@ -4699,7 +5512,7 @@ return typeof Math.imul === 'function';
           <td class="yes firefox34">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[12]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[16]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
           <td class="yes chrome34 obsolete">Yes</td>
@@ -5390,7 +6203,7 @@ return typeof Math.fround === 'function';
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[13]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[17]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
@@ -5473,7 +6286,7 @@ return typeof Math.cbrt === 'function';
           <th colspan="43" class="separator"></th>
         </tr>
         <tr>
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[14]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
 <script data-source="function () {
 var passed = { __proto__ : [] } instanceof Array
   && !({ __proto__ : null } instanceof Object);
@@ -5518,8 +6331,8 @@ return passed;
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32">Yes</td>
-          <td class="yes firefox33">Yes<a href="#fx-proto-shorthand-note"><sup>[15]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proto-shorthand-note"><sup>[15]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proto-shorthand-note"><sup>[19]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proto-shorthand-note"><sup>[19]</sup></a></td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -5543,7 +6356,7 @@ return passed;
           <td class="yes ios8">Yes</td>
         </tr>
         <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[16]</sup></a></span></td>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[20]</sup></a></span></td>
 <script data-source="
 // Note: only available outside of strict mode.
 var passed = f() === 2 && g() === 4;
@@ -5802,29 +6615,41 @@ return typeof RegExp.prototype.compile === 'function';
       <p id="weakmap-constructor-note">
         <sup>[8]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
       </p>
+      <p id="fx-proxy-get-note">
+        <sup>[9]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
+      </p>
+      <p id="fx-proxy-set-note">
+        <sup>[10]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
+      </p>
+      <p id="fx-proxy-getown-note">
+        <sup>[11]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+      </p>
+      <p id="fx-proxy-ownkeys-note">
+        <sup>[12]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+      </p>
       <p id="block-level-function-note">
-        <sup>[9]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[13]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[10]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[14]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[11]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[15]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[12]</sup> Available since Chrome 28
+        <sup>[16]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[13]</sup> Available since Firefox 26
+        <sup>[17]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[14]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
       <p id="fx-proto-shorthand-note">
-        <sup>[15]</sup> Firefox 33+ incorrectly regards both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
+        <sup>[19]</sup> Firefox 33+ incorrectly regards both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
       </p>
       <p id="hoisted-block-level-function-note">
-        <sup>[16]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
+        <sup>[20]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This adds individual tests for the Proxy `get`, `set`, `has`, `deleteProperty`, `getOwnPropertyDescriptor`, `defineProperty`, `getPrototypeOf`, `setPrototypeOf`, `isExtensible`, `preventExtensions`, `enumerate`, `ownKeys`, `apply` and `construct` handlers. Currently Firefox supports most of them, excepting the prototype handlers and the enumerate handler.

EJS support was inferred from the EJS source.

Also updates the Reflect test to match all the Proxy handlers.
