### PR TITLE
Marked Firefox 24 as obsolete (ESR expired)

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -66,7 +66,7 @@ exports.browsers = {
   firefox24: {
     full: 'Firefox',
     short: 'FF 24',
-    obsolete: false // ESR (EOL at end of 2014)
+    obsolete: true
   },
   firefox25: {
     full: 'Firefox',
@@ -90,7 +90,8 @@ exports.browsers = {
   },
   firefox31: {
     full: 'Firefox',
-    short: 'FF 31'
+    short: 'FF 31',
+    obsolete: false // ESR (EOL at Aug 2015)
   },
   firefox32: {
     full: 'Firefox',

--- a/es6/index.html
+++ b/es6/index.html
@@ -88,7 +88,7 @@
           <th class="firefox17 obsolete"><a href="#firefox17" class="browser-name"><abbr title="Firefox">FF 17</abbr></th>
           <th class="firefox18 obsolete"><a href="#firefox18" class="browser-name"><abbr title="Firefox">FF 18</abbr></th>
           <th class="firefox23 obsolete"><a href="#firefox23" class="browser-name"><abbr title="Firefox">FF 23</abbr></th>
-          <th class="firefox24"><a href="#firefox24" class="browser-name"><abbr title="Firefox">FF 24</abbr></th>
+          <th class="firefox24 obsolete"><a href="#firefox24" class="browser-name"><abbr title="Firefox">FF 24</abbr></th>
           <th class="firefox25 obsolete"><a href="#firefox25" class="browser-name"><abbr title="Firefox">FF 25</abbr></th>
           <th class="firefox27 obsolete"><a href="#firefox27" class="browser-name"><abbr title="Firefox">FF 27-28</abbr></th>
           <th class="firefox29 obsolete"><a href="#firefox29" class="browser-name"><abbr title="Firefox">FF 29</abbr></th>
@@ -147,7 +147,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -209,7 +209,7 @@ return true;
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -269,7 +269,7 @@ try {
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -347,7 +347,7 @@ test((function () {
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -406,7 +406,7 @@ test(function(){try{return Function("\nvar passed = (function (a = 1, b = 2) { r
           <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
           <td class="yes firefox23 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
-          <td class="yes firefox24">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
           <td class="yes firefox25 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
           <td class="yes firefox27 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes<a href="#fx-defaults-scope-note"><sup>[3]</sup></a></td>
@@ -457,7 +457,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -508,7 +508,7 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n  ")
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -559,7 +559,7 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n  ")()}c
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -610,7 +610,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td class="no firefox17 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
           <td class="no firefox18 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
           <td class="no firefox23 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
           <td class="no firefox25 obsolete">No<a href="#fx-spreading-strings-note"><sup>[4]</sup></a></td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -666,7 +666,7 @@ test(function(){try{return Function("\nclass C extends Array {\n  constructor() 
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -739,7 +739,7 @@ test(function(){try{return Function("\nvar passed = true;\nvar B = class extends
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -791,7 +791,7 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -843,7 +843,7 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -894,7 +894,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -946,7 +946,7 @@ test(function(){try{return Function("\nexport var foo = 1;\nreturn true;\n  ")()
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -999,7 +999,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1062,7 +1062,7 @@ test(function(){try{return Function("\nvar generator = (function* () {\n  yield*
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1113,7 +1113,7 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n  ")()}
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
           <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
@@ -1164,7 +1164,7 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n  ")()}
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
           <td class="yes firefox27 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes<a href="#octal-to-string-note"><sup>[5]</sup></a></td>
@@ -1217,7 +1217,7 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -1279,7 +1279,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -1334,7 +1334,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1385,7 +1385,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -1460,7 +1460,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar pa
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1523,7 +1523,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1580,7 +1580,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1637,7 +1637,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1693,7 +1693,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar weakmap = new WeakMap
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="yes firefox23 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox24">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="yes firefox25 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="yes firefox27 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[8]</sup></a></td>
@@ -1750,7 +1750,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -1812,7 +1812,7 @@ return false;
           <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -1888,7 +1888,7 @@ return true;
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -1968,7 +1968,7 @@ return true;
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2023,7 +2023,7 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2083,7 +2083,7 @@ test(function(){try{return Function("\n// Array destructuring\nvar [a, , [b], g]
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2136,7 +2136,7 @@ test(function(){try{return Function("\nreturn (function({a, x:b}, [c, d]) {\n  r
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2188,7 +2188,7 @@ test(function(){try{return Function("\nvar {a = 1, b = 1, c = 3} = {b:2, c:undef
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2242,7 +2242,7 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2296,7 +2296,7 @@ return typeof Promise !== 'undefined' &&
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2348,7 +2348,7 @@ return typeof Object.assign === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2400,7 +2400,7 @@ return typeof Object.is === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2452,7 +2452,7 @@ return typeof Object.getOwnPropertySymbols === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2504,7 +2504,7 @@ return typeof Object.setPrototypeOf === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2556,7 +2556,7 @@ return (function foo(){}).name == 'foo';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2608,7 +2608,7 @@ return typeof Function.prototype.toMethod === "function";
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2660,7 +2660,7 @@ return typeof String.raw === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2712,7 +2712,7 @@ return typeof String.fromCodePoint === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2764,7 +2764,7 @@ return typeof String.prototype.codePointAt === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2820,7 +2820,7 @@ return typeof String.prototype.normalize === "function"
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -2872,7 +2872,7 @@ return typeof String.prototype.repeat === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2924,7 +2924,7 @@ return typeof String.prototype.startsWith === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -2976,7 +2976,7 @@ return typeof String.prototype.endsWith === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -3028,7 +3028,7 @@ return typeof String.prototype.contains === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -3079,7 +3079,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3155,7 +3155,7 @@ catch(e) {
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3208,7 +3208,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3264,7 +3264,7 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3318,7 +3318,7 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3369,7 +3369,7 @@ test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] 
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3433,7 +3433,7 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3493,7 +3493,7 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3546,7 +3546,7 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3601,7 +3601,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3653,7 +3653,7 @@ return typeof RegExp.prototype.match === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3705,7 +3705,7 @@ return typeof RegExp.prototype.replace === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3757,7 +3757,7 @@ return typeof RegExp.prototype.search === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3809,7 +3809,7 @@ return typeof RegExp.prototype.split === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3861,7 +3861,7 @@ return typeof Array.from === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -3913,7 +3913,7 @@ return typeof Array.of === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -3965,7 +3965,7 @@ return typeof Array.prototype.copyWithin === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4017,7 +4017,7 @@ return typeof Array.prototype.find === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4069,7 +4069,7 @@ return typeof Array.prototype.findIndex === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4121,7 +4121,7 @@ return typeof Array.prototype.fill === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4173,7 +4173,7 @@ return typeof Array.prototype.keys === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4225,7 +4225,7 @@ return typeof Array.prototype.values === 'function';
           <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
           <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
           <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
-          <td class="no firefox24">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
           <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[11]</sup></a></td>
           <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[12]</sup></a></td>
           <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[12]</sup></a></td>
@@ -4277,7 +4277,7 @@ return typeof Array.prototype.entries === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4333,7 +4333,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4385,7 +4385,7 @@ return typeof Number.isFinite === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4437,7 +4437,7 @@ return typeof Number.isInteger === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4489,7 +4489,7 @@ return typeof Number.isSafeInteger === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4541,7 +4541,7 @@ return typeof Number.isNaN === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4593,7 +4593,7 @@ return typeof Number.EPSILON === 'number';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4645,7 +4645,7 @@ return typeof Number.MIN_SAFE_INTEGER === 'number';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4697,7 +4697,7 @@ return typeof Number.MAX_SAFE_INTEGER === 'number';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4749,7 +4749,7 @@ return typeof Math.clz32 === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -4801,7 +4801,7 @@ return typeof Math.imul === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4853,7 +4853,7 @@ return typeof Math.sign === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4905,7 +4905,7 @@ return typeof Math.log10 === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -4957,7 +4957,7 @@ return typeof Math.log2 === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5009,7 +5009,7 @@ return typeof Math.log1p === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5061,7 +5061,7 @@ return typeof Math.expm1 === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5113,7 +5113,7 @@ return typeof Math.cosh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5165,7 +5165,7 @@ return typeof Math.sinh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5217,7 +5217,7 @@ return typeof Math.tanh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5269,7 +5269,7 @@ return typeof Math.acosh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5321,7 +5321,7 @@ return typeof Math.asinh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5373,7 +5373,7 @@ return typeof Math.atanh === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5425,7 +5425,7 @@ return typeof Math.hypot === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5477,7 +5477,7 @@ return typeof Math.trunc === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5529,7 +5529,7 @@ return typeof Math.fround === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[14]</sup></a></td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5581,7 +5581,7 @@ return typeof Math.cbrt === 'function';
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5656,7 +5656,7 @@ return passed;
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5711,7 +5711,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no firefox17 obsolete">No</td>
           <td class="no firefox18 obsolete">No</td>
           <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24">No</td>
+          <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
           <td class="no firefox27 obsolete">No</td>
           <td class="no firefox29 obsolete">No</td>
@@ -5779,7 +5779,7 @@ return !!(desc
           <td class="no firefox17 obsolete">No</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5845,7 +5845,7 @@ return true;
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
@@ -5897,7 +5897,7 @@ return typeof RegExp.prototype.compile === 'function';
           <td class="yes firefox17 obsolete">Yes</td>
           <td class="yes firefox18 obsolete">Yes</td>
           <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
           <td class="yes firefox25 obsolete">Yes</td>
           <td class="yes firefox27 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>


### PR DESCRIPTION
Firefox 24's extended support end-of-life was a week ago. This also marks Firefox 31 as having ESR until late 2015.
