### PR TITLE
Replace the colour strip with a coloured bar graph

### DIFF
--- a/master.css
+++ b/master.css
@@ -219,35 +219,3 @@ label[for="sort"] {
 .this-browser {
     background-color: #eef; color: #55f; text-transform: uppercase; padding: 4px 5px; width: 110px; font-size: 13px; vertical-align: top; 
 }
-
-/* browser engine color stripes */
-
-/* Trident */
-th[class^=ie] {
-  border-bottom: 5px solid #2571ed;
-}
-/* SpiderMonkey */
-th[class^=firefox],
-th[class^=rhino] {
-  border-bottom: 5px solid #E66000;
-}
-/* JavaScriptCore */
-th[class^=webkit],
-th[class^=safari],
-th[class^=phantom],
-th[class^=ios] {
-  border-bottom: 5px solid #b2b2b2;
-}
-/* V8 */
-th[class^=chrome],
-th[class^=node] {
-  border-bottom: 5px solid #4db848;
-}
-/* Carakan */
-th[class^=opera] {
-  border-bottom: 5px solid #CC0F16;
-}
-/* KJS */
-th[class^=konq] {
-  border-bottom: 5px solid #7BD2FF;
-}

--- a/master.js
+++ b/master.js
@@ -23,6 +23,7 @@ window.test = function(expression) {
 document.write('<style>td:nth-of-type(2) { outline: #aaf solid 3px; }</style>');
 
 $(function() {
+  'use strict';
   var table = $('#table-wrapper');
   var currentBrowserSelector = ":nth-of-type(2)";
 

--- a/master.js
+++ b/master.js
@@ -132,6 +132,38 @@ $(function() {
     }
   };
   window.onhashchange();
+  
+  // browser engine color stripes
+  function getBrowserColour(name) {
+    /* Trident */
+    if (/^ie/.exec(name)) { 
+      return "hsla(217, 85%, 54%, .5)";
+    }
+    /* SpiderMonkey */
+    if (/^(firefox|rhino)/.exec(name)) {
+      return "hsla(35, 100%, 50%, .5)";
+    }
+    /* JavaScriptCore */
+    if (/^(webkit|safari|phantom|ios)/.exec(name)) {
+      return "hsla(0, 0%, 70%, .5)";
+    }
+    /* V8 */
+    if (/^(chrome|node)/.exec(name)) {
+      return "hsla(79, 100%, 37%, .5)";
+    }
+    /* Carakan */
+    if (/^opera/.exec(name)) {
+      return "hsla(358, 86%, 43%, .5)";
+    }
+    /* KJS */
+    if (/^konq/.exec(name)) {
+      return "hsla(200, 100%, 74%, .5)";
+    }
+    if (name === "current") {
+      return "hsla(0, 0%, 88%, .5)";
+    }
+    return "hsla(52, 85%, 63%, .5)";
+  }
 
   // store number of features for each column/browser and numeric index
   $('.browser-name, th.current').each(function(i) {
@@ -149,6 +181,7 @@ $(function() {
     var yesResults = results.filter('.yes');
     var featuresCount = yesResults.length / results.length;
 
+    var colour = getBrowserColour(elem.attr('class'));
     elem
       .attr('data-num', i)
       .attr('data-features', featuresCount)
@@ -159,7 +192,8 @@ $(function() {
         '</b>/' +
         results.length + '</sup>')
       // Fancy bar graph background garnish (again, no fallback required).
-      .css({'background-image':'linear-gradient(to top, #ddd 0%, #ddd ' +
+      .css({'background-image':'linear-gradient(to top, ' +
+        colour + ' 0%, ' + colour + ' ' +
         (featuresCount * 100|0) + '%, transparent ' + (featuresCount * 100|0) +
         '%,transparent 100%)'});
   });

--- a/master.js
+++ b/master.js
@@ -145,7 +145,7 @@ $(function() {
     }
     /* JavaScriptCore */
     if (/^(webkit|safari|phantom|ios)/.exec(name)) {
-      return "hsla(0, 0%, 70%, .5)";
+      return "hsla(220, 25%, 70%, .5)";
     }
     /* V8 */
     if (/^(chrome|node)/.exec(name)) {
@@ -159,13 +159,22 @@ $(function() {
     if (/^konq/.exec(name)) {
       return "hsla(200, 100%, 74%, .5)";
     }
-    if (name === "current") {
-      return "hsla(0, 0%, 88%, .5)";
+    /* BESEN */
+    if (name === "besen") {
+      return "rgba(173, 108, 23, .5)";
     }
-    return "hsla(52, 85%, 63%, .5)";
+    /* Current browser */
+    if (name === "current") {
+      return "hsla(0, 0%, 75%, .5)";
+    }
+    /* Compilers */
+    return "hsla(52, 85%, 63%, .5)";    
   }
 
-  // store number of features for each column/browser and numeric index
+  // Store number of features for each column/browser and numeric index.
+  // The reason this is done at runtime instead of build time is because
+  // the current browser's totals must be done at runtime, and to save on
+  // duplicated code, we may as well do the predefined results too.
   $('.browser-name, th.current').each(function(i) {
     var elem = $(this);
     var name;


### PR DESCRIPTION
As discussed in the notes to #268, this removes the thin full-colour stripe, and instead changes the background bar-graph to use a grayed version of the colours. This avoids issues where e.g. Firefox's colour/stripe clashes with the No cells' colour.
![](http://i.imgur.com/GGJpGBq.png)
