### PR TITLE
Made some displayed tooltip code for certain tests appear cleaner

### DIFF
--- a/build.js
+++ b/build.js
@@ -213,7 +213,7 @@ function testScript(fn) {
     // if there wasn't an expression, make the function statement into one
     if (!expr) {
       expr = deindentFunc(fn);
-      return '<script data-source="' + expr.replace(/"/g,'&quot;') + '">test(\n' + expr + '())</script>\n';
+      return '<script data-source="' + expr.replace(/"/g,'&quot;').replace(/^\s*function ?\(\) ?{|\s*}\s*$/g,'') + '">test(\n' + expr + '())</script>\n';
     }
     else {
       expr = deindentFunc(expr[1]);


### PR DESCRIPTION
Tests which aren't in comment strings now have their code stripped of the "function () {" wrapper when included in a tooltip, putting them on par with the others.

(For merge conflict avoidance, this commit doesn't update the HTML files.)
