### PR TITLE
ES6: Improved the template strings test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1334,12 +1334,74 @@ exports.tests = [
   }
 },
 {
-  name: 'Template Strings',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:quasis',
+  name: 'template strings',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals',
   exec: function () {
     try {
-      eval('var u = function () { return true }; u`literal`');
-      return true;
+      var a = "ba", b = "QUX";
+      return eval('`foo bar\n${a + "z"} ${b.toLowerCase()}`') === "foo bar\nbaz qux";
+    } catch (e) {
+      return false;
+    }
+  },
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   false,
+    firefox30:   false,
+    firefox31:   false,
+    firefox32:   false,
+    firefox33:   false,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    false,
+    chrome34:    false,
+    chrome35:    false,
+    chrome37:    false,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      false,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: false
+  }
+},
+{
+  name: 'tagged template strings',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals',
+  exec: function () {
+    try {
+      var called = false;
+      function fn(parts, a, b) {
+        called = true;
+        return parts instanceof Array &&
+          parts[0]     === "foo"      &&
+          parts[1]     === "bar\n"    &&
+          parts.raw[0] === "foo"      &&
+          parts.raw[1] === "bar\\n"   &&
+          a === 123                   &&
+          b === 456;
+      }
+      return eval('fn `foo${123}bar\\n${456}`') && called;
     } catch (e) {
       return false;
     }

--- a/es6/index.html
+++ b/es6/index.html
@@ -1131,12 +1131,73 @@ test(function () {
           <td class="no nodeharmony">No</td>
         </tr>
         <tr>
-          <td id="Template_Strings"><span><a class="anchor" href="#Template_Strings">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:quasis">Template Strings</a></span></td>
+          <td id="template_strings"><span><a class="anchor" href="#template_strings">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">template strings</a></span></td>
 <script>
 test(function () {
   try {
-    eval('var u = function () { return true }; u`literal`');
-    return true;
+    var a = "ba", b = "QUX";
+    return eval('`foo bar\n${a + "z"} ${b.toLowerCase()}`') === "foo bar\nbaz qux";
+  } catch (e) {
+    return false;
+  }
+}());
+</script>
+
+          <td class="yes tr">Yes</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32">No</td>
+          <td class="no firefox33">No</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35">No</td>
+          <td class="no chrome37">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+        </tr>
+        <tr>
+          <td id="tagged_template_strings"><span><a class="anchor" href="#tagged_template_strings">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">tagged template strings</a></span></td>
+<script>
+test(function () {
+  try {
+    var called = false;
+    function fn(parts, a, b) {
+      called = true;
+      return parts instanceof Array &&
+        parts[0]     === "foo"      &&
+        parts[1]     === "bar\n"    &&
+        parts.raw[0] === "foo"      &&
+        parts.raw[1] === "bar\\n"   &&
+        a === 123                   &&
+        b === 456;
+    }
+    return eval('fn `foo${123}bar\\n${456}`') && called;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
This splits the template strings test into two tests: one that checks basic expression interpolation (e.g. `${expression}` syntax) and one that performs various tagged template function checks (including checks for the "call site array" argument, its standard and raw properties, and the expression value arguments).
