### PR TITLE
Updated note about Firefox and __proto__ restrictions

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1048,7 +1048,7 @@ exports.tests = [
     firefox33:   {
       val: true,
       note_id: 'fx-proto-shorthand',
-      note_html: 'Firefox 33+ incorrectly regards both of the following as true: <ul>'
+      note_html: 'Firefox 33 and 34 incorrectly regard both of the following as true: <ul>'
       +'<li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code>'
       +'<li><code>({ __proto__(){} }) instanceof Function</code>'
       +'</ul>'

--- a/es6/index.html
+++ b/es6/index.html
@@ -5759,7 +5759,7 @@ return typeof RegExp.prototype.compile === 'function';
         <sup>[15]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
       <p id="fx-proto-shorthand-note">
-        <sup>[16]</sup> Firefox 33+ incorrectly regards both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
+        <sup>[16]</sup> Firefox 33 and 34 incorrectly regard both of the following as true: <ul><li><code>var __proto__ = []; ({ __proto__ }) instanceof Array</code><li><code>({ __proto__(){} }) instanceof Function</code></ul>
       </p>
       <p id="hoisted-block-level-function-note">
         <sup>[17]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.


### PR DESCRIPTION
Correct behavior was implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1061853.
