### PR TITLE
Fixes ES5 and non-standard pages in IE 8

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -497,11 +497,16 @@ exports.tests = [
 {
   name: '__lookupGetter__',
   link: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__',
-  exec: function () {
-    var obj = { get foo() { return "bar"; } };
+  exec: function () {/*
+    try {
+      var obj = eval('{ get foo() { return "bar"; } }');
+    }
+    catch(e) {
+      obj = {}; obj.__defineGetter__("foo", function(){ return "bar"; });
+    }
     var func = obj.__lookupGetter__("foo");
     return typeof func === "function" && func() === "bar";
-  },
+  */},
   res: {
     ie7: false,
     ie11: true,
@@ -695,8 +700,8 @@ exports.tests = [
   exec: function () {/*
     var str = '';
     for each (var item in {a: "foo", b: "bar", c: "baz"}) {
-	  str += item;
-	}
+      str += item;
+    }
     return str === "foobarbaz";
   */},
   res: {
@@ -730,7 +735,7 @@ exports.tests = [
   link: 'https://developer.mozilla.org/en/Sharp_variables_in_JavaScript',
   exec: function () {/*
     var arr = #1=[1, #1#, 3]; 
-	return arr[1] === arr;
+    return arr[1] === arr;
   */},
   res: {
     ie7: false,

--- a/master.css
+++ b/master.css
@@ -12,16 +12,17 @@ table { margin-bottom: 2em; width: 100%; }
 p { margin-bottom: 0.5em; margin-top: 0; }
 code { font-family: "Courier New", Courier, monospace; }
 
-table.one-selected td:not(:first-child) { opacity: 0.3; }
-table.one-selected tr.selected td { padding-top: 30px; padding-bottom: 30px; opacity: 1; }
-table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacity: 1; }
+table.one-selected td { opacity: 0.3; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; }
+table.one-selected td:first-child { opacity: 1; }
+table.one-selected tr.selected td { padding-top: 30px; padding-bottom: 30px; opacity: 1; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; }
+table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacity: 1; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; }
 
 #table-wrapper tr:hover td { background: #ddd; }
-#table-wrapper tr:hover td.yes, #table-wrapper td.hover.yes { background: hsl(120,  74%,  27%); }
-#table-wrapper tr:hover td.no,  #table-wrapper td.hover.no  { background: hsl(  0,  83%,  40%); }
-#table-wrapper tr:hover td.yes.obsolete, #table-wrapper td.hover.yes.obsolete { background: hsl(120,  24%,  37%); }
-#table-wrapper tr:hover td.no.obsolete,  #table-wrapper td.hover.no.obsolete  { background: hsl(  0,  33%,  50%); }
-#table-wrapper tr:hover td.not-applicable, #table-wrapper td.hover.not-applicable { background: hsl(120,  14%,  47%); }
+#table-wrapper tr:hover td.yes, #table-wrapper td.hover.yes { background: hsl(120,  74%,  27%); background: #127812; }
+#table-wrapper tr:hover td.no,  #table-wrapper td.hover.no   { background: hsl(  0,  83%,  40%); background: #b11; }
+#table-wrapper tr:hover td.yes.obsolete, #table-wrapper td.hover.yes.obsolete { background: hsl(120,  24%,  37%); background: #487548; }
+#table-wrapper tr:hover td.no.obsolete,  #table-wrapper td.hover.no.obsolete  { background: hsl(  0,  33%,  50%); background: #a55; }
+#table-wrapper tr:hover td.not-applicable, #table-wrapper td.hover.not-applicable { background: hsl(120,  14%,  47%); background: #678967; }
 
 #body { padding-left: 1em; position: relative; min-width: 1250px; }
 
@@ -40,11 +41,11 @@ table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacit
 .yes, .no, .not-applicable { text-align: center; font-family: 'Open Sans', sans-serif;
             font-size: 0.8em; padding: 0.25em 0.5em; color: #fff; }
 
-.yes          { background: hsl(120,  43%,  47%); }
-.no           { background: hsl(  0,  87%,  50%); }
-.yes.obsolete { background: hsl(120,  28%,  61%); }
-.no.obsolete  { background: hsl(  0,  72%,  65%); }
-.not-applicable { background: hsl(120,  14%,  67%); cursor: help; }
+.yes          { background: hsl(120,  43%,  47%); background: #44ab44;}
+.no           { background: hsl(  0,  87%,  50%); background: #e11; }
+.yes.obsolete { background: hsl(120,  28%,  61%); background: #80b780; }
+.no.obsolete  { background: hsl(  0,  72%,  65%); background: #e66565; }
+.not-applicable { background: hsl(120,  14%,  67%); background: #9fb79f; cursor: help; }
 
 .test-name { width: 260px; }
 .warning { background: #ffc; display: inline-block; margin: 0 0 2em 0; padding: 0.25em; }
@@ -53,7 +54,9 @@ table.one-selected td.selected { padding-left: 30px; padding-right: 30px; opacit
   font-size: 13px; vertical-align: top; }
 
 #table-wrapper .obsolete { display: none; }
-#show-obsolete:checked + #table-wrapper .obsolete { display: table-cell; }
+#show-obsolete:checked + #table-wrapper .obsolete         { display: table-cell;  }
+#show-obsolete[value='on'] + #table-wrapper .obsolete { display: table-cell; }
+
 label[for="show-obsolete"] { background: #eef; padding: 5px; margin-left: 10px; margin-right: -30px; padding-right: 30px; }
 
 label[for="sort"] { margin-left: 20px; background: #fee; padding: 5px; margin-right: -30px; padding-right: 30px; }

--- a/master.js
+++ b/master.js
@@ -13,25 +13,12 @@ function test(expression) {
 document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 
 domready(function() {
-  if (!/#showold$/.test(location.href))
-    document.body.className += ' hide-old-browsers';
-  else
-    document.getElementById('show-old-browsers').checked = true
-  var wrapper = document.getElementById('show-old-browsers-wrapper');
-  if (wrapper) {
-    wrapper.style.display = '';
-    document.getElementById('show-old-browsers').onclick = function() {
-      if (this.checked) {
-        document.body.className = document.body.className.replace('hide-old-browsers', '');
-        location.href = location.href.replace(/#*$/, '#showold')
-      }
-      else {
-        document.body.className += 'hide-old-browsers';
-        location.href = location.href.replace(/(#showold)*$/, '#')
-      }
-    };
+  var showObsolete = document.getElementById('show-obsolete');
+  showObsolete.onclick = function() {
+    this.setAttribute('value',this.getAttribute('value')==="on" ? "off" : "on");
   }
-
+  showObsolete.setAttribute('value', showObsolete.checked);
+  
   var table = document.getElementById('table-wrapper');
   
   var mouseoverTimeout;
@@ -57,6 +44,7 @@ domready(function() {
     rows[i].cells[0].appendChild(infoEl);
 
     infoEl.onmouseover = function(e) {
+      e = e || window.event;
       mouseoverTimeout = null;
       
       var scriptEl = this.parentNode.parentNode.getElementsByTagName('script')[0];
@@ -64,10 +52,14 @@ domready(function() {
       
       infoTooltip.innerHTML = scriptEl.getAttribute('data-source')
         // trim sides, and escape <
-        .trim().replace(/</g, '&lt;');
+        .replace(/^\s*|\s*$/g,'').replace(/</g, '&lt;');
       
+      if (!e.pageX) {
+        e.pageX = e.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
+        e.pageY = e.clientY + document.body.scrollTop + document.documentElement.scrollTop;
+      }
       infoTooltip.style.left = e.pageX + 10 + 'px';
-      infoTooltip.style.top = e.pageY + 'px';
+      infoTooltip.style.top  = e.pageY + 'px';
       infoTooltip.style.display = 'block';
     };
     infoEl.onmouseout = function(e) {
@@ -104,6 +96,8 @@ domready(function() {
   }
 
   document.onclick = function(e) {
+    e = e || window.event;
+    e.target = e.target || e.srcElement;
     if (e.target.className === 'anchor') {
       // <tr><td><span><a>
       highlightSelected(e.target.parentNode.parentNode.parentNode);
@@ -112,8 +106,12 @@ domready(function() {
         e.target.parentNode.className === 'browser-name') {
 
       var target = e.target.className ? e.target : e.target.parentNode;
-      var headerCells = [].slice.call(table.rows[0].cells);
-      var index = headerCells.indexOf(target.parentNode);
+      
+      for(var i=0; i<table.rows[0].cells.length;i++) {
+        if (table.rows[0].cells===target.parentNode) {
+          var index = i;
+        }
+      }
 
       highlightColumn(index);
     }
@@ -142,7 +140,6 @@ domready(function() {
     }
 
     table.className = 'one-selected';
-
     for (var i = 0, len = table.rows.length; i < len; i++) {
       var row = table.rows[i];
       for (var j = 0, jlen = row.cells.length; j < jlen; j++) {

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -505,16 +505,18 @@ return '__defineSetter__' in {};
           </tr>
           <tr>
             <td id="__lookupGetter__"><span><a class="anchor" href="#__lookupGetter__">&sect;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span></td>
-<script data-source="function () {
-var obj = { get foo() { return &quot;bar&quot;; } };
+<script data-source="
+try {
+    var obj = eval('{ get foo() { return &quot;bar&quot;; } }');
+  }
+  catch(e) {
+  obj = {}; obj.__defineGetter__(&quot;foo&quot;, function(){ return &quot;bar&quot;; });
+  }
 var func = obj.__lookupGetter__(&quot;foo&quot;);
 return typeof func === &quot;function&quot; && func() === &quot;bar&quot;;
-  }">test(
-function () {
-var obj = { get foo() { return "bar"; } };
-var func = obj.__lookupGetter__("foo");
-return typeof func === "function" && func() === "bar";
-  }())</script>
+  ">
+test(function(){try{return Function("\ntry {\n\t  var obj = eval('{ get foo() { return \"bar\"; } }');\n\t}\n\tcatch(e) {\n  obj = {}; obj.__defineGetter__(\"foo\", function(){ return \"bar\"; });\n\t}\nvar func = obj.__lookupGetter__(\"foo\");\nreturn typeof func === \"function\" && func() === \"bar\";\n  ")()}catch(e){return false;}}());
+</script>
 
             <td class="no ie7">No</td>
             <td class="yes ie11">Yes</td>


### PR DESCRIPTION
The ES5 and non-standard pages should now work in IE 8 again.
(The ES6 page, puzzlingly, seems to make it freeze or crash. Oh well, maybe later.)

Fixes include:
- Fallback for hsl() colours. (I prefer the hsl format for clarity of reading and understanding - the relation between the "hover" and normal colours is made obvious in HSL, so I opt to leave both colour formats in the CSS.)
- "Show obsolete browsers" checkbox works again
- Fallback for opacity when selecting a column
- Tooltips work again (incorrectly uses String#trim and Array#forEach)
