### PR TITLE
Fix invalid Symbol.iterator test

### DIFF
--- a/es6/index.html
+++ b/es6/index.html
@@ -2758,7 +2758,9 @@ test(function () {
         }
       };
     };
-    return Function("for (var c of b) { return c === 0; } return false;")();
+    var c;
+    eval("for (c of b) {}");
+    return c === 0;
   }
   catch(e) {
     return false;


### PR DESCRIPTION
The test was using Function() which implies global scope. Since
the test tries to access the local variable b there was a
ReferenceError.

Changed the test to use eval instead.
