### PR TITLE
data*.js files' tests are exported as JS strings

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -1869,3 +1869,18 @@ exports.tests = [
   }
 }
 ];
+
+//Convert all test functions to strings of ES code,
+//which interpreter platforms etc. can examine.
+exports.tests.forEach(function (test) {
+  function unwrap(s) {
+    return (s+'').replace(/^\s*function ?\(\) ?{|\s*}\s*$/g,'');
+  }
+  if (Array.isArray(test.exec)) {
+    test.exec.forEach(function(test) { test.script = unwrap(test.script); });
+    return;
+  }
+  if (m = /[^]*\/\*([^]*)\*\/\s*$/.exec(test.exec = unwrap(test.exec))) {
+    test.exec = m[1];
+  }
+});

--- a/data-es6.js
+++ b/data-es6.js
@@ -5896,7 +5896,21 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   separator: 'after'
 }
 ];
-
 //Shift annex B features to the bottom
 exports.tests = exports.tests.filter(function(e) { return !e.annex_b })
         .concat(exports.tests.filter(function(e) { return  e.annex_b }));
+        
+//Convert all test functions to strings of ES code,
+//which interpreter platforms etc. can examine.
+exports.tests.forEach(function (test) {
+  function unwrap(s) {
+    return (s+'').replace(/^\s*function ?\(\) ?{|\s*}\s*$/g,'');
+  }
+  if (Array.isArray(test.exec)) {
+    test.exec.forEach(function(test) { test.script = unwrap(test.script); });
+    return;
+  }
+  if (m = /[^]*\/\*([^]*)\*\/\s*$/.exec(test.exec = unwrap(test.exec))) {
+    test.exec = m[1];
+  }
+});

--- a/data-es7.js
+++ b/data-es7.js
@@ -388,3 +388,18 @@ exports.tests = [
   }
 }
 ];
+
+//Convert all test functions to strings of ES code,
+//which interpreter platforms etc. can examine.
+exports.tests.forEach(function (test) {
+  function unwrap(s) {
+    return (s+'').replace(/^\s*function ?\(\) ?{|\s*}\s*$/g,'');
+  }
+  if (Array.isArray(test.exec)) {
+    test.exec.forEach(function(test) { test.script = unwrap(test.script); });
+    return;
+  }
+  if (m = /[^]*\/\*([^]*)\*\/\s*$/.exec(test.exec = unwrap(test.exec))) {
+    test.exec = m[1];
+  }
+});

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1523,3 +1523,18 @@ exports.tests = [
   separator: 'after'
 }
 ];
+
+//Convert all test functions to strings of ES code,
+//which interpreter platforms etc. can examine.
+exports.tests.forEach(function (test) {
+  function unwrap(s) {
+    return (s+'').replace(/^\s*function ?\(\) ?{|\s*}\s*$/g,'');
+  }
+  if (Array.isArray(test.exec)) {
+    test.exec.forEach(function(test) { test.script = unwrap(test.script); });
+    return;
+  }
+  if (m = /[^]*\/\*([^]*)\*\/\s*$/.exec(test.exec = unwrap(test.exec))) {
+    test.exec = m[1];
+  }
+});


### PR DESCRIPTION
This tries to answer #229, and incidentally accomplishes the same thing as #233.
A 10-line function has been added to the end of each `data*.js` script, which converts all the test.exec properties (that is, the test functions) into strings containing just the function body, so that they can be analysed by external testing scripts, or recreated using the Function() constructor.

Essentially, this takes functionality already present in `build.js`, and adds them to the `data*.js` files to give them a slightly more usable API. While there's a maintainability hit in having the same function duplicated in each file, I think it's acceptable.
