### PR TITLE
Fixed bugs in Safari 7.1 commit

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1816,7 +1816,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     safari51:    false,
     safari6:     false,
     safari7:     false,
-    safari71_8:  true,
+    safari71_8:  { val: true, note_id: 'map-constructor' },
     webkit:      { val: true, note_id: 'map-constructor' },
     opera:       false,
     konq49:      false,
@@ -1874,7 +1874,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     safari51:    false,
     safari6:     false,
     safari7:     false,
-    safari71_8:  true,
+    safari71_8:  { val: true, note_id: 'map-constructor' },
     webkit:      { val: true, note_id: 'map-constructor' },
     opera:       false,
     konq49:      false,
@@ -1935,7 +1935,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     safari51:    false,
     safari6:     false,
     safari7:     false,
-    safari71_8:  true,
+    safari71_8:  { val: true, note_id: 'weakmap-constructor' },
     webkit:      { val: true, note_id: 'weakmap-constructor' },
     opera:       false,
     konq49:      false,
@@ -2358,7 +2358,11 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     safari51:    false,
     safari6:     false,
     safari7:     false,
-    safari71_8:  true,
+    safari71_8:  {
+      val: true,
+      note_id: 'fx-destructuring',
+      note_html: 'Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>'
+    },
     webkit:      true,
     opera:       false,
     konq49:      false,
@@ -2367,11 +2371,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     node:        false,
     nodeharmony: false,
     ios7:        false,
-    ios8:        {
-      val: true,
-      note_id: 'fx-destructuring',
-      note_html: 'iOS 8 fails to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>'
-    },
+    ios8:        { val: true, note_id: 'fx-destructuring' },
   }
 },
 {

--- a/es6/index.html
+++ b/es6/index.html
@@ -69,7 +69,7 @@
         <tr>
           <th colspan="3"  class="platformtype ignore"></th>
           <th colspan="3"  class="platformtype ignore compiler" style="background: #ffdfa4">Compilers</th>
-          <th colspan="15" class="platformtype ignore desktop"  style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="16" class="platformtype ignore desktop"  style="background: #fff4c3">Desktop browsers</th>
           <th colspan="4"  class="platformtype ignore server"   style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype ignore mobile"   style="background: #f8daa0">Mobile</th>
         </tr>
@@ -1601,7 +1601,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes</td>
+          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -1658,7 +1658,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes</td>
+          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[7]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -1714,7 +1714,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar weakmap = new WeakMap
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes</td>
+          <td class="yes safari71_8">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="yes webkit">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -2104,7 +2104,7 @@ test(function(){try{return Function("\n// Array destructuring\nvar [a, , [b], g]
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes</td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[10]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -5960,7 +5960,7 @@ return typeof RegExp.prototype.compile === 'function';
         <sup>[9]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-destructuring-note">
-        <sup>[10]</sup> iOS 8 fails to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
+        <sup>[10]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
       <p id="fx-array-prototype-values-note">
         <sup>[11]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -69,7 +69,7 @@
         <tr>
           <th colspan="3"  class="platformtype ignore"></th>
           <th colspan="3"  class="platformtype ignore compiler" style="background: #ffdfa4">Compilers</th>
-          <th colspan="15" class="platformtype ignore desktop"  style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="16" class="platformtype ignore desktop"  style="background: #fff4c3">Desktop browsers</th>
           <th colspan="4"  class="platformtype ignore server"   style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype ignore mobile"   style="background: #f8daa0">Mobile</th>
         </tr>

--- a/master.js
+++ b/master.js
@@ -17,7 +17,7 @@ domready(function() {
   showObsolete.onclick = function() {
     this.setAttribute('value', this.getAttribute('value') === "on" ? "off" : "on");
 
-    document.getElementsByClassName('desktop')[0].colSpan = showObsolete.checked ? 32 : 15;
+    document.getElementsByClassName('desktop')[0].colSpan = showObsolete.checked ? 33 : 16;
   };
   showObsolete.setAttribute('value', showObsolete.checked);
 


### PR DESCRIPTION
- The colspan of the "desktop" platform column wasn't updated.
- Added Map, Set, WeakMap and destructuring notes to Safari 7.1's results.
