### PR TITLE
Updated the generator test to include yield*

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1077,37 +1077,28 @@ exports.tests = [
 {
   name: 'Generators (yield)',
   link: 'http://wiki.ecmascript.org/doku.php?id=harmony:generators',
-  exec: [
-    {
-      type: 'application/javascript;version=1.8',
-      script: function () {
-        test((function () {
-          try {
-            eval('(function* () { yield 5; }())');
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }()));
-        global.__yield_script_executed = true;
-      }
-    },
-    {
-      script: function () {
-        if (!global.__yield_script_executed) {
-          test((function () {
-            try {
-              eval('(function* () { yield 5; }())');
-              return true;
-            } catch (e) {
-              return false;
-            }
-          }()));
-          global.__yield_script_executed = true;
-        }
-      }
+  exec: function () {
+    try {
+      var generator = eval(
+         '(function* () {'
+        +'  yield* (function* () {'
+        +'    yield 5; yield 6;'
+        +'  }());'
+        +'}())'
+      );
+      
+      var item = generator.next();
+      var passed = item.value === 5 && item.done === false;
+      item = generator.next();
+      passed    &= item.value === 6 && item.done === false;
+      item = generator.next();
+      passed    &= item.value === undefined && item.done === true;
+      
+      return passed;
+    } catch (e) {
+      return false;
     }
-  ],
+  },
   res: {
     tr:          true,
     ejs:         false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -890,29 +890,29 @@ test(function () {
         </tr>
         <tr>
           <td id="Generators_(yield)"><span><a class="anchor" href="#Generators_(yield)">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:generators">Generators (yield)</a></span></td>
-<script type="application/javascript;version=1.8">
-test((function () {
+<script>
+test(function () {
   try {
-    eval('(function* () { yield 5; }())');
-    return true;
+    var generator = eval(
+       '(function* () {'
+      +'  yield* (function* () {'
+      +'    yield 5; yield 6;'
+      +'  }());'
+      +'}())'
+    );
+    
+    var item = generator.next();
+    var passed = item.value === 5 && item.done === false;
+    item = generator.next();
+    passed    &= item.value === 6 && item.done === false;
+    item = generator.next();
+    passed    &= item.value === undefined && item.done === true;
+    
+    return passed;
   } catch (e) {
     return false;
   }
-}()));
-global.__yield_script_executed = true;
-</script>
-<script>
-if (!global.__yield_script_executed) {
-  test((function () {
-    try {
-      eval('(function* () { yield 5; }())');
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }()));
-  global.__yield_script_executed = true;
-}
+}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -2763,9 +2763,7 @@ test(function () {
         }
       };
     };
-    var c;
-    eval("for (c of b) {}");
-    return c === 0;
+    return Function("for (var c of b) { return c === 0; } return false;")();
   }
   catch(e) {
     return false;
@@ -2919,7 +2917,7 @@ test(function () {
 test(function () {
   if (typeof Symbol === "function" && typeof Symbol.unscopables === "symbol") {
     var a = { foo: 1, bar: 2 };
-    a[Symbol.unscopables] = { bar: true };
+    a[Symbol.unscopables] = ["bar"];
     with (a) {
       return foo === 1 && typeof bar === "undefined";
     }


### PR DESCRIPTION
The `yield*` keyword, as you know, successively yields values from the given iterable until it's exhausted.

This also removes the `application/javascript;version=1.8` version of the test, which doesn't seem to have affected past Firefox's support for this feature.

This test change doesn't alter any of the support results.
