### PR TITLE
Add Closure Compiler column

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -17,6 +17,12 @@ exports.browsers = {
     obsolete: false, // always up-to-date version
     nonbrowser: true
   },
+  closure: {
+    full: 'Closure Compiler v20140923',
+    short: 'Closure Compiler',
+    obsolete: false, // always up-to-date version
+    nonbrowser: true
+  },
   ie10: {
     full: 'Internet Explorer',
     short: 'IE 10',
@@ -237,6 +243,7 @@ exports.tests = [
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -292,6 +299,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -346,6 +354,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        true,
     firefox11:   false,
@@ -421,6 +430,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        true,
     firefox11:   true,
@@ -479,6 +489,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -533,6 +544,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -583,6 +595,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -633,6 +646,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -683,6 +697,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -742,6 +757,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -814,6 +830,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -865,6 +882,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -916,6 +934,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -966,6 +985,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1029,6 +1049,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        true,
     firefox11:   true,
@@ -1087,6 +1108,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1139,6 +1161,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1201,6 +1224,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1251,6 +1275,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1305,6 +1330,7 @@ exports.tests = [
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1357,6 +1383,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1418,6 +1445,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1472,6 +1500,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   true,
@@ -1522,6 +1551,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1596,6 +1626,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        {
       val: false,
       note_id: 'ie-typedarray',
@@ -1662,6 +1693,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        true,
     ie11:        true,
     firefox11:   false,
@@ -1718,6 +1750,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        {
       val: true,
@@ -1778,6 +1811,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        { val: true, note_id: 'map-constructor' },
     firefox11:   false,
@@ -1833,6 +1867,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        {
       val: true,
@@ -1893,6 +1928,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -1948,6 +1984,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2010,6 +2047,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2074,6 +2112,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2130,6 +2169,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        true,
     firefox11:   false,
@@ -2187,6 +2227,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        true,
     ie11:        false,
     firefox11:   false,
@@ -2246,6 +2287,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   true,
@@ -2302,6 +2344,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   true,
@@ -2353,6 +2396,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2406,6 +2450,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2457,6 +2502,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2507,6 +2553,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2557,6 +2604,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2607,6 +2655,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2657,6 +2706,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        true,
     firefox11:   false,
@@ -2716,6 +2766,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        true,
     firefox11:   false,
@@ -2766,6 +2817,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   true,
@@ -2816,6 +2868,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2866,6 +2919,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2916,6 +2970,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -2966,6 +3021,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3018,6 +3074,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3068,6 +3125,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3118,6 +3176,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3168,6 +3227,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3218,6 +3278,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3276,6 +3337,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        true,
     ie11:        true,
     firefox11:   true,
@@ -3326,6 +3388,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     true,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3388,6 +3451,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3440,6 +3504,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3495,6 +3560,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3548,6 +3614,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3598,6 +3665,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3661,6 +3729,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3720,6 +3789,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3772,6 +3842,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3826,6 +3897,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3876,6 +3948,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3926,6 +3999,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -3976,6 +4050,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4026,6 +4101,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4077,6 +4153,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         false,
+    closure:     false,
     ie10:        true,
     ie11:        true,
     firefox11:   true,
@@ -4127,6 +4204,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4177,6 +4255,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4227,6 +4306,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4277,6 +4357,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4327,6 +4408,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4377,6 +4459,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4427,6 +4510,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4477,6 +4561,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4535,6 +4620,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4590,6 +4676,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         false,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4640,6 +4727,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4690,6 +4778,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4740,6 +4829,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4790,6 +4880,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4840,6 +4931,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4890,6 +4982,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4940,6 +5033,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          true,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -4990,6 +5084,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5040,6 +5135,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5094,6 +5190,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5144,6 +5241,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5194,6 +5292,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5244,6 +5343,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5294,6 +5394,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5344,6 +5445,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5394,6 +5496,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5444,6 +5547,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5494,6 +5598,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5544,6 +5649,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5594,6 +5700,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5642,6 +5749,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     return typeof Math.hypot === 'function';
   },
   res: {
+    closure:     false,
     tr:          false,
     ejs:         true,
     ie10:        false,
@@ -5694,6 +5802,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5744,6 +5853,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,
@@ -5798,6 +5908,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
   res: {
     tr:          false,
     ejs:         true,
+    closure:     false,
     ie10:        false,
     ie11:        false,
     firefox11:   false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -72,6 +72,7 @@
           <th></th>
           <th class="tr"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></th>
           <th class="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">EJS</abbr></th>
+          <th class="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20140923">Closure Compiler</abbr></th>
           <th class="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></th>
           <th class="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></th>
           <th class="firefox11 obsolete"><a href="#firefox11" class="browser-name"><abbr title="Firefox">FF 11-12</abbr></th>
@@ -129,6 +130,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -189,6 +191,7 @@ return true;
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -247,6 +250,7 @@ try {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -323,6 +327,7 @@ test((function () {
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -380,6 +385,7 @@ test(function(){try{return Function("\nvar passed = (function (a = 1, b = 2) { r
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -429,6 +435,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -478,6 +485,7 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n  ")
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -527,6 +535,7 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n  ")()}c
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -576,6 +585,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -630,6 +640,7 @@ test(function(){try{return Function("\nclass C extends Array {\n  constructor() 
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -701,6 +712,7 @@ test(function(){try{return Function("\nvar passed = true;\nvar B = class extends
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -751,6 +763,7 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -801,6 +814,7 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -850,6 +864,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -900,6 +915,7 @@ test(function(){try{return Function("\nexport var foo = 1;\nreturn true;\n  ")()
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -951,6 +967,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1012,6 +1029,7 @@ test(function(){try{return Function("\nvar generator = (function* () {\n  yield*
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1061,6 +1079,7 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n  ")()}
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1110,6 +1129,7 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n  ")()}
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1161,6 +1181,7 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1221,6 +1242,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1274,6 +1296,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -1323,6 +1346,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1396,6 +1420,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar pa
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No<a href="#ie-typedarray-note"><sup>[6]</sup></a></td>
           <td class="no ie11">No<a href="#ie-typedarray-note"><sup>[6]</sup></a></td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -1457,6 +1482,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1512,6 +1538,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
@@ -1567,6 +1594,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
@@ -1621,6 +1649,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar weakmap = new WeakMap
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
@@ -1676,6 +1705,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1736,6 +1766,7 @@ return false;
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1810,6 +1841,7 @@ return true;
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1888,6 +1920,7 @@ return true;
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1941,6 +1974,7 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -1999,6 +2033,7 @@ test(function(){try{return Function("\n// Array destructuring\nvar [a, , [b], g]
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -2050,6 +2085,7 @@ test(function(){try{return Function("\nreturn (function({a, x:b}, [c, d]) {\n  r
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -2100,6 +2136,7 @@ test(function(){try{return Function("\nvar {a = 1, b = 1, c = 3} = {b:2, c:undef
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2152,6 +2189,7 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2204,6 +2242,7 @@ return typeof Promise !== 'undefined' &&
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2254,6 +2293,7 @@ return typeof Object.assign === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2304,6 +2344,7 @@ return typeof Object.is === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2354,6 +2395,7 @@ return typeof Object.getOwnPropertySymbols === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2404,6 +2446,7 @@ return typeof Object.setPrototypeOf === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2454,6 +2497,7 @@ return (function foo(){}).name == 'foo';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -2504,6 +2548,7 @@ return typeof Function.prototype.toMethod === "function";
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2554,6 +2599,7 @@ return typeof String.raw === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2604,6 +2650,7 @@ return typeof String.fromCodePoint === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2654,6 +2701,7 @@ return typeof String.prototype.codePointAt === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2708,6 +2756,7 @@ return typeof String.prototype.normalize === "function"
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2758,6 +2807,7 @@ return typeof String.prototype.repeat === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2808,6 +2858,7 @@ return typeof String.prototype.startsWith === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2858,6 +2909,7 @@ return typeof String.prototype.endsWith === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2908,6 +2960,7 @@ return typeof String.prototype.contains === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -2957,6 +3010,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3031,6 +3085,7 @@ catch(e) {
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3082,6 +3137,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3136,6 +3192,7 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3188,6 +3245,7 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3237,6 +3295,7 @@ test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] 
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3299,6 +3358,7 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3357,6 +3417,7 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3408,6 +3469,7 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3461,6 +3523,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3511,6 +3574,7 @@ return typeof RegExp.prototype.match === 'function';
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3561,6 +3625,7 @@ return typeof RegExp.prototype.replace === 'function';
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3611,6 +3676,7 @@ return typeof RegExp.prototype.search === 'function';
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3661,6 +3727,7 @@ return typeof RegExp.prototype.split === 'function';
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3711,6 +3778,7 @@ return typeof Array.from === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3761,6 +3829,7 @@ return typeof Array.of === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3811,6 +3880,7 @@ return typeof Array.prototype.copyWithin === 'function';
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3861,6 +3931,7 @@ return typeof Array.prototype.find === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3911,6 +3982,7 @@ return typeof Array.prototype.findIndex === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -3961,6 +4033,7 @@ return typeof Array.prototype.fill === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4011,6 +4084,7 @@ return typeof Array.prototype.keys === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4061,6 +4135,7 @@ return typeof Array.prototype.values === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4111,6 +4186,7 @@ return typeof Array.prototype.entries === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4165,6 +4241,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
 
           <td class="no tr">No</td>
           <td class="no ejs">No</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4215,6 +4292,7 @@ return typeof Number.isFinite === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4265,6 +4343,7 @@ return typeof Number.isInteger === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4315,6 +4394,7 @@ return typeof Number.isSafeInteger === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4365,6 +4445,7 @@ return typeof Number.isNaN === 'function';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4415,6 +4496,7 @@ return typeof Number.EPSILON === 'number';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4465,6 +4547,7 @@ return typeof Number.MIN_SAFE_INTEGER === 'number';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4515,6 +4598,7 @@ return typeof Number.MAX_SAFE_INTEGER === 'number';
 
           <td class="yes tr">Yes</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4565,6 +4649,7 @@ return typeof Math.clz32 === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4615,6 +4700,7 @@ return typeof Math.imul === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4665,6 +4751,7 @@ return typeof Math.sign === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4715,6 +4802,7 @@ return typeof Math.log10 === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4765,6 +4853,7 @@ return typeof Math.log2 === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4815,6 +4904,7 @@ return typeof Math.log1p === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4865,6 +4955,7 @@ return typeof Math.expm1 === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4915,6 +5006,7 @@ return typeof Math.cosh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -4965,6 +5057,7 @@ return typeof Math.sinh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5015,6 +5108,7 @@ return typeof Math.tanh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5065,6 +5159,7 @@ return typeof Math.acosh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5115,6 +5210,7 @@ return typeof Math.asinh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5165,6 +5261,7 @@ return typeof Math.atanh === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5215,6 +5312,7 @@ return typeof Math.hypot === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5265,6 +5363,7 @@ return typeof Math.trunc === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5315,6 +5414,7 @@ return typeof Math.fround === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5365,6 +5465,7 @@ return typeof Math.cbrt === 'function';
 
           <td class="no tr">No</td>
           <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5405,7 +5506,7 @@ return typeof Math.cbrt === 'function';
           <td class="yes ios8">Yes</td>
         </tr>
         <tr>
-          <th colspan="43" class="separator"></th>
+          <th colspan="44" class="separator"></th>
         </tr>
         <tr>
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[15]</sup></a></span></td>
@@ -5438,6 +5539,7 @@ return passed;
 
           <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -5491,6 +5593,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
 
           <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="no ie11">No</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5557,6 +5660,7 @@ return !!(desc
 
           <td title="This feature is optional on non-browser platforms." class="not-applicable tr">No</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="no firefox11 obsolete">No</td>
@@ -5621,6 +5725,7 @@ return true;
 
           <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
@@ -5671,6 +5776,7 @@ return typeof RegExp.prototype.compile === 'function';
 
           <td title="This feature is optional on non-browser platforms." class="not-applicable tr">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="not-applicable ejs">No</td>
+          <td title="This feature is optional on non-browser platforms." class="not-applicable closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>


### PR DESCRIPTION
Google Closure Compiler began to support ES6 transpiration.
https://github.com/google/closure-compiler/wiki/ECMAScript6

I created [test tool](https://github.com/teppeis/closure-compiler-es6-compat-table) and added the result to es6 table.
