### PR TITLE
Fixed whitespace

### DIFF
--- a/build.js
+++ b/build.js
@@ -218,7 +218,7 @@ function testScript(fn) {
     else {
       expr = deindentFunc(expr[1]);
       return '<script data-source="' + expr.replace(/"/g,'&quot;') + '">\n' +
-      'test(function(){try{return Function(' + JSON.stringify(expr) + ')()}catch(e){return false;}}());\n' +
+      'test(function(){try{return Function(' + JSON.stringify(expr).replace(/\\r/g,'') + ')()}catch(e){return false;}}());\n' +
       '</script>\n';
     }
   } else {

--- a/data-es6.js
+++ b/data-es6.js
@@ -1480,31 +1480,31 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   name: 'typed arrays',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects',
   exec: function () {/*
-	var buffer = new ArrayBuffer(64);
-	var passed = true;
-	var view;
+    var buffer = new ArrayBuffer(64);
+    var passed = true;
+    var view;
 
-	// Check that each int type overflows as expected.
-	view = new Int8Array(buffer);         view[0] = 0x80;
-	passed &= view[0] === -0x80;
-	view = new Uint8Array(buffer);        view[0] = 0x100;
-	passed &= view[0] === 0;
-	view = new Uint8ClampedArray(buffer); view[0] = 0x100;
-	passed &= view[0] === 0xFF;
-	view = new Int16Array(buffer);        view[0] = 0x8000;
-	passed &= view[0] === -0x8000;
-	view = new Uint16Array(buffer);       view[0] = 0x10000;
-	passed &= view[0] === 0;
-	view = new Int32Array(buffer);        view[0] = 0x80000000;
-	passed &= view[0] === -0x80000000;
-	view = new Uint32Array(buffer);       view[0] = 0x100000000;
-	passed &= view[0] === 0;
-	// Check that each float type loses precision as expected.
-	view = new Float32Array(buffer);      view[0] = 0.1;
-	passed &= view[0] === 0.10000000149011612;
-	view = new Float64Array(buffer);      view[0] = 0.1;
-	passed &= view[0] === 0.1;
-	return passed;
+    // Check that each int type overflows as expected.
+    view = new Int8Array(buffer);         view[0] = 0x80;
+    passed &= view[0] === -0x80;
+    view = new Uint8Array(buffer);        view[0] = 0x100;
+    passed &= view[0] === 0;
+    view = new Uint8ClampedArray(buffer); view[0] = 0x100;
+    passed &= view[0] === 0xFF;
+    view = new Int16Array(buffer);        view[0] = 0x8000;
+    passed &= view[0] === -0x8000;
+    view = new Uint16Array(buffer);       view[0] = 0x10000;
+    passed &= view[0] === 0;
+    view = new Int32Array(buffer);        view[0] = 0x80000000;
+    passed &= view[0] === -0x80000000;
+    view = new Uint32Array(buffer);       view[0] = 0x100000000;
+    passed &= view[0] === 0;
+    // Check that each float type loses precision as expected.
+    view = new Float32Array(buffer);      view[0] = 0.1;
+    passed &= view[0] === 0.10000000149011612;
+    view = new Float64Array(buffer);      view[0] = 0.1;
+    passed &= view[0] === 0.1;
+    return passed;
   */},
   res: {
     tr:          false,
@@ -1551,19 +1551,19 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   name: 'typed arrays (DataView)',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-dataview-objects',
   exec: function () {/*
-	var buffer = new ArrayBuffer(64);
-	var view = new DataView(buffer);
-	var passed = true;
+    var buffer = new ArrayBuffer(64);
+    var view = new DataView(buffer);
+    var passed = true;
 
-	view.setInt8 (0, 0x80);        passed &= view.getInt8(0)   === -0x80;
-	view.setUint8(0, 0x100);       passed &= view.getUint8(0)  === 0;
-	view.setInt16(0, 0x8000);      passed &= view.getInt16(0)  === -0x8000;
-	view.setUint16(0,0x10000);     passed &= view.getUint16(0) === 0;
-	view.setInt32(0, 0x80000000);  passed &= view.getInt32(0)  === -0x80000000;
-	view.setUint32(0,0x100000000); passed &= view.getUint32(0) === 0;
-	view.setFloat32(0, 0.1);       passed &= view.getFloat32(0)=== 0.10000000149011612;
-	view.setFloat64(0, 0.1);       passed &= view.getFloat64(0)=== 0.1;
-	return passed;
+    view.setInt8 (0, 0x80);        passed &= view.getInt8(0)   === -0x80;
+    view.setUint8(0, 0x100);       passed &= view.getUint8(0)  === 0;
+    view.setInt16(0, 0x8000);      passed &= view.getInt16(0)  === -0x8000;
+    view.setUint16(0,0x10000);     passed &= view.getUint16(0) === 0;
+    view.setInt32(0, 0x80000000);  passed &= view.getInt32(0)  === -0x80000000;
+    view.setUint32(0,0x100000000); passed &= view.getUint32(0) === 0;
+    view.setFloat32(0, 0.1);       passed &= view.getFloat32(0)=== 0.10000000149011612;
+    view.setFloat64(0, 0.1);       passed &= view.getFloat64(0)=== 0.1;
+    return passed;
   */},
   res: {
     tr:          false,
@@ -3484,13 +3484,13 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     var a = 0, b = {};
     b[Symbol.iterator] = function() {
       return {
-	    next: function() {
-		  return {
-		    done: a === 1,
-		    value: a++
-		  };
-	    }
-	  };
+        next: function() {
+          return {
+            done: a === 1,
+            value: a++
+          };
+        }
+      };
     };
     var c;
     for (c of b) {}

--- a/es6/index.html
+++ b/es6/index.html
@@ -3164,19 +3164,19 @@ test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] 
 var a = 0, b = {};
 b[Symbol.iterator] = function() {
   return {
-      next: function() {
+    next: function() {
       return {
         done: a === 1,
         value: a++
       };
-      }
-    };
+    }
+  };
 };
 var c;
 for (c of b) {}
 return c === 0;
   ">
-test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n\t    next: function() {\n\t\t  return {\n\t\t    done: a === 1,\n\t\t    value: a++\n\t\t  };\n\t    }\n\t  };\n};\nvar c;\nfor (c of b) {}\nreturn c === 0;\n  ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a === 1,\n        value: a++\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === 0;\n  ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>


### PR DESCRIPTION
In addition to removing tabs from data-es6.js, this also fixes an inconsistency for Windows node - JSON.stringify() outputs \r\n for line-break-containing strings in Windows instead of \n.
