### PR TITLE
Improved Promise tests, and added support for async testing

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2966,21 +2966,39 @@ exports.tests = [
     },
   },
 },
+
 {
   name: 'Promise',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
-  exec: function () {/*
-    return typeof Promise !== 'undefined' &&
-           typeof Promise.all === 'function';
+  exec: function (passTest) {/*
+    var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
+    var p2 = new Promise(function(resolve, reject) { reject("quux"); });
+    var score = 0;
+    
+    function thenFn(result)  { score += (result === "foo");  check(); }
+    function catchFn(result) { score += (result === "quux"); check(); }
+    function shouldNotRun(result)  { score = -Infinity;   }
+    
+    p1.then(thenFn, shouldNotRun);
+    p2.then(shouldNotRun, catchFn);
+    p1.catch(shouldNotRun);
+    p2.catch(catchFn);
+    
+    p1.then(function() {
+      // Promise.prototype.then() should return a new Promise
+      score += p1.then() !== p1;
+      check();
+    });
+    
+    function check() {
+      if (score === 4) asyncTestPassed();
+    }
   */},
   res: {
     tr:          true,
-    _6to5:       true,
     ejs:         true,
-    closure:     false,
     ie10:        false,
     ie11:        false,
-    ie11tp:      true,
     firefox11:   false,
     firefox13:   false,
     firefox16:   false,
@@ -3009,7 +3027,6 @@ exports.tests = [
     safari51:    false,
     safari6:     false,
     safari7:     false,
-    safari71_8:  true,
     webkit:      true,
     opera:       false,
     konq49:      false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -1498,7 +1498,7 @@ exports.tests = [
         closure:     true,
         firefox34:   true,
       },
-    }
+    },
   },
 },
 {
@@ -2970,7 +2970,7 @@ exports.tests = [
 {
   name: 'Promise',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
-  exec: function (passTest) {/*
+  exec: function () {/*
     var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
     var p2 = new Promise(function(resolve, reject) { reject("quux"); });
     var score = 0;
@@ -3036,6 +3036,128 @@ exports.tests = [
     nodeharmony: true,
     ios7:        false,
     ios8:        true
+  }
+},
+{
+  name: 'Promise.all',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all',
+  exec: function () {/*
+    var fulfills = Promise.all([
+      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+      new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
+    ]);
+    var rejects = Promise.all([
+      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+      new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
+    ]);
+    var score = 0;
+    fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
+    rejects.catch(function(result) { score += (result === "qux"); check(); });
+    
+    function check() {
+      if (score === 2) asyncTestPassed();
+    }
+  */},
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      true,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: true
+  }
+},
+{
+  name: 'Promise.race',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.race',
+  exec: function () {/*
+    var fulfills = Promise.race([
+      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+      new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
+    ]);
+    var rejects = Promise.race([
+      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+      new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
+    ]);
+    var score = 0;
+    fulfills.then(function(result) { score += (result === "foo"); check(); });
+    rejects.catch(function(result) { score += (result === "baz"); check(); });
+    
+    function check() {
+      if (score === 2) asyncTestPassed();
+    }
+  */},
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      true,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: true
   }
 },
 {

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -12,6 +12,18 @@
       if (typeof global === 'undefined') {
         var global = this;
       }
+      // For async tests, this returned function is used to set results
+      // instead of returning true/false.
+      var __asyncPassedFn = function(id) {
+      return function() {
+          // Uses nextSibling for IE < 9 compatibility
+          // rather than document.querySelector("#" + id + " ~ td")
+          var elem = document.getElementById(id)
+            .nextSibling.nextSibling.nextSibling;
+          elem.className = "yes";
+          elem.textContent = "Yes";
+        }
+      }
     </script>
 </head>
 <body class="es6">

--- a/node.js
+++ b/node.js
@@ -13,47 +13,39 @@ var fs = require('fs')
 
 global.__script_executed = {};
 
-$('#body tbody tr').each(function () {
+$('#body tbody tr').each(function (index) {
   if (this.find('.separator')[0])
     return
   var scripts = this.find('script')
-    , result = null
-	, id = this.find('td').attr('id')
     , i = 0, scr
     , test = function test (expression) {
-      results[id] = results[id] || expression
+      results[index] = results[index] || expression
     }
-	, asyncTestPassed = function passTest (id) {
-	  results[id] = true
+	, asyncPassed = function asyncPassed () {
+	  results[index] = true
     }
   
-  desc[id] = (function (el) {
-    while (el && !el.data)
-      el = el.children[0]
-    return (el && el.data) || 'ERROR!'
-  }(this.find('td>span')[0].children[1]))
+  results[index] = null
+  
+  desc[index] = this.find('td>span:first-child').text()
 
   // can be multiple scripts
   for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {
     scr = scripts[i].children[0].data.trim()
+      .replace(/global\.__asyncPassedFn && __asyncPassedFn\(".*?"\)/g, "asyncPassed")
     eval(scr)
-  }
-  if (result === null) {
-    console.log('\u25BC\t' + desc.replace('§',''))
-  }
-  else {
-    console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
   }
 })
 
 setTimeout(function(){
   Object.keys(results).forEach(function(test) {
-    var result = results[test];
+    var result = results[test]
+    var name = desc[test]
     if (result === null) {
-      console.log('\u25BC\t' + desc.replace('§',''))
+      console.log('\u25BC\t' + name.replace('§',''))
     }
     else {
-      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
+      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (name[0]!== '§' ? '\t' + name : name.slice(1)) + '\t'))
     }
   })
 },500)

--- a/node.js
+++ b/node.js
@@ -7,19 +7,31 @@ var fs = require('fs')
 
   , page = fs.readFileSync(path.join(__dirname, 'es6', 'index.html')).toString().replace(/data-source="[^"]*"/g,'')
   , $ = cheerio.load(page)
+  , results = {}
+  , desc = {}
+  , done = false
 
 global.__script_executed = {};
 
 $('#body tbody tr').each(function () {
   if (this.find('.separator')[0])
     return
-  var desc = this.find('td>span:first-child').text()
-    , scripts = this.find('script')
+  var scripts = this.find('script')
     , result = null
+	, id = this.find('td').attr('id')
     , i = 0, scr
     , test = function test (expression) {
-        result = result || expression
-      }
+      results[id] = results[id] || expression
+    }
+	, asyncTestPassed = function passTest (id) {
+	  results[id] = true
+    }
+  
+  desc[id] = (function (el) {
+    while (el && !el.data)
+      el = el.children[0]
+    return (el && el.data) || 'ERROR!'
+  }(this.find('td>span')[0].children[1]))
 
   // can be multiple scripts
   for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {
@@ -33,3 +45,15 @@ $('#body tbody tr').each(function () {
     console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
   }
 })
+
+setTimeout(function(){
+  Object.keys(results).forEach(function(test) {
+    var result = results[test];
+    if (result === null) {
+      console.log('\u25BC\t' + desc.replace('§',''))
+    }
+    else {
+      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
+    }
+  })
+},500)


### PR DESCRIPTION
Closes #247. This makes the Promise test call `Promise#then` and `Promise#catch` and checks what behaviour results, and also adds `Promise.all` and `Promise.race` tests.

In order to get the Promise test to work, I needed to implement asynchronous test result writing. To do this, test functions may now, instead of returning true/false, instead at some point call `asyncTestPassed()`, which is a function of no arguments, provided by the testing environment, that records the test as passed regardless of execution order. `build.js` has been updated to provide such a function (which manually updates the class and text of the corresponding `<td>`) as has the `node.js` test runner script.

The historical results have not _yet_ been re-verified (WebKit, Chrome 33 or Firefox 29 might actually fail these new tests, unlikely though it seems).
