### PR TITLE
Altered WeakMap note regarding WeakSet in Firefox

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1625,7 +1625,7 @@ exports.tests = [
     ie11:        {
       val: true,
       note_id: 'weakmap-constructor',
-      note_html: 'WeakMap and WeakSet constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.'
+      note_html: 'WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.'
     },
     firefox11:   false,
     firefox13:   false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -5148,7 +5148,7 @@ test(typeof RegExp.prototype.compile === 'function');
         <sup>[5]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.
       </p>
       <p id="weakmap-constructor-note">
-        <sup>[6]</sup> WeakMap and WeakSet constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
+        <sup>[6]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
       </p>
       <p id="fx-array-prototype-values-note">
         <sup>[7]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>


### PR DESCRIPTION
FF Nightly 34's WeakSet allows constructor arguments, even though WeakMap seemingly doesn't - `new WeakSet([Math]).has(Math)` returns true, even though `new WeakMap([[Math,1]]).has(Math)` doesn't.
