### PR TITLE
Fixed some Safari 5.1 results.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1660,7 +1660,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     ie10:        {
       val: false,
       note_id: 'ie-typedarray',
-      note_html: 'Internet Explorer supports every typed array class except <code>Uint8ClampedArray</code>.'
+      note_html: 'Internet Explorer and Safari 5.1 support every typed array class except <code>Uint8ClampedArray</code>.'
     },
     ie11:        { val: false, note_id: 'ie-typedarray' },
     firefox11:   true,
@@ -1688,7 +1688,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     chrome35:    true,
     chrome37:    true,
     chrome39:    true,
-    safari51:    true,
+    safari51:    { val: false, note_id: 'ie-typedarray' },
     safari6:     true,
     safari7:     true,
     safari71_8:  true,
@@ -2844,7 +2844,7 @@ ${a + "z"} ${b.toLowerCase()}` === "foo bar\nbaz qux";
     chrome35:    true,
     chrome37:    true,
     chrome39:    true,
-    safari51:    true,
+    safari51:    false,
     safari6:     true,
     safari7:     true,
     safari71_8:  true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -1478,7 +1478,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar pa
           <td class="yes chrome35">Yes</td>
           <td class="yes chrome37">Yes</td>
           <td class="yes chrome39">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
+          <td class="no safari51 obsolete">No<a href="#ie-typedarray-note"><sup>[6]</sup></a></td>
           <td class="yes safari6">Yes</td>
           <td class="yes safari7">Yes</td>
           <td class="yes safari71_8">Yes</td>
@@ -5797,7 +5797,7 @@ return !!(desc
           <td class="yes chrome35">Yes</td>
           <td class="yes chrome37">Yes</td>
           <td class="yes chrome39">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
+          <td class="no safari51 obsolete">No</td>
           <td class="yes safari6">Yes</td>
           <td class="yes safari7">Yes</td>
           <td class="yes safari71_8">Yes</td>
@@ -5948,7 +5948,7 @@ return typeof RegExp.prototype.compile === 'function';
         <sup>[5]</sup> Firefox doesn't support <code>Number("0o1")</code> and <code>Number("0b1")</code> evaluating to 1 instead of NaN.
       </p>
       <p id="ie-typedarray-note">
-        <sup>[6]</sup> Internet Explorer supports every typed array class except <code>Uint8ClampedArray</code>.
+        <sup>[6]</sup> Internet Explorer and Safari 5.1 support every typed array class except <code>Uint8ClampedArray</code>.
       </p>
       <p id="map-constructor-note">
         <sup>[7]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.


### PR DESCRIPTION
Safari 5.1 does not actually fully support `Object.prototype.__proto__` or `Uint8ClampedArray`.
