### PR TITLE
ES6 test functions in multi-line strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ECMAScript 5/6/7/non-standard compatibility tables
+==================================================
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/kangax/es5-compat-table/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
@@ -6,3 +7,5 @@ Editing the tests
 -----------------
 
 Edit the `data-es5.js`, `data-es6.js`, `data-es7.js`, or `data-non-standard.js` files to adjust the tests and their recorded browser results. Run `node build.js` to build the HTML files from these JavaScript sources.
+
+The tests themselves should be written in pure ES3, *except* for the sole ES6 feature being tested (as well as any ES5 features strictly required to use the ES6 feature). The test code is placed in multi-line comments (as in [this hack](http://tomasz.janczuk.org/2013/05/multi-line-strings-in-javascript-and.html)), so that node can parse the data scripts without throwing syntax errors. The `build.js` script will wrap the code in an `eval` call inside a `try`, so the tests themselves do not need to catch errors that non-supporting platforms may throw.

--- a/build.js
+++ b/build.js
@@ -197,8 +197,8 @@ function replaceAndIndent(str, replacements) {
 }
 
 function deindentFunc(fn) {
-  fn += '';
-  var indent = /\n([\t ]*)[^\n]*$/.exec(fn);
+  fn = (fn+'');
+  var indent = /(?:^|\n)([\t ]+)[^\n]+/.exec(fn);
   if (indent) {
     fn = fn.replace(new RegExp('\n' + indent[1], 'g'), '\n');
   }
@@ -207,20 +207,19 @@ function deindentFunc(fn) {
 
 function testScript(fn) {
   if (typeof fn === 'function') {
-    fn = deindentFunc(fn);
-
-    // find the expression if it's there
-    var expr = /^function \(\) \{\s*return\s+([\s\S]+?);?\s*\}$/.exec(fn);
-    expr = expr && expr[1];
+  
+    // see if the code is encoded in a comment
+    var expr = (fn+"").match(/[^]*\/\*([^]*)\*\/\}$/);
 
     // if there wasn't an expression, make the function statement into one
     if (!expr) {
-      expr = fn + '()';
+      return '<script>test(\n' + deindentFunc(fn) + '())</script>\n';
     }
-
-    return '<script>\n' +
-      'test(' + expr + ');\n' +
+    else {
+      return '<script>\n' +
+      'test(function(){try{return Function(' + JSON.stringify(deindentFunc(expr[1])) + ')()}catch(e){return false;}}());\n' +
       '</script>\n';
+    }
   } else {
     // it's an array of objects like the following:
     // { type: 'application/javascript;version=1.8', script: function () { ... } }

--- a/data-es6.js
+++ b/data-es6.js
@@ -493,7 +493,7 @@ exports.tests = [
 },
 {
   name: 'rest parameters',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions',
   exec: function() {/*
     return (function (...args) { return typeof args !== "undefined"; }())
   */},
@@ -540,7 +540,7 @@ exports.tests = [
 },
 {
   name: 'spread call (...) operator',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation',
   exec: function () {/*
     return Math.max(...[1, 2, 3]) === 3
   */},
@@ -587,7 +587,7 @@ exports.tests = [
 },
 {
   name: 'spread array (...) operator',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-literal',
   exec: function() {/*
     return [...[1, 2, 3]][2] === 3;
   */},
@@ -634,7 +634,7 @@ exports.tests = [
 },
 {
   name: 'string spreading',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-literal',
   exec: function() {/*
     return ["a", ..."bcd", "e"][3] === "d" && Math.max(..."1234") === 4;
   */},
@@ -685,7 +685,7 @@ exports.tests = [
 },
 {
   name: 'class',
-  link: 'http://wiki.ecmascript.org/doku.php?id=strawman:maximally_minimal_classes',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions',
   exec: function () {/*
     class C extends Array {
       constructor() { this.b = true; }
@@ -1011,7 +1011,7 @@ exports.tests = [
 },
 {
   name: 'modules',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:modules',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-modules',
   exec: function () {/*
     export var foo = 1;
     return true;
@@ -1058,8 +1058,8 @@ exports.tests = [
   }
 },
 {
-  name: 'For..of loops',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:iterators',
+  name: 'for..of loops',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements',
   exec: function () {/*
     var arr = [5];
     for (var item of arr)
@@ -1107,8 +1107,8 @@ exports.tests = [
   }
 },
 {
-  name: 'Generators (yield)',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:generators',
+  name: 'generators (yield)',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions',
   exec: function () {/*
     var generator = (function* () {
       yield* (function* () {
@@ -1372,7 +1372,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 },
 {
   name: 'RegExp "y" flag',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky',
   exec: function () {/*
     var re = new RegExp('\\w');
     var re2 = new RegExp('\\w', 'y');
@@ -1469,40 +1469,35 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Typed Arrays',
+  name: 'typed arrays',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects',
-  exec: function () {
-    try {
-      var buffer = new ArrayBuffer(64);
-      var passed = true;
-      var view;
-      
-      // Check that each int type overflows as expected.
-      view = new Int8Array(buffer);         view[0] = 0x80;
-      passed &= view[0] === -0x80;
-      view = new Uint8Array(buffer);        view[0] = 0x100;
-      passed &= view[0] === 0;
-      view = new Uint8ClampedArray(buffer); view[0] = 0x100;
-      passed &= view[0] === 0xFF;
-      view = new Int16Array(buffer);        view[0] = 0x8000;
-      passed &= view[0] === -0x8000;
-      view = new Uint16Array(buffer);       view[0] = 0x10000;
-      passed &= view[0] === 0;
-      view = new Int32Array(buffer);        view[0] = 0x80000000;
-      passed &= view[0] === -0x80000000;
-      view = new Uint32Array(buffer);       view[0] = 0x100000000;
-      passed &= view[0] === 0;
-      // Check that each float type loses precision as expected.
-      view = new Float32Array(buffer);      view[0] = 0.1;
-      passed &= view[0] === 0.10000000149011612;
-      view = new Float64Array(buffer);      view[0] = 0.1;
-      passed &= view[0] === 0.1;
-      return passed;
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+	var buffer = new ArrayBuffer(64);
+	var passed = true;
+	var view;
+
+	// Check that each int type overflows as expected.
+	view = new Int8Array(buffer);         view[0] = 0x80;
+	passed &= view[0] === -0x80;
+	view = new Uint8Array(buffer);        view[0] = 0x100;
+	passed &= view[0] === 0;
+	view = new Uint8ClampedArray(buffer); view[0] = 0x100;
+	passed &= view[0] === 0xFF;
+	view = new Int16Array(buffer);        view[0] = 0x8000;
+	passed &= view[0] === -0x8000;
+	view = new Uint16Array(buffer);       view[0] = 0x10000;
+	passed &= view[0] === 0;
+	view = new Int32Array(buffer);        view[0] = 0x80000000;
+	passed &= view[0] === -0x80000000;
+	view = new Uint32Array(buffer);       view[0] = 0x100000000;
+	passed &= view[0] === 0;
+	// Check that each float type loses precision as expected.
+	view = new Float32Array(buffer);      view[0] = 0.1;
+	passed &= view[0] === 0.10000000149011612;
+	view = new Float64Array(buffer);      view[0] = 0.1;
+	passed &= view[0] === 0.1;
+	return passed;
+  */},
   res: {
     tr:          false,
     ejs:         true,
@@ -1545,28 +1540,23 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Typed Arrays (DataView)',
+  name: 'typed arrays (DataView)',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-dataview-objects',
-  exec: function () {
-    try {
-      var buffer = new ArrayBuffer(64);
-      var view = new DataView(buffer);
-      var passed = true;
-      
-      view.setInt8 (0, 0x80);        passed &= view.getInt8(0)   === -0x80;
-      view.setUint8(0, 0x100);       passed &= view.getUint8(0)  === 0;
-      view.setInt16(0, 0x8000);      passed &= view.getInt16(0)  === -0x8000;
-      view.setUint16(0,0x10000);     passed &= view.getUint16(0) === 0;
-      view.setInt32(0, 0x80000000);  passed &= view.getInt32(0)  === -0x80000000;
-      view.setUint32(0,0x100000000); passed &= view.getUint32(0) === 0;
-      view.setFloat32(0, 0.1);       passed &= view.getFloat32(0)=== 0.10000000149011612;
-      view.setFloat64(0, 0.1);       passed &= view.getFloat64(0)=== 0.1;
-      return passed;
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+	var buffer = new ArrayBuffer(64);
+	var view = new DataView(buffer);
+	var passed = true;
+
+	view.setInt8 (0, 0x80);        passed &= view.getInt8(0)   === -0x80;
+	view.setUint8(0, 0x100);       passed &= view.getUint8(0)  === 0;
+	view.setInt16(0, 0x8000);      passed &= view.getInt16(0)  === -0x8000;
+	view.setUint16(0,0x10000);     passed &= view.getUint16(0) === 0;
+	view.setInt32(0, 0x80000000);  passed &= view.getInt32(0)  === -0x80000000;
+	view.setUint32(0,0x100000000); passed &= view.getUint32(0) === 0;
+	view.setFloat32(0, 0.1);       passed &= view.getFloat32(0)=== 0.10000000149011612;
+	view.setFloat64(0, 0.1);       passed &= view.getFloat64(0)=== 0.1;
+	return passed;
+  */},
   res: {
     tr:          false,
     ejs:         true,
@@ -2001,7 +1991,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 },
 {
   name: 'Block-level function declaration',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:block_functions',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
   exec: function () {/*
     'use strict';
     {
@@ -2103,8 +2093,8 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Destructuring',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
+  name: 'destructuring',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment',
   exec: function () {/*
     // Array destructuring
     var [a, , [b], g] = [5, null, [6]];
@@ -2159,8 +2149,8 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Destructuring parameters',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
+  name: 'destructuring parameters',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment',
   exec: function () {/*
     return (function({a, x:b}, [c, d]) {
       return a === 1 && b === 2 && c === 3 && d === 4;
@@ -2208,8 +2198,8 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Destructuring defaults',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
+  name: 'destructuring defaults',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment',
   exec: function () {/*
     var {a = 1, b = 1, c = 3} = {b:2, c:undefined};
     return a === 1 && b === 2 && c === 3;
@@ -2256,8 +2246,8 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   }
 },
 {
-  name: 'Destructuring rest',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
+  name: 'destructuring rest',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment',
   exec: function () {/*
     var [a, ...b] = [3, 4, 5];
     var [c, ...d] = [6];
@@ -3335,15 +3325,12 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.hasInstance',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    if (typeof Symbol === "function" && typeof Symbol.hasInstance === "symbol") {
-      var a = 2, b = function(){};
-      b[Symbol.hasInstance] = function() { a = 4; return false; };
-      ({}) instanceof b;
-      return a === 4;
-    }
-    return false;
-  },
+  exec: function() {/*
+    var a = 2, b = function(){};
+    b[Symbol.hasInstance] = function() { a = 4; return false; };
+    ({}) instanceof b;
+    return a === 4;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -3388,15 +3375,12 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.isConcatSpreadable',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    if (typeof Symbol === "function" && typeof Symbol.isConcatSpreadable === "symbol") {
-      var a = [], b = [];
-      b[Symbol.isConcatSpreadable] = false;
-      a = a.concat(b);
-      return a[0] === b;
-    }
-    return false;
-  },
+  exec: function() {/*
+    var a = [], b = [];
+    b[Symbol.isConcatSpreadable] = false;
+    a = a.concat(b);
+    return a[0] === b;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -3441,10 +3425,9 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.isRegExp',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    return typeof Symbol === "function" && typeof Symbol.isRegExp === "symbol"
-      && RegExp.prototype[Symbol.isRegExp] === true;
-  },
+  exec: function() {/*
+    return RegExp.prototype[Symbol.isRegExp] === true;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -3489,27 +3472,22 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.iterator',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    try {
-      var a = 0, b = {};
-      b[Symbol.iterator] = function() {
-        return {
-          next: function() {
-            return {
-              done: a === 1,
-              value: a++
-            };
-          }
-        };
-      };
-      var c;
-      eval("for (c of b) {}");
-      return c === 0;
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    var a = 0, b = {};
+    b[Symbol.iterator] = function() {
+      return {
+	    next: function() {
+		  return {
+		    done: a === 1,
+		    value: a++
+		  };
+	    }
+	  };
+    };
+    var c;
+    for (c of b) {}
+    return c === 0;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -3554,14 +3532,11 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.toPrimitive',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    if (typeof Symbol === "function" && typeof Symbol.toPrimitive === "symbol") {
-      var a = {};
-      a[Symbol.toPrimitive] = function() { return 7; };
-      return a == 7;
-    }
-    return false;
-  },
+  exec: function() {/*
+    var a = {};
+    a[Symbol.toPrimitive] = function() { return 7; };
+    return a == 7;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -3606,14 +3581,11 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.toStringTag',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    if (typeof Symbol === "function" && typeof Symbol.toStringTag === "symbol") {
-      var a = {};
-      a[Symbol.toStringTag] = "foo";
-      return (a + "") === "[object foo]";
-    }
-    return false;
-  },
+  exec: function() {/*
+    var a = {};
+    a[Symbol.toStringTag] = "foo";
+    return (a + "") === "[object foo]";
+  */},
   res: {
     tr:          false,
     ejs:         true,
@@ -3658,16 +3630,13 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Symbol.unscopables',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
-  exec: function() {
-    if (typeof Symbol === "function" && typeof Symbol.unscopables === "symbol") {
-      var a = { foo: 1, bar: 2 };
-      a[Symbol.unscopables] = { bar: true };
-      with (a) {
-        return foo === 1 && typeof bar === "undefined";
-      }
+  exec: function() {/*
+    var a = { foo: 1, bar: 2 };
+    a[Symbol.unscopables] = { bar: true };
+    with (a) {
+      return foo === 1 && typeof bar === "undefined";
     }
-    return false;
-  },
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -4379,17 +4348,14 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
 {
   name: 'Array.prototype[Symbol.unscopables]',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype-@@unscopables',
-  exec: function () {
-    if (typeof Symbol !== "function") return false;
-    if (typeof Symbol.unscopables !== "symbol") return false;
+  exec: function () {/*
     var unscopables = Array.prototype[Symbol.unscopables];
-    if (!unscopables) return false;
     var ns = "find,findIndex,fill,copyWithin,entries,keys,values".split(",");
     for (var i = 0; i < ns.length; i++) {
       if (!unscopables[ns[i]]) return false;
     }
     return true;
-  },
+  */},
   res: {
     tr:          false,
     ejs:         false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -439,20 +439,17 @@ exports.tests = [
 {
   name: 'default function parameters',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
-  exec: function () {
-    try {
-      return !!Function(
-         'var passed = (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));'
-         // explicit undefined will defer to the default
-        +'passed    &= (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));'
-         // defaults can refer to previous parameters
-        +'passed    &= (function (a, b = a) { return b === 5; }(5));'
-        +'return passed;'
-        )();
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var passed = (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));
+    
+    // explicit undefined will defer to the default
+    passed    &= (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));
+    
+    // defaults can refer to previous parameters
+    passed    &= (function (a, b = a) { return b === 5; }(5));
+    
+    return passed;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -741,40 +738,34 @@ exports.tests = [
 {
   name: 'super',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword',
-  exec: function () {
-    try {
-      var passed = false;
-      var B = eval(
-         "class extends class {"
-        +"  constructor(a) { return this.id + a; }"
-        +"  foo(a)         { return a + this.id; }"
-        +"} {"
-        +"  constructor(a) {"
-        +"    this.id = 'AB';"
-          // "super" in the constructor calls
-          // the superclass's constructor on "this".
-        +"    passed  = super(a)     === 'ABCD';"
-          // "super" can be also used to call
-          // superclass methods on "this".
-        +"    passed &= super.foo(a) === 'CDAB';"
-        +"  }"
-        +"  foo(a) {"
-          // "super" in methods calls the
-          // superclass's same-named method on "this".
-        +"    passed &= super(a) === 'YZEF';"
-        +"    passed &= super(a) === super.foo(a);"
-        +"  }"
-        +"}"
-      );
-      var b = new B("CD");
-      // "super" is bound statically, even though "this" isn't
-      var obj = { foo: b.foo, id:"EF" };
-      obj.foo("YZ");
-      return passed;
-    } catch (e) {
-      return false;
+  exec: function () {/*
+    var passed = true;
+    var B = class extends class {
+      constructor(a) { return this.id + a; }
+      foo(a)         { return a + this.id; }
+    } {
+      constructor(a) {
+        this.id = 'AB';
+        // "super" in the constructor calls
+        // the superclass's constructor on "this".
+        passed &= super(a)     === 'ABCD';
+        // "super" can be also used to call
+        // superclass methods on "this".
+        passed &= super.foo(a) === 'CDAB';
+      }
+      foo(a) {
+        // "super" in methods calls the
+        // superclass's same-named method on "this".
+        passed &= super(a) === 'YZEF';
+        passed &= super(a) === super.foo(a);
+      }
     }
-  },
+    var b = new B("CD");
+    // "super" is bound statically, even though "this" isn't
+    var obj = { foo: b.foo, id:"EF" };
+    obj.foo("YZ");
+    return passed;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -820,6 +811,7 @@ exports.tests = [
   name: 'computed properties',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
   exec: function() {/*
+    var x = 'y';
     return ({ [x]: 1 })['y'] === 1;
   */},
   res: {
@@ -1020,13 +1012,10 @@ exports.tests = [
 {
   name: 'modules',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:modules',
-  exec: function () {
-    try {
-      return eval('export var foo = 1;');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    export var foo = 1;
+    return true;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1120,28 +1109,21 @@ exports.tests = [
 {
   name: 'Generators (yield)',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:generators',
-  exec: function () {
-    try {
-      var generator = eval(
-         '(function* () {'
-        +'  yield* (function* () {'
-        +'    yield 5; yield 6;'
-        +'  }());'
-        +'}())'
-      );
-      
-      var item = generator.next();
-      var passed = item.value === 5 && item.done === false;
-      item = generator.next();
-      passed    &= item.value === 6 && item.done === false;
-      item = generator.next();
-      passed    &= item.value === undefined && item.done === true;
-      
-      return passed;
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var generator = (function* () {
+      yield* (function* () {
+        yield 5; yield 6;
+      }());
+    }());
+    
+    var item = generator.next();
+    var passed = item.value === 5 && item.done === false;
+    item = generator.next();
+    passed    &= item.value === 6 && item.done === false;
+    item = generator.next();
+    passed    &= item.value === undefined && item.done === true;
+	return passed;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -1186,13 +1168,9 @@ exports.tests = [
 {
   name: 'octal literals',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals',
-  exec: function () {
-    try {
-      return eval('0o10') === 8 && eval('0O10') === 8;
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return 0o10 === 8 && 0O10 === 8;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -1241,13 +1219,9 @@ exports.tests = [
 {
   name: 'binary literals',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals',
-  exec: function () {
-    try {
-      return eval('0b10') === 2 && eval('0B10') === 2;
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return 0b10 === 2 && 0B10 === 2;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -1292,14 +1266,11 @@ exports.tests = [
 {
   name: 'template strings',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals',
-  exec: function () {
-    try {
-      var a = "ba", b = "QUX";
-      return eval('`foo bar\n${a + "z"} ${b.toLowerCase()}`') === "foo bar\nbaz qux";
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var a = "ba", b = "QUX";
+    return `foo bar
+${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1344,24 +1315,20 @@ exports.tests = [
 {
   name: 'tagged template strings',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals',
-  exec: function () {
-    try {
-      var called = false;
-      function fn(parts, a, b) {
-        called = true;
-        return parts instanceof Array &&
-          parts[0]     === "foo"      &&
-          parts[1]     === "bar\n"    &&
-          parts.raw[0] === "foo"      &&
-          parts.raw[1] === "bar\\n"   &&
-          a === 123                   &&
-          b === 456;
-      }
-      return eval('fn `foo${123}bar\\n${456}`') && called;
-    } catch (e) {
-      return false;
+  exec: function () {/*
+    var called = false;
+    function fn(parts, a, b) {
+      called = true;
+      return parts instanceof Array &&
+        parts[0]     === "foo"      &&
+        parts[1]     === "bar\n"    &&
+        parts.raw[0] === "foo"      &&
+        parts.raw[1] === "bar\\n"   &&
+        a === 123                   &&
+        b === 456;
     }
-  },
+    return fn `foo${123}bar\n${456}` && called;
+  */},
   res: {
     tr:          true,
     ejs:         true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -812,7 +812,7 @@ exports.tests = [
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
   exec: function() {/*
     var x = 'y';
-    return ({ [x]: 1 })['y'] === 1;
+    return ({ [x]: 1 }).y === 1;
   */},
   res: {
     tr:          true,
@@ -1122,7 +1122,7 @@ exports.tests = [
     passed    &= item.value === 6 && item.done === false;
     item = generator.next();
     passed    &= item.value === undefined && item.done === true;
-	return passed;
+    return passed;
   */},
   res: {
     tr:          true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -211,19 +211,15 @@ exports.tests = [
 {
   name: 'proper tail calls (tail call optimisation)',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls',
-  exec: function() {
+  exec: function() {/*
     "use strict";
-    try {
-      return (function f(n){
-        if (n <= 0) {
-          return  "foo";
-        }
-        return f(n - 1);
-      }(1e6)) === "foo";
-    } catch (e) {
-      return false;
-    }
-  },
+    return (function f(n){
+      if (n <= 0) {
+        return  "foo";
+      }
+      return f(n - 1);
+    }(1e6)) === "foo";
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -501,13 +497,9 @@ exports.tests = [
 {
   name: 'rest parameters',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:rest_parameters',
-  exec: function () {
-    try {
-      return eval('(function (...args) { return typeof args !== "undefined"; }())');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return (function (...args) { return typeof args !== "undefined"; }())
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -552,13 +544,9 @@ exports.tests = [
 {
   name: 'spread call (...) operator',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
-  exec: function () {
-    try {
-      return eval('Math.max(...[1, 2, 3]) === 3');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return Math.max(...[1, 2, 3]) === 3
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -603,13 +591,9 @@ exports.tests = [
 {
   name: 'spread array (...) operator',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
-  exec: function () {
-    try {
-      return eval('[...[1, 2, 3]][2] === 3');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return [...[1, 2, 3]][2] === 3;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -654,13 +638,9 @@ exports.tests = [
 {
   name: 'string spreading',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:spread',
-  exec: function () {
-    try {
-      return eval('["a", ..."bcd", "e"][3] === "d" && Math.max(..."1234") === 4');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return ["a", ..."bcd", "e"][3] === "d" && Math.max(..."1234") === 4;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -709,19 +689,14 @@ exports.tests = [
 {
   name: 'class',
   link: 'http://wiki.ecmascript.org/doku.php?id=strawman:maximally_minimal_classes',
-  exec: function () {
-    try {
-      return eval(
-         'class C extends Array {'
-        +'  constructor() { this.b = true; }'
-        +'  a(){}'
-        +'  static d(){}'
-        +'}'
-        +'C.d && new C().a && new C().b && new C() instanceof Array');
-    } catch (e) {
-      return false;
+  exec: function () {/*
+    class C extends Array {
+      constructor() { this.b = true; }
+      a(){}
+      static d(){}
     }
-  },
+    return C.d && new C().a && new C().b && new C() instanceof Array;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -844,15 +819,9 @@ exports.tests = [
 {
   name: 'computed properties',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
-  exec: function() {
-    try {
-      var x = 'y';
-      return eval("({ [x]: 1 })['y'] === 1");
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return ({ [x]: 1 })['y'] === 1;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -897,14 +866,10 @@ exports.tests = [
 {
   name: 'shorthand properties',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
-  exec: function() {
-    try {
-      return eval("var a = 7, b = 8, c = {a,b}; c.a === 7 && c.b === 8");
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var a = 7, b = 8, c = {a,b};
+    return c.a === 7 && c.b === 8;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -949,14 +914,9 @@ exports.tests = [
 {
   name: 'shorthand methods',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
-  exec: function() {
-    try {
-      return eval("({ y() { return 2; } }).y() === 2");
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return ({ y() { return 2; } }).y() === 2;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1111,13 +1071,11 @@ exports.tests = [
 {
   name: 'For..of loops',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:iterators',
-  exec: function () {
-    try {
-      return eval('(function () { var arr = [5]; for (var item of arr) return item === 5; }())');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var arr = [5];
+    for (var item of arr)
+      return item === 5;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1448,17 +1406,13 @@ exports.tests = [
 {
   name: 'RegExp "y" flag',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:regexp_y_flag',
-  exec: function () {
-    try {
-      var re = new RegExp('\\w');
-      var re2 = new RegExp('\\w', 'y');
-      re.exec('xy');
-      re2.exec('xy');
-      return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var re = new RegExp('\\w');
+    var re2 = new RegExp('\\w', 'y');
+    re.exec('xy');
+    re2.exec('xy');
+    return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -1503,14 +1457,9 @@ exports.tests = [
 {
   name: 'RegExp "u" flag',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode',
-  exec: function() {
-    try {
-      return eval('"𠮷".match(/./u)[0].length === 2');
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    return "𠮷".match(/./u)[0].length === 2;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -1695,16 +1644,15 @@ exports.tests = [
 {
   name: 'Map',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects',
-  exec: function () {
-    try {
-      var map = new Map();
-      map.set('key', 123);
-      return map.has("key") && map.get('key') === 123 && map.size === 1;
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var key = {};
+    var map = new Map();
+    
+    map.set(key, 123);
+    
+    return map.has(key) && map.get(key) === 123 &&
+           map.size === 1;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1753,16 +1701,15 @@ exports.tests = [
 {
   name: 'Set',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects',
-  exec: function () {
-    try {
-      var set = new Set();
-      set.add(123);
-      return set.has(123) && set.size === 1;
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var obj = {};
+    var set = new Set();
+    
+    set.add(123);
+    set.add(123);
+    
+    return set.has(123) && set.size === 1;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -1807,17 +1754,14 @@ exports.tests = [
 {
   name: 'WeakMap',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects',
-  exec: function () {
-    try {
-      var weakMap = new WeakMap();
-      var key = [1,2,3];
-      weakMap.set(key, 123);
-      return weakMap.has(key) && weakMap.get(key) === 123;
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var key1 = {};
+    var weakmap = new WeakMap();
+    
+    weakmap.set(key1, 123);
+    
+    return weakmap.has(key1) && weakmap.get(key1) === 123;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -1866,16 +1810,15 @@ exports.tests = [
 {
   name: 'WeakSet',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects',
-  exec: function () {
-    try {
-      var set = new WeakSet(), obj = { };
-      set.add(obj);
-      return set.has(obj);
-    }
-    catch(err) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var obj1 = {}, obj2 = {};
+    var weakset = new WeakSet();
+    
+    weakset.add(obj1);
+    weakset.add(obj1);
+    
+    return weakset.has(obj1);
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -2092,14 +2035,13 @@ exports.tests = [
 {
   name: 'Block-level function declaration',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:block_functions',
-  exec: function () {
+  exec: function () {/*
     'use strict';
-    try {
-      return eval('{function f(){}} typeof f == "undefined"');
-    } catch (e) {
-      return false;
+    {
+      function f(){}
     }
-  },
+    return typeof f === "undefined";
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -2145,19 +2087,13 @@ exports.tests = [
   name: 'Hoisted block-level function declaration',
   annex_b: true,
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics',
-  exec: function () {
+  exec: function () {/*
     // Note: only available outside of strict mode.
-    try {
-      return !!Function(
-         'var passed = f() === 2 && g() === 4;'
-        +'if (true) { function f(){ return 1; } } else { function f(){ return 2; } }'
-        +'if (false){ function g(){ return 3; } } else { function g(){ return 4; } }'
-        +'return passed;'
-      )();
-    } catch (e) {
-      return false;
-    }
-  },
+    var passed = f() === 2 && g() === 4;
+    if (true) { function f(){ return 1; } } else { function f(){ return 2; } }
+    if (false){ function g(){ return 3; } } else { function g(){ return 4; } }
+    return passed;
+  */},
   res: {
     tr:          false,
     ejs:         false,
@@ -2202,22 +2138,18 @@ exports.tests = [
 {
   name: 'Destructuring',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
-  exec: function () {
-    'use strict';
-    try {
-      return eval(
-        // Array destructuring
-         'var [a, , [b], g] = [5, null, [6]];'
-        // Object destructuring
-        +'var {c, x:d, h} = {c:7, x:8};'
-        // Combined destructuring
-        +'var [e, {x:f, i}] = [9, {x:10}];'
-        +'a === 5 && b === 6 && c === 7 && d === 8 && e === 9 && f === 10 &&'
-        +'g === undefined && h === undefined && i === undefined');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    // Array destructuring
+    var [a, , [b], g] = [5, null, [6]];
+    // Object destructuring
+    var {c, x:d, h} = {c:7, x:8};
+    // Combined destructuring
+    var [e, {x:f, i}] = [9, {x:10}];
+    
+    return a === 5 && b === 6 && c === 7 &&
+           d === 8 && e === 9 && f === 10 &&
+           g === undefined && h === undefined && i === undefined;
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -2262,18 +2194,11 @@ exports.tests = [
 {
   name: 'Destructuring parameters',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
-  exec: function () {
-    'use strict';
-    try {
-      return eval(
-         '(function({a, x:b}, [c, d]) {'
-        +'  return a === 1 && b === 2 && c === 3 && d === 4;'
-        +'}({a:1, x:2},[3, 4]))'
-      );
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return (function({a, x:b}, [c, d]) {
+      return a === 1 && b === 2 && c === 3 && d === 4;
+    }({a:1, x:2},[3, 4]));
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -2318,17 +2243,10 @@ exports.tests = [
 {
   name: 'Destructuring defaults',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
-  exec: function () {
-    'use strict';
-    try {
-      return eval(
-         'var {a = 1, b = 1, c = 3} = {b:2, c:undefined};'
-        +'a === 1 && b === 2 && c === 3'
-      );
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var {a = 1, b = 1, c = 3} = {b:2, c:undefined};
+    return a === 1 && b === 2 && c === 3;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -2373,19 +2291,12 @@ exports.tests = [
 {
   name: 'Destructuring rest',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:destructuring',
-  exec: function () {
-    'use strict';
-    try {
-      return eval(
-         'var [a, ...b] = [3, 4, 5];'
-        +'var [c, ...d] = [6];'
-        +'a === 3 && b instanceof Array && (b + "") === "4,5" && '
-        +'c === 6 && d instanceof Array && d.length === 0'
-      );
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var [a, ...b] = [3, 4, 5];
+    var [c, ...d] = [6];
+    return a === 3 && b instanceof Array && (b + "") === "4,5" &&
+           c === 6 && d instanceof Array && d.length === 0;
+  */},
   res: {
     tr:          true,
     ejs:         false,
@@ -2769,8 +2680,8 @@ exports.tests = [
 {
   name: 'Function.prototype.toMethod',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod',
-  exec: function f() {
-    return typeof f.toMethod === "function";
+  exec: function () {
+    return typeof Function.prototype.toMethod === "function";
   },
   res: {
     tr:          false,
@@ -3249,13 +3160,9 @@ exports.tests = [
 {
   name: 'Unicode code point escapes',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals',
-  exec: function () {
-    try {
-      return eval("'\\u{1d306}' == '\\ud834\\udf06'");
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return '\u{1d306}' == '\ud834\udf06';
+  */},
   res: {
     tr:          true,
     ejs:         true,
@@ -3359,16 +3266,11 @@ exports.tests = [
 {
   name: 'Global symbol registry',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol.for',
-  exec: function() {
-    try {
-      var symbol = Symbol.for('foo');
-      return Symbol.for('foo') === symbol &&
-             Symbol.keyFor(symbol) === 'foo';
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function() {/*
+    var symbol = Symbol.for('foo');
+    return Symbol.for('foo') === symbol &&
+           Symbol.keyFor(symbol) === 'foo';
+  */},
   res: {
     tr:          false,
     ejs:         true,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -434,7 +434,7 @@ exports.tests = [
   name: '__defineGetter__',
   link: 'https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter',
   exec: function () {
-    return '__defineGetter__' in ({ });
+    return '__defineGetter__' in {};
   },
   res: {
     ie7: false,
@@ -466,7 +466,7 @@ exports.tests = [
   name: '__defineSetter__',
   link: 'https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter',
   exec: function () {
-    return '__defineSetter__' in ({ });
+    return '__defineSetter__' in {};
   },
   res: {
     ie7: false,
@@ -632,13 +632,9 @@ exports.tests = [
 },
 {
   name: 'Expression closures',
-  exec: function () {
-    try {
-      return eval('(function(x)x)(1)') === 1;
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return (function(x)x)(1) === 1;
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -668,13 +664,9 @@ exports.tests = [
 {
   name: 'ECMAScript for XML (E4X)',
   link: 'https://developer.mozilla.org/en-US/docs/Archive/Web/E4X',
-  exec: function () {
-    try {
-      return eval('typeof <foo/> === "xml"');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return typeof <foo/> === "xml";
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -742,13 +734,10 @@ exports.tests = [
 {
   name: 'Sharp variables',
   link: 'https://developer.mozilla.org/en/Sharp_variables_in_JavaScript',
-  exec: function () {
-    try {
-      return eval('(function () { var arr = #1=[1, #1#, 3]; return arr[1] === arr; }())');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var arr = #1=[1, #1#, 3]; 
+	return arr[1] === arr;
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -1074,13 +1063,9 @@ exports.tests = [
 },
 {
   name: 'Callable RegExp',
-  exec: function () {
-    try {
-      return eval('/\\w/("x")[0] === "x"');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return /\\w/("x")[0] === "x";
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -1109,13 +1094,9 @@ exports.tests = [
 },
 {
   name: 'RegExp named groups',
-  exec: function () {
-    try {
-      return eval('/(?P<name>a)(?P=name)/.test("aa")');
-    } catch (e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    return /(?P<name>a)(?P=name)/.test("aa");
+  */},
   res: {
     ie7: false,
     ie11: false,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -595,15 +595,11 @@ exports.tests = [
 {
   name: 'Array comprehensions (right-to-left)',
   link: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions',
-  exec: function () {
-    try {
-      var a = eval('[i * 2 for (i in { 2: true, "foo": true, 4: true }) if (i !== "foo")]');
-      return a instanceof Array && a[0] === 4 && a[1] === 8;
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var obj = { 2: true, "foo": true, 4: true };
+    var a = [i * 2 for (i in obj) if (i !== "foo")];
+    return a instanceof Array && a[0] === 4 && a[1] === 8;
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -696,15 +692,13 @@ exports.tests = [
 {
   name: '"for each..in" loops',
   link: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in',
-  exec: function () {
+  exec: function () {/*
     var str = '';
-    try {
-      eval('for each (var item in {a: "foo", b: "bar", c: "baz"}) { str += item; }');
-      return str === "foobarbaz";
-    } catch(e) {
-      return false;
-    }
-  },
+    for each (var item in {a: "foo", b: "bar", c: "baz"}) {
+	  str += item;
+	}
+    return str === "foobarbaz";
+  */},
   res: {
     ie7: false,
     ie11: false,
@@ -920,15 +914,11 @@ exports.tests = [
 {
   name: 'Generator comprehensions (JS 1.8)',
   link: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions',
-  exec: function () {
-    try {
-      var g = eval('(i * 2 for (i in { 2: true, "foo": true, 4: true }) if (i !== "foo"))');
-      return g.next() === 4 && g.next() === 8;
-    }
-    catch(e) {
-      return false;
-    }
-  },
+  exec: function () {/*
+    var obj = { 2: true, "foo": true, 4: true };
+    var g = (i * 2 for (i in obj) if (i !== "foo"));
+    return g.next() === 4 && g.next() === 8;
+  */},
   res: {
     ie7: false,
     ie11: false,

--- a/master.js
+++ b/master.js
@@ -56,21 +56,16 @@ domready(function() {
     infoEl.innerHTML = 'c';
     rows[i].cells[0].appendChild(infoEl);
 
-    var tooltipCache = {};
-    
     infoEl.onmouseover = function(e) {
       mouseoverTimeout = null;
-	  
+      
       var scriptEl = this.parentNode.parentNode.getElementsByTagName('script')[0];
       var id = "tooltip_" + this.parentNode.id;
-	  
-      infoTooltip.innerHTML = tooltipCache[id] = tooltipCache[id] || scriptEl.innerHTML
-        // unwrap "multi-line comment" code
-        .replace(/\s*test\(function\(\){try{return Function\((.*?)\)\(\)}catch\(e\){return false;}}\(\)\);\n/, function(_,a){return eval(a);})
-        // unwrap ES5 code
-        .replace(/\s*test\(\(?\s*function\s*\(\)\s*\{/m,'').replace(/\}\s*\(\){2,3}[^\(\)]*$/m,'')
-		// trim sides, and escape <
-        .replace(/^\s*|\s*$/g,'').replace(/</g, '&lt;');
+      
+      infoTooltip.innerHTML = scriptEl.getAttribute('data-source')
+        // trim sides, and escape <
+        .trim().replace(/</g, '&lt;');
+      
       infoTooltip.style.left = e.pageX + 10 + 'px';
       infoTooltip.style.top = e.pageY + 'px';
       infoTooltip.style.display = 'block';

--- a/master.js
+++ b/master.js
@@ -56,10 +56,21 @@ domready(function() {
     infoEl.innerHTML = 'c';
     rows[i].cells[0].appendChild(infoEl);
 
+    var tooltipCache = {};
+    
     infoEl.onmouseover = function(e) {
       mouseoverTimeout = null;
+	  
       var scriptEl = this.parentNode.parentNode.getElementsByTagName('script')[0];
-      infoTooltip.innerHTML = scriptEl.innerHTML.replace(/^\n/, '').replace(/</g, '&lt;');
+      var id = "tooltip_" + this.parentNode.id;
+	  
+      infoTooltip.innerHTML = tooltipCache[id] = tooltipCache[id] || scriptEl.innerHTML
+        // unwrap "multi-line comment" code
+        .replace(/\s*test\(function\(\){try{return Function\((.*?)\)\(\)}catch\(e\){return false;}}\(\)\);\n/, function(_,a){return eval(a);})
+        // unwrap ES5 code
+        .replace(/\s*test\(\(?\s*function\s*\(\)\s*\{/m,'').replace(/\}\s*\(\){2,3}[^\(\)]*$/m,'')
+		// trim sides, and escape <
+        .replace(/^\s*|\s*$/g,'').replace(/</g, '&lt;');
       infoTooltip.style.left = e.pageX + 10 + 'px';
       infoTooltip.style.top = e.pageY + 'px';
       infoTooltip.style.display = 'block';


### PR DESCRIPTION
This updates the build script, allowing it to interpret ES6 code expressed in function comments instead of concatenated strings (see #190 iscussion) - which is then wrapped in try-catch, eval() and test() structures automatically.

Also, the runtime script has been updated to unwrap those same structures for the tooltip preview, making the resulting display cleaner - lacking even the test() call wrapper.

Only some ES6 and non-standard tests have been converted to make use of this format, for the moment. The remaining tests are the subjects of various pull-requests currently. If those other requests are resolved, conversion of those tests may then be done.

NOTE: as this drastically affects the output of all HTML files, they have not been included in this commit, to allow branch-merging to pass smoothly. A new build commit will thus have to be done after the merge.
