### PR TITLE
Fix unscopables test

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -2912,7 +2912,7 @@ test(function () {
 test(function () {
   if (typeof Symbol === "function" && typeof Symbol.unscopables === "symbol") {
     var a = { foo: 1, bar: 2 };
-    a[Symbol.unscopables] = ["bar"];
+    a[Symbol.unscopables] = { bar: true };
     with (a) {
       return foo === 1 && typeof bar === "undefined";
     }


### PR DESCRIPTION
The unscopables object is now speced as an Object and not an Array.

This now correctly passes in Chrome 38.
