### PR TITLE
ES5: Added parseInt("010") test results

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -22,7 +22,7 @@ exports.browsers = {
   },
   ie10: {
     full: 'Internet Explorer 10, 11',
-    short: 'IE 10, 11',
+    short: 'IE 10+',
     obsolete: false
   },
 
@@ -37,8 +37,13 @@ exports.browsers = {
     obsolete: true
   },
   firefox4: {
-    full: 'Firefox 4+',
-    short: 'FF 4+',
+    full: 'Firefox 4-20',
+    short: 'FF 4-20',
+    obsolete: true
+  },
+  firefox21: {
+    full: 'Firefox 21+',
+    short: 'FF 21+',
     obsolete: false
   },
 
@@ -60,11 +65,11 @@ exports.browsers = {
   safari51: {
     full: 'Safari 5.1.4',
     short: 'SF 5.1.4',
-    obsolete: false
+    obsolete: true
   },
   safari6: {
     full: 'Safari 6.0, Safari 7.0',
-    short: 'SF 6,7',
+    short: 'SF 6+',
     obsolete: false
   },
   webkit: {
@@ -94,8 +99,13 @@ exports.browsers = {
     obsolete: true
   },
   chrome19: {
-    full: 'Chrome 19 (19.0.1084.56 stable), Opera 15+',
-    short: 'CH 19+, OP 15+',
+    full: 'Chrome 19 (19.0.1084.56 stable), Chrome 22',
+    short: 'CH 19-22',
+    obsolete: true
+  },
+  chrome23: {
+    full: 'Chrome 23+, Opera 15+',
+    short: 'CH 23+,<br>OP 15+',
     obsolete: false
   },
 
@@ -177,6 +187,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -190,6 +201,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -225,6 +237,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -242,6 +255,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -272,6 +286,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -285,6 +300,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -315,6 +331,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -328,6 +345,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -358,6 +376,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -371,6 +390,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -401,6 +421,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -414,6 +435,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -444,6 +466,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -457,6 +480,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -487,6 +511,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -500,6 +525,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -530,6 +556,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -543,6 +570,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -573,6 +601,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -586,6 +615,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -616,6 +646,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -629,6 +660,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -664,6 +696,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -677,6 +710,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -707,6 +741,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -720,6 +755,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -751,6 +787,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: true,
@@ -764,6 +801,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -794,6 +832,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: true,
@@ -807,6 +846,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -837,6 +877,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -850,6 +891,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -880,6 +922,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: true,
@@ -893,6 +936,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -923,6 +967,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -936,6 +981,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -966,6 +1012,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -979,6 +1026,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -1010,6 +1058,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1023,6 +1072,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1053,6 +1103,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1066,6 +1117,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1096,6 +1148,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1109,6 +1162,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1139,6 +1193,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1152,6 +1207,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1182,6 +1238,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1195,6 +1252,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1225,6 +1283,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1238,6 +1297,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1268,6 +1328,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1281,6 +1342,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1311,6 +1373,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: true,
@@ -1324,6 +1387,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -1354,6 +1418,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: true,
@@ -1367,6 +1432,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: true,
@@ -1402,6 +1468,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1415,6 +1482,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1451,6 +1519,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1464,6 +1533,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1495,6 +1565,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: true,
     safari4: true,
@@ -1508,6 +1579,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: true,
     opera10_50: true,
@@ -1544,6 +1616,7 @@ exports.tests = [
     firefox3: true,
     firefox3_5: true,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -1557,6 +1630,7 @@ exports.tests = [
     chrome7: true,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -1594,6 +1668,7 @@ exports.tests = [
       note_id: 'zero-width-char',
       note_html: 'Firefox 4 &amp; 5 fail this test'
     },
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -1607,6 +1682,7 @@ exports.tests = [
     chrome7: false,
     chrome13: false,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -1619,6 +1695,51 @@ exports.tests = [
 
     besen: true,
     rhino: true,
+    phantom: false,
+    ejs: true
+  }
+},
+{
+  name: 'parseInt() ignores leading zeros',
+  exec: function () {
+    return parseInt('010') === 10;
+  },
+  res: {
+    ie7: false,
+    ie8: false,
+    ie9: true,
+    ie10: true,
+
+    firefox3: false,
+    firefox3_5: false,
+    firefox4: false,
+    firefox21: true,
+
+    safari3: false,
+    safari4: false,
+    safari5: false,
+    safari51: false,
+    safari6: true,
+    webkit: true,
+
+    chrome5: false,
+    chrome6: false,
+    chrome7: false,
+    chrome13: false,
+    chrome19: false,
+    chrome23: true,
+
+    opera10_10: false,
+    opera10_50: false,
+    opera12: false,
+    opera12_10: false,
+
+    konq43: false,
+    konq49: false,
+    konq413: false,
+
+    besen: true,
+    rhino: false,
     phantom: false,
     ejs: true
   }
@@ -1644,6 +1765,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -1657,6 +1779,7 @@ exports.tests = [
     chrome7: false,
     chrome13: false,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,
@@ -1693,6 +1816,7 @@ exports.tests = [
     firefox3: false,
     firefox3_5: false,
     firefox4: true,
+    firefox21: true,
 
     safari3: false,
     safari4: false,
@@ -1706,6 +1830,7 @@ exports.tests = [
     chrome7: false,
     chrome13: true,
     chrome19: true,
+    chrome23: true,
 
     opera10_10: false,
     opera10_50: false,

--- a/es5/index.html
+++ b/es5/index.html
@@ -69,21 +69,23 @@
             <th class="ie7 obsolete"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></th>
             <th class="ie8 obsolete"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></th>
             <th class="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></th>
-            <th class="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10, 11">IE 10, 11</abbr></th>
+            <th class="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10, 11">IE 10+</abbr></th>
             <th class="firefox3 obsolete"><a href="#firefox3" class="browser-name"><abbr title="Firefox 3">FF 3</abbr></th>
             <th class="firefox3_5 obsolete"><a href="#firefox3_5" class="browser-name"><abbr title="Firefox 3.5, Firefox 3.6">FF 3.5, 3.6</abbr></th>
-            <th class="firefox4"><a href="#firefox4" class="browser-name"><abbr title="Firefox 4+">FF 4+</abbr></th>
+            <th class="firefox4 obsolete"><a href="#firefox4" class="browser-name"><abbr title="Firefox 4-20">FF 4-20</abbr></th>
+            <th class="firefox21"><a href="#firefox21" class="browser-name"><abbr title="Firefox 21+">FF 21+</abbr></th>
             <th class="safari3 obsolete"><a href="#safari3" class="browser-name"><abbr title="Safari 3.2">SF 3.2</abbr></th>
             <th class="safari4 obsolete"><a href="#safari4" class="browser-name"><abbr title="Safari 4.0.5">SF 4</abbr></th>
             <th class="safari5 obsolete"><a href="#safari5" class="browser-name"><abbr title="Safari 5.0.5">SF 5</abbr></th>
-            <th class="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1.4">SF 5.1.4</abbr></th>
-            <th class="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari 6.0, Safari 7.0">SF 6,7</abbr></th>
+            <th class="safari51 obsolete"><a href="#safari51" class="browser-name"><abbr title="Safari 5.1.4">SF 5.1.4</abbr></th>
+            <th class="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari 6.0, Safari 7.0">SF 6+</abbr></th>
             <th class="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r120398 (June 20, 2012)">WebKit</abbr></th>
             <th class="chrome5 obsolete"><a href="#chrome5" class="browser-name"><abbr title="Chrome 5 (5.0.375.127)">CH 5</abbr></th>
             <th class="chrome6 obsolete"><a href="#chrome6" class="browser-name"><abbr title="Chrome 6 (6.0.472.55)">CH 6</abbr></th>
             <th class="chrome7 obsolete"><a href="#chrome7" class="browser-name"><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev), Chrome 10, Chrome 11, Chrome 12 (12.0.742.91)">CH 7-12</abbr></th>
             <th class="chrome13 obsolete"><a href="#chrome13" class="browser-name"><abbr title="Chrome 13 (13.0.782.107 beta), Chrome 14 (14.0.835.8 dev), Chrome 15, Chrome 16 (16.0.891.0 dev)">CH 13-16</abbr></th>
-            <th class="chrome19"><a href="#chrome19" class="browser-name"><abbr title="Chrome 19 (19.0.1084.56 stable), Opera 15+">CH 19+, OP 15+</abbr></th>
+            <th class="chrome19 obsolete"><a href="#chrome19" class="browser-name"><abbr title="Chrome 19 (19.0.1084.56 stable), Chrome 22">CH 19-22</abbr></th>
+            <th class="chrome23"><a href="#chrome23" class="browser-name"><abbr title="Chrome 23+, Opera 15+">CH 23+,<br>OP 15+</abbr></th>
             <th class="opera10_10 obsolete"><a href="#opera10_10" class="browser-name"><abbr title="Opera 10.10">OP 10.1</abbr></th>
             <th class="opera10_50 obsolete"><a href="#opera10_50" class="browser-name"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156), Opera 11.10 (build 2048), Opera 11.11 (build 2109), Opera 11.50 (build 1074)">OP 10.50-11.50</abbr></th>
             <th class="opera12 obsolete"><a href="#opera12" class="browser-name"><abbr title="Opera 12 (build 1065)">OP 12</abbr></th>
@@ -110,18 +112,20 @@ test(typeof Object.create == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -146,18 +150,20 @@ test(typeof Object.defineProperty == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -182,18 +188,20 @@ test(typeof Object.defineProperties == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -218,18 +226,20 @@ test(typeof Object.getPrototypeOf == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -254,18 +264,20 @@ test(typeof Object.keys == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -290,18 +302,20 @@ test(typeof Object.seal == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -326,18 +340,20 @@ test(typeof Object.freeze == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -362,18 +378,20 @@ test(typeof Object.preventExtensions == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -398,18 +416,20 @@ test(typeof Object.isSealed == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -434,18 +454,20 @@ test(typeof Object.isFrozen == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -470,18 +492,20 @@ test(typeof Object.isExtensible == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -506,18 +530,20 @@ test(typeof Object.getOwnPropertyDescriptor == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -542,18 +568,20 @@ test(typeof Object.getOwnPropertyNames == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -567,7 +595,7 @@ test(typeof Object.getOwnPropertyNames == 'function');
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="32" class="separator"></th>
+            <th colspan="34" class="separator"></th>
           </tr>
           <tr>
             <td id="Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&sect;</a>Date.prototype.toISOString</span></td>
@@ -581,18 +609,20 @@ test(typeof Date.prototype.toISOString == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -617,18 +647,20 @@ test(typeof Date.now == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -653,18 +685,20 @@ test(typeof Array.isArray == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -689,18 +723,20 @@ test(typeof JSON == 'object');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -725,18 +761,20 @@ test(typeof Function.prototype.bind == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -761,18 +799,20 @@ test(typeof String.prototype.trim == 'function');
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -786,7 +826,7 @@ test(typeof String.prototype.trim == 'function');
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="32" class="separator"></th>
+            <th colspan="34" class="separator"></th>
           </tr>
           <tr>
             <td id="Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&sect;</a>Array.prototype.indexOf</span></td>
@@ -800,18 +840,20 @@ test(typeof Array.prototype.indexOf == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -836,18 +878,20 @@ test(typeof Array.prototype.lastIndexOf == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -872,18 +916,20 @@ test(typeof Array.prototype.every == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -908,18 +954,20 @@ test(typeof Array.prototype.some == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -944,18 +992,20 @@ test(typeof Array.prototype.forEach == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -980,18 +1030,20 @@ test(typeof Array.prototype.map == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1016,18 +1068,20 @@ test(typeof Array.prototype.filter == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1052,18 +1106,20 @@ test(typeof Array.prototype.reduce == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1088,18 +1144,20 @@ test(typeof Array.prototype.reduceRight == 'function');
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1113,7 +1171,7 @@ test(typeof Array.prototype.reduceRight == 'function');
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="32" class="separator"></th>
+            <th colspan="34" class="separator"></th>
           </tr>
           <tr>
             <td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&sect;</a>Getter in property initializer</span></td>
@@ -1133,18 +1191,20 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1177,18 +1237,20 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1202,7 +1264,7 @@ test(function () {
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="32" class="separator"></th>
+            <th colspan="34" class="separator"></th>
           </tr>
           <tr>
             <td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&sect;</a>Property access on strings</span></td>
@@ -1216,18 +1278,20 @@ test("foobar"[3] === "b");
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="yes safari3 obsolete">Yes</td>
             <td class="yes safari4 obsolete">Yes</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="yes chrome5 obsolete">Yes</td>
             <td class="yes chrome6 obsolete">Yes</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="yes opera10_10 obsolete">Yes</td>
             <td class="yes opera10_50 obsolete">Yes</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1260,18 +1324,20 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="yes firefox3 obsolete">Yes</td>
             <td class="yes firefox3_5 obsolete">Yes</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="yes chrome7 obsolete">Yes</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1285,7 +1351,7 @@ test(function () {
             <td class="yes ejs">Yes</td>
           </tr>
           <tr>
-            <th colspan="32" class="separator"></th>
+            <th colspan="34" class="separator"></th>
           </tr>
           <tr>
             <td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&sect;</a>Zero-width chars in identifiers</span></td>
@@ -1303,18 +1369,20 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes<a href="#zero-width-char-note"><sup>[4]</sup></a></td>
+            <td class="yes firefox4 obsolete">Yes<a href="#zero-width-char-note"><sup>[4]</sup></a></td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="no safari51">No</td>
+            <td class="no safari51 obsolete">No</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
             <td class="no chrome13 obsolete">No</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="no opera12 obsolete">No</td>
@@ -1324,6 +1392,44 @@ test(function () {
             <td class="no konq413">No</td>
             <td class="yes besen">Yes</td>
             <td class="yes rhino">Yes</td>
+            <td class="no phantom">No</td>
+            <td class="yes ejs">Yes</td>
+          </tr>
+          <tr>
+            <td id="parseInt()_ignores_leading_zeros"><span><a class="anchor" href="#parseInt()_ignores_leading_zeros">&sect;</a>parseInt() ignores leading zeros</span></td>
+<script>
+test(parseInt('010') === 10);
+</script>
+
+            <td class="no ie7 obsolete">No</td>
+            <td class="no ie8 obsolete">No</td>
+            <td class="yes ie9">Yes</td>
+            <td class="yes ie10">Yes</td>
+            <td class="no firefox3 obsolete">No</td>
+            <td class="no firefox3_5 obsolete">No</td>
+            <td class="no firefox4 obsolete">No</td>
+            <td class="yes firefox21">Yes</td>
+            <td class="no safari3 obsolete">No</td>
+            <td class="no safari4 obsolete">No</td>
+            <td class="no safari5 obsolete">No</td>
+            <td class="no safari51 obsolete">No</td>
+            <td class="yes safari6">Yes</td>
+            <td class="yes webkit">Yes</td>
+            <td class="no chrome5 obsolete">No</td>
+            <td class="no chrome6 obsolete">No</td>
+            <td class="no chrome7 obsolete">No</td>
+            <td class="no chrome13 obsolete">No</td>
+            <td class="no chrome19 obsolete">No</td>
+            <td class="yes chrome23">Yes</td>
+            <td class="no opera10_10 obsolete">No</td>
+            <td class="no opera10_50 obsolete">No</td>
+            <td class="no opera12 obsolete">No</td>
+            <td class="no opera12_10">No</td>
+            <td class="no konq43 obsolete">No</td>
+            <td class="no konq49 obsolete">No</td>
+            <td class="no konq413">No</td>
+            <td class="yes besen">Yes</td>
+            <td class="no rhino">No</td>
             <td class="no phantom">No</td>
             <td class="yes ejs">Yes</td>
           </tr>
@@ -1348,18 +1454,20 @@ test(function () {
             <td class="yes ie10">Yes</td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="yes safari5 obsolete">Yes</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
             <td class="no chrome13 obsolete">No</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>
@@ -1387,18 +1495,20 @@ test(function () {
             <td class="yes ie10">Yes<a href="#strict-mode-ie10-note"><sup>[5]</sup></a></td>
             <td class="no firefox3 obsolete">No</td>
             <td class="no firefox3_5 obsolete">No</td>
-            <td class="yes firefox4">Yes</td>
+            <td class="yes firefox4 obsolete">Yes</td>
+            <td class="yes firefox21">Yes</td>
             <td class="no safari3 obsolete">No</td>
             <td class="no safari4 obsolete">No</td>
             <td class="no safari5 obsolete">No</td>
-            <td class="yes safari51">Yes</td>
+            <td class="yes safari51 obsolete">Yes</td>
             <td class="yes safari6">Yes</td>
             <td class="yes webkit">Yes</td>
             <td class="no chrome5 obsolete">No</td>
             <td class="no chrome6 obsolete">No</td>
             <td class="no chrome7 obsolete">No</td>
             <td class="yes chrome13 obsolete">Yes</td>
-            <td class="yes chrome19">Yes</td>
+            <td class="yes chrome19 obsolete">Yes</td>
+            <td class="yes chrome23">Yes</td>
             <td class="no opera10_10 obsolete">No</td>
             <td class="no opera10_50 obsolete">No</td>
             <td class="yes opera12 obsolete">Yes</td>


### PR DESCRIPTION
Can you believe Chrome only supported this from version 23? And Firefox from version 21? Columns for these versions thus had to be added to the ES5 page.

Closes #216.
