### PR TITLE
Fixed #291, added FF35, and updated CH39 results.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -23,7 +23,7 @@ exports.browsers = {
   },
   closure: {
     full: 'Closure Compiler v20140923',
-    short: 'Closure Compiler',
+    short: 'Closure<br>Compiler',
     obsolete: false, // always up-to-date version
     platformtype: 'compiler',
   },
@@ -115,6 +115,10 @@ exports.browsers = {
     full: 'Firefox',
     short: 'FF 34'
   },
+  firefox35: {
+    full: 'Firefox',
+    short: 'FF 35'
+  },
   chrome: {
     full: 'Chrome',
     short: 'CH &lt;19',
@@ -204,7 +208,7 @@ exports.browsers = {
   },
   safari71_8: {
     full: 'Safari',
-    short: 'SF 7.1, SF 8',
+    short: 'SF 7.1,<br>SF 8',
     obsolete: false
   },
   webkit: {
@@ -241,7 +245,7 @@ exports.browsers = {
   },
   nodeharmony: {
     full: 'Node 0.11.14 harmony',
-    short: 'Node harmony',
+    short: 'Node<br>harmony',
     obsolete: false, // current version
     platformtype: 'engine',
     note_id: 'harmony-flag',
@@ -578,6 +582,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
+        firefox11:   { val: false, note_id: 'fx-let', },
       },
     },
     'for-loop statement scope': {
@@ -590,6 +595,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
+        firefox11:   { val: false, note_id: 'fx-let', },
       },
     },
     'temporal dead zone': {
@@ -655,6 +661,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
+        firefox11:   { val: false, note_id: 'fx-let', },
         chrome19dev: true,
         nodeharmony: true,
       },
@@ -670,6 +677,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
+        firefox11:   { val: false, note_id: 'fx-let', },
         chrome19dev: true,
         chrome37:    false, // this test crashes the tab
         chrome38:    true,
@@ -686,6 +694,7 @@ exports.tests = [
       res: {
         ejs:         true,
         ie11:        true,
+        firefox35:   { val: false, note_id: 'fx-let-tdz', },
         chrome19dev: true,
         nodeharmony: true,
       },
@@ -1119,6 +1128,7 @@ exports.tests = [
         }
       */},
       res: {
+        firefox35:    true,
       },
     },
     'not a computed property': {
@@ -1135,13 +1145,17 @@ exports.tests = [
         var __proto__ = [];
         return !({ __proto__ } instanceof Array);
       */},
-      res: {},
+      res: {
+        firefox35:    true,
+      },
     },
     'not a shorthand method': {
       exec: function() {/*
-        return !({ __proto__(){} }) instanceof Function;
+        return !({ __proto__(){} } instanceof Function);
       */},
-      res: {},
+      res: {
+        firefox35:    true,
+      },
     },
   },
 },
@@ -1267,6 +1281,8 @@ exports.tests = [
       res: {
         tr:          true,
         closure:     true,
+        chrome39:    true,
+        firefox35:   true,
       },
     },
   },
@@ -1382,6 +1398,7 @@ exports.tests = [
       */},
       res: {
         firefox11:   true,
+        chrome39:    true,
       },
     },
     '"u" flag': {
@@ -2657,6 +2674,7 @@ exports.tests = [
       */},
       res: {
         firefox34:    true,
+        chrome39:     true,
       },
     },
     'symbol-keyed methods': {
@@ -3093,7 +3111,9 @@ exports.tests = [
       exec: function(){/*
         return String(Symbol("foo")) === "Symbol(foo)";
       */},
-      res: {},
+      res: {
+        chrome39:    true,
+      },
     },
     'new Symbol() throws': {
       exec: function(){/*

--- a/es6/index.html
+++ b/es6/index.html
@@ -79,7 +79,7 @@
           <th></th>
           <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></th>
           <th class="platform ejs compiler"><a href="#ejs" class="browser-name"><abbr title="Echo JS">EJS</abbr></th>
-          <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20140923">Closure Compiler</abbr></th>
+          <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20140923">Closure<br>Compiler</abbr></th>
           <th class="platform ie10 desktop"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></th>
           <th class="platform ie11 desktop"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></th>
           <th class="platform firefox11 obsolete desktop"><a href="#firefox11" class="browser-name"><abbr title="Firefox">FF 11-12</abbr></th>
@@ -98,6 +98,7 @@
           <th class="platform firefox32 obsolete desktop"><a href="#firefox32" class="browser-name"><abbr title="Firefox">FF 32</abbr></th>
           <th class="platform firefox33 desktop"><a href="#firefox33" class="browser-name"><abbr title="Firefox">FF 33</abbr></th>
           <th class="platform firefox34 desktop"><a href="#firefox34" class="browser-name"><abbr title="Firefox">FF 34</abbr></th>
+          <th class="platform firefox35 desktop"><a href="#firefox35" class="browser-name"><abbr title="Firefox">FF 35</abbr></th>
           <th class="platform chrome obsolete desktop"><a href="#chrome" class="browser-name"><abbr title="Chrome">CH &lt;19</abbr></th>
           <th class="platform chrome19dev obsolete desktop"><a href="#chrome19dev" class="browser-name"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
           <th class="platform chrome21dev obsolete desktop"><a href="#chrome21dev" class="browser-name"><abbr title="Chrome">CH 21-29</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
@@ -113,14 +114,14 @@
           <th class="platform safari51 obsolete desktop"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></th>
           <th class="platform safari6 desktop"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></th>
           <th class="platform safari7 desktop"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 7.0</abbr></th>
-          <th class="platform safari71_8 desktop"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1, SF 8</abbr></th>
+          <th class="platform safari71_8 desktop"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></th>
           <th class="platform webkit desktop"><a href="#webkit" class="browser-name"><abbr title="WebKit r173886">WK</abbr></th>
           <th class="platform opera desktop"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></th>
           <th class="platform konq49 desktop"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[2]</sup></a></th>
           <th class="platform rhino17 engine"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></th>
           <th class="platform phantom engine"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></th>
           <th class="platform node engine"><a href="#node" class="browser-name"><abbr title="Node 0.10">Node</abbr></th>
-          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node harmony</abbr><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node<br>harmony</abbr><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
           <th class="platform ios7 mobile"><a href="#ios7" class="browser-name"><abbr title="iOS Safari">iOS7</abbr></th>
           <th class="platform ios8 mobile"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS8</abbr></th>
         </tr>
@@ -161,6 +162,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -211,6 +213,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="tally firefox32 obsolete" data-tally="0.75">6/8</td>
           <td class="tally firefox33" data-tally="0.75">6/8</td>
           <td class="tally firefox34" data-tally="0.75">6/8</td>
+          <td class="tally firefox35" data-tally="0.75">6/8</td>
           <td class="tally chrome obsolete" data-tally="0">0/8</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/8</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/8</td>
@@ -265,6 +268,7 @@ test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}cat
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -320,6 +324,7 @@ test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fe
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -375,6 +380,7 @@ test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w +
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -431,6 +437,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -487,6 +494,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -542,6 +550,7 @@ test(function(){try{return Function("\nvar f = (function() { return z => argumen
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -598,6 +607,7 @@ test(function(){try{return Function("\nreturn () => {\n  try { Function(\"x\\n =
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -653,6 +663,7 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -703,6 +714,7 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
           <td class="tally firefox32 obsolete" data-tally="0.375">3/8</td>
           <td class="tally firefox33" data-tally="0.375">3/8</td>
           <td class="tally firefox34" data-tally="0.375">3/8</td>
+          <td class="tally firefox35" data-tally="0.375">3/8</td>
           <td class="tally chrome obsolete" data-tally="0.25">2/8</td>
           <td class="tally chrome19dev obsolete" data-tally="0.5">4/8</td>
           <td class="tally chrome21dev obsolete" data-tally="0.625">5/8</td>
@@ -758,6 +770,7 @@ test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -813,6 +826,7 @@ test(function(){try{return Function("\n{ const bar = 456; }\nreturn (function(){
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -872,6 +886,7 @@ test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -928,6 +943,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try { qux; } ca
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -984,6 +1000,7 @@ test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1040,6 +1057,7 @@ test(function(){try{return Function("\n'use strict';\n{ const bar = 456; }\nretu
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1100,6 +1118,7 @@ test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  F
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1157,6 +1176,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1207,6 +1227,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="tally firefox32 obsolete" data-tally="0">0/10</td>
           <td class="tally firefox33" data-tally="0">0/10</td>
           <td class="tally firefox34" data-tally="0">0/10</td>
+          <td class="tally firefox35" data-tally="0">0/10</td>
           <td class="tally chrome obsolete" data-tally="0">0/10</td>
           <td class="tally chrome19dev obsolete" data-tally="0.4">4/10</td>
           <td class="tally chrome21dev obsolete" data-tally="0.4">4/10</td>
@@ -1262,6 +1283,7 @@ test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n  
           <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1301,22 +1323,23 @@ test(function(){try{return Function("\n{ let bar = 456; }\nreturn (function(){ t
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1356,22 +1379,23 @@ test(function(){try{return Function("\nfor(let baz = 0; false;) {}\nreturn (func
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1428,6 +1452,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1493,6 +1518,7 @@ test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1549,6 +1575,7 @@ test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (fo
           <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1589,22 +1616,23 @@ test(function(){try{return Function("\n'use strict';\n{ let bar = 456; }\nreturn
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1645,22 +1673,23 @@ test(function(){try{return Function("\n'use strict';\nfor(let baz = 0; false;) {
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1718,6 +1747,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1784,6 +1814,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1834,6 +1865,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
           <td class="tally firefox32 obsolete" data-tally="0.75">3/4</td>
           <td class="tally firefox33" data-tally="0.75">3/4</td>
           <td class="tally firefox34" data-tally="0.75">3/4</td>
+          <td class="tally firefox35" data-tally="0.75">3/4</td>
           <td class="tally chrome obsolete" data-tally="0">0/4</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
@@ -1888,6 +1920,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1942,6 +1975,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1996,6 +2030,7 @@ test(function(){try{return Function("\nreturn (function (a, b = a) { return b ==
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2064,6 +2099,7 @@ test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    e
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2119,6 +2155,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2169,6 +2206,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td class="tally firefox32 obsolete" data-tally="1">4/4</td>
           <td class="tally firefox33" data-tally="1">4/4</td>
           <td class="tally firefox34" data-tally="1">4/4</td>
+          <td class="tally firefox35" data-tally="1">4/4</td>
           <td class="tally chrome obsolete" data-tally="0">0/4</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
@@ -2223,6 +2261,7 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n    
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2277,6 +2316,7 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2331,6 +2371,7 @@ test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n    
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2385,6 +2426,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2435,6 +2477,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td class="tally firefox32 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox33" data-tally="0">0/6</td>
           <td class="tally firefox34" data-tally="0">0/6</td>
+          <td class="tally firefox35" data-tally="0">0/6</td>
           <td class="tally chrome obsolete" data-tally="0">0/6</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/6</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/6</td>
@@ -2490,6 +2533,7 @@ test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"functio
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2544,6 +2588,7 @@ test(function(){try{return Function("\nreturn typeof class C {} === \"function\"
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2602,6 +2647,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2661,6 +2707,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  method()
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2720,6 +2767,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  static m
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2776,6 +2824,7 @@ test(function(){try{return Function("\nclass C extends Array {}\nreturn Array.is
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2853,6 +2902,7 @@ test(function(){try{return Function("\nvar passed = true;\nvar B = class extends
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -2903,6 +2953,7 @@ test(function(){try{return Function("\nvar passed = true;\nvar B = class extends
           <td class="tally firefox32 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox33" data-tally="0.3333333333333333">1/3</td>
           <td class="tally firefox34" data-tally="1">3/3</td>
+          <td class="tally firefox35" data-tally="1">3/3</td>
           <td class="tally chrome obsolete" data-tally="0">0/3</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/3</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/3</td>
@@ -2958,6 +3009,7 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3013,6 +3065,7 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
           <td class="no firefox32 obsolete">No</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3067,6 +3120,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3124,6 +3178,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3174,6 +3229,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td class="tally firefox32 obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally firefox33" data-tally="0.6666666666666666">2/3</td>
           <td class="tally firefox34" data-tally="0.6666666666666666">2/3</td>
+          <td class="tally firefox35" data-tally="1">3/3</td>
           <td class="tally chrome obsolete" data-tally="0">0/3</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/3</td>
           <td class="tally chrome21dev obsolete" data-tally="0.6666666666666666">2/3</td>
@@ -3185,7 +3241,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td class="tally chrome36 obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally chrome37 obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally chrome38" data-tally="0.6666666666666666">2/3</td>
-          <td class="tally chrome39" data-tally="0.6666666666666666">2/3</td>
+          <td class="tally chrome39" data-tally="1">3/3</td>
           <td class="tally safari51 obsolete" data-tally="0">0/3</td>
           <td class="tally safari6" data-tally="0">0/3</td>
           <td class="tally safari7" data-tally="0">0/3</td>
@@ -3238,6 +3294,7 @@ test(function(){try{return Function("\nfunction* generator(){\n  yield 5; yield 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -3303,6 +3360,7 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -3369,6 +3427,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3380,7 +3439,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td class="no chrome36 obsolete">No</td>
           <td class="no chrome37 obsolete">No</td>
           <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -3419,6 +3478,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td class="tally firefox32 obsolete" data-tally="0.5">2/4</td>
           <td class="tally firefox33" data-tally="0.5">2/4</td>
           <td class="tally firefox34" data-tally="0.5">2/4</td>
+          <td class="tally firefox35" data-tally="0.5">2/4</td>
           <td class="tally chrome obsolete" data-tally="0">0/4</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
@@ -3473,6 +3533,7 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      "
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3527,6 +3588,7 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      "
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3581,6 +3643,7 @@ test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}c
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3635,6 +3698,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3685,6 +3749,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
           <td class="tally firefox32 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox33" data-tally="0">0/2</td>
           <td class="tally firefox34" data-tally="1">2/2</td>
+          <td class="tally firefox35" data-tally="1">2/2</td>
           <td class="tally chrome obsolete" data-tally="0">0/2</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/2</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/2</td>
@@ -3741,6 +3806,7 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3806,6 +3872,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3856,6 +3923,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="tally firefox32 obsolete" data-tally="0.5">1/2</td>
           <td class="tally firefox33" data-tally="0.5">1/2</td>
           <td class="tally firefox34" data-tally="0.5">1/2</td>
+          <td class="tally firefox35" data-tally="0.5">1/2</td>
           <td class="tally chrome obsolete" data-tally="0">0/2</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/2</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/2</td>
@@ -3867,7 +3935,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="tally chrome36 obsolete" data-tally="0">0/2</td>
           <td class="tally chrome37 obsolete" data-tally="0">0/2</td>
           <td class="tally chrome38" data-tally="0">0/2</td>
-          <td class="tally chrome39" data-tally="0">0/2</td>
+          <td class="tally chrome39" data-tally="0.5">1/2</td>
           <td class="tally safari51 obsolete" data-tally="0">0/2</td>
           <td class="tally safari6" data-tally="0">0/2</td>
           <td class="tally safari7" data-tally="0">0/2</td>
@@ -3914,6 +3982,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -3925,7 +3994,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
           <td class="no chrome36 obsolete">No</td>
           <td class="no chrome37 obsolete">No</td>
           <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -3968,6 +4037,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -4018,6 +4088,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td class="tally firefox32 obsolete" data-tally="0.45">18/40</td>
           <td class="tally firefox33" data-tally="0.45">18/40</td>
           <td class="tally firefox34" data-tally="0.475">19/40</td>
+          <td class="tally firefox35" data-tally="0.475">19/40</td>
           <td class="tally chrome obsolete" data-tally="0.45">18/40</td>
           <td class="tally chrome19dev obsolete" data-tally="0.45">18/40</td>
           <td class="tally chrome21dev obsolete" data-tally="0.45">18/40</td>
@@ -4074,6 +4145,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4130,6 +4202,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4186,6 +4259,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4242,6 +4316,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4298,6 +4373,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4354,6 +4430,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4410,6 +4487,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4466,6 +4544,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4522,6 +4601,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4579,6 +4659,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4636,6 +4717,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4693,6 +4775,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4750,6 +4833,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4807,6 +4891,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4864,6 +4949,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4921,6 +5007,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4978,6 +5065,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -5040,6 +5128,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.from === \"functi
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5102,6 +5191,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5164,6 +5254,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarra
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -5226,6 +5317,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5288,6 +5380,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5350,6 +5443,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastInd
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5412,6 +5506,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice =
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5474,6 +5569,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every =
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5536,6 +5632,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5598,6 +5695,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5660,6 +5758,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map ===
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5722,6 +5821,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5784,6 +5884,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceR
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5846,6 +5947,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5908,6 +6010,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -5970,6 +6073,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6032,6 +6136,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWit
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6094,6 +6199,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6156,6 +6262,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findInd
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6218,6 +6325,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6280,6 +6388,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys ==
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6342,6 +6451,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6404,6 +6514,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6448,7 +6559,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6465,31 +6576,32 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome31 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome35 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome36 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome37 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome38">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome31 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome35 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome36 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome37 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome38">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
         </tr>
         <tr>
           <td id="Set"><span><a class="anchor" href="#Set">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
@@ -6509,7 +6621,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6526,31 +6638,32 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome31 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome35 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome36 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome37 obsolete">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome38">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome31 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome35 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome36 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome37 obsolete">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome38">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
-          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#map-constructor-note"><sup>[5]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#map-constructor-note"><sup>[6]</sup></a></td>
         </tr>
         <tr>
           <td id="WeakMap"><span><a class="anchor" href="#WeakMap">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
@@ -6569,48 +6682,49 @@ test(function(){try{return Function("\nvar key1 = {};\nvar weakmap = new WeakMap
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
-          <td class="yes ie11">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox11 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox13 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox16 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox17 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox18 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes ie11">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox11 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox13 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox16 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox17 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox28 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox32 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox35">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome31 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome35 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome36 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome37 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome38">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome30 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome31 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome35 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome36 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome37 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome38">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes webkit">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes webkit">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
         </tr>
         <tr>
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -6647,18 +6761,19 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
           <td class="no chrome30 obsolete">No</td>
           <td class="yes chrome31 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome35 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome36 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome37 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome38">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
-          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes chrome33 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome34 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome35 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome36 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome37 obsolete">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome38">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
+          <td class="yes chrome39">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -6669,7 +6784,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[6]</sup></a></td>
+          <td class="yes nodeharmony">Yes<a href="#weakmap-constructor-note"><sup>[7]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -6697,6 +6812,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="tally firefox32 obsolete" data-tally="0.6666666666666666">10/15</td>
           <td class="tally firefox33" data-tally="0.7333333333333333">11/15</td>
           <td class="tally firefox34" data-tally="0.8">12/15</td>
+          <td class="tally firefox35" data-tally="0.8">12/15</td>
           <td class="tally chrome obsolete" data-tally="0">0/15</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/15</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/15</td>
@@ -6745,18 +6861,19 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox35">Yes<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6807,18 +6924,19 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
+          <td class="yes firefox35">Yes<a href="#fx-proxy-set-note"><sup>[9]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6880,6 +6998,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6941,6 +7060,7 @@ test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -6996,18 +7116,19 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7073,6 +7194,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7134,6 +7256,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nv
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7199,6 +7322,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nva
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7262,6 +7386,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7326,6 +7451,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7392,6 +7518,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nf
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7443,18 +7570,19 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7519,6 +7647,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7581,6 +7710,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7643,6 +7773,7 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7693,6 +7824,7 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
           <td class="tally firefox32 obsolete" data-tally="0">0/10</td>
           <td class="tally firefox33" data-tally="0">0/10</td>
           <td class="tally firefox34" data-tally="0">0/10</td>
+          <td class="tally firefox35" data-tally="0">0/10</td>
           <td class="tally chrome obsolete" data-tally="0">0/10</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/10</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/10</td>
@@ -7747,6 +7879,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.apply === \"functio
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7801,6 +7934,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.construct === \"fun
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7855,6 +7989,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.defineProperty === 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7909,6 +8044,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.deleteProperty === 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -7963,6 +8099,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.getOwnPropertyDescr
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8017,6 +8154,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.getPrototypeOf === 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8071,6 +8209,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.has === \"function\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8125,6 +8264,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.isExtensible === \"
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8179,6 +8319,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.set === \"function\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8233,6 +8374,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.setPrototypeOf === 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8260,7 +8402,7 @@ test(function(){try{return Function("\nreturn typeof Reflect.setPrototypeOf === 
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[12]</sup></a></span></td>
 <script data-source="
 'use strict';
 {
@@ -8292,6 +8434,7 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -8342,6 +8485,7 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
           <td class="tally firefox32 obsolete" data-tally="0.5714285714285714">4/7</td>
           <td class="tally firefox33" data-tally="0.5714285714285714">4/7</td>
           <td class="tally firefox34" data-tally="0.7142857142857143">5/7</td>
+          <td class="tally firefox35" data-tally="0.7142857142857143">5/7</td>
           <td class="tally chrome obsolete" data-tally="0">0/7</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/7</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/7</td>
@@ -8397,6 +8541,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8412,7 +8557,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -8421,7 +8566,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>object destructuring</span></td>
 <script data-source="
@@ -8452,6 +8597,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8467,7 +8613,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -8476,7 +8622,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>combined destructuring</span></td>
 <script data-source="
@@ -8507,6 +8653,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8522,7 +8669,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -8531,7 +8678,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[13]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>destructuring parameters</span></td>
 <script data-source="
@@ -8564,6 +8711,7 @@ test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8621,6 +8769,7 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8676,6 +8825,7 @@ test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undef
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8733,6 +8883,7 @@ test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8791,6 +8942,7 @@ return typeof Promise !== 'undefined' &&
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8841,6 +8993,7 @@ return typeof Promise !== 'undefined' &&
           <td class="tally firefox32 obsolete" data-tally="0.5">2/4</td>
           <td class="tally firefox33" data-tally="0.5">2/4</td>
           <td class="tally firefox34" data-tally="0.75">3/4</td>
+          <td class="tally firefox35" data-tally="0.75">3/4</td>
           <td class="tally chrome obsolete" data-tally="0">0/4</td>
           <td class="tally chrome19dev obsolete" data-tally="0.25">1/4</td>
           <td class="tally chrome21dev obsolete" data-tally="0.25">1/4</td>
@@ -8896,6 +9049,7 @@ test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true},
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8952,6 +9106,7 @@ test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -9009,6 +9164,7 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9063,6 +9219,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9113,6 +9270,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
           <td class="tally firefox32 obsolete" data-tally="0.1875">3/16</td>
           <td class="tally firefox33" data-tally="0.1875">3/16</td>
           <td class="tally firefox34" data-tally="0.25">4/16</td>
+          <td class="tally firefox35" data-tally="0.25">4/16</td>
           <td class="tally chrome obsolete" data-tally="0.125">2/16</td>
           <td class="tally chrome19dev obsolete" data-tally="0.125">2/16</td>
           <td class="tally chrome21dev obsolete" data-tally="0.125">2/16</td>
@@ -9124,7 +9282,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
           <td class="tally chrome36 obsolete" data-tally="0.125">2/16</td>
           <td class="tally chrome37 obsolete" data-tally="0.125">2/16</td>
           <td class="tally chrome38" data-tally="0.125">2/16</td>
-          <td class="tally chrome39" data-tally="0.125">2/16</td>
+          <td class="tally chrome39" data-tally="0.1875">3/16</td>
           <td class="tally safari51 obsolete" data-tally="0.1875">3/16</td>
           <td class="tally safari6" data-tally="0.1875">3/16</td>
           <td class="tally safari7" data-tally="0.1875">3/16</td>
@@ -9169,6 +9327,7 @@ test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -9224,6 +9383,7 @@ test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -9278,6 +9438,7 @@ test(function(){try{return Function("\nreturn (new Function).name === \"anonymou
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9334,6 +9495,7 @@ test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).n
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9390,6 +9552,7 @@ test(function(){try{return Function("\nvar foo = function() {};\nvar bar = funct
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9448,6 +9611,7 @@ test(function(){try{return Function("\nvar o = { foo: function(){}, bar: functio
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9505,6 +9669,7 @@ test(function(){try{return Function("\nvar o = { get foo(){}, set foo(){} };\nva
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9560,6 +9725,7 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9571,7 +9737,7 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
           <td class="no chrome36 obsolete">No</td>
           <td class="no chrome37 obsolete">No</td>
           <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -9622,6 +9788,7 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol(\"foo\");\n
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9679,6 +9846,7 @@ test(function(){try{return Function("\nclass foo {};\nclass bar { static name() 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9734,6 +9902,7 @@ test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9793,6 +9962,7 @@ test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9851,6 +10021,7 @@ test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9906,6 +10077,7 @@ test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -9961,6 +10133,7 @@ test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10018,6 +10191,7 @@ test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDes
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10074,6 +10248,7 @@ return typeof Function.prototype.toMethod === "function";
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10124,6 +10299,7 @@ return typeof Function.prototype.toMethod === "function";
           <td class="tally firefox32 obsolete" data-tally="0.5">1/2</td>
           <td class="tally firefox33" data-tally="0.5">1/2</td>
           <td class="tally firefox34" data-tally="1">2/2</td>
+          <td class="tally firefox35" data-tally="1">2/2</td>
           <td class="tally chrome obsolete" data-tally="0">0/2</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/2</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/2</td>
@@ -10178,6 +10354,7 @@ test(function(){try{return Function("\nreturn typeof String.raw === 'function';\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10232,6 +10409,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10282,6 +10460,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td class="tally firefox32 obsolete" data-tally="1">6/6</td>
           <td class="tally firefox33" data-tally="1">6/6</td>
           <td class="tally firefox34" data-tally="1">6/6</td>
+          <td class="tally firefox35" data-tally="1">6/6</td>
           <td class="tally chrome obsolete" data-tally="0">0/6</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/6</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/6</td>
@@ -10336,6 +10515,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.codePointA
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10392,6 +10572,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.normalize 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10447,6 +10628,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.repeat ===
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10502,6 +10684,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.startsWith
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10557,6 +10740,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.endsWith =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10612,6 +10796,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.contains =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10667,6 +10852,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10717,6 +10903,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="tally firefox32 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox33" data-tally="0">0/8</td>
           <td class="tally firefox34" data-tally="0">0/8</td>
+          <td class="tally firefox35" data-tally="0">0/8</td>
           <td class="tally chrome obsolete" data-tally="0">0/8</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/8</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/8</td>
@@ -10728,7 +10915,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="tally chrome36 obsolete" data-tally="0.625">5/8</td>
           <td class="tally chrome37 obsolete" data-tally="0.625">5/8</td>
           <td class="tally chrome38" data-tally="0.75">6/8</td>
-          <td class="tally chrome39" data-tally="0.75">6/8</td>
+          <td class="tally chrome39" data-tally="0.875">7/8</td>
           <td class="tally safari51 obsolete" data-tally="0">0/8</td>
           <td class="tally safari6" data-tally="0">0/8</td>
           <td class="tally safari7" data-tally="0">0/8</td>
@@ -10775,6 +10962,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10829,6 +11017,7 @@ test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10895,6 +11084,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10958,6 +11148,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11025,6 +11216,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11079,6 +11271,7 @@ test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symb
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11090,7 +11283,7 @@ test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symb
           <td class="no chrome36 obsolete">No</td>
           <td class="no chrome37 obsolete">No</td>
           <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -11138,6 +11331,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symb
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11197,6 +11391,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11254,6 +11449,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11304,6 +11500,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td class="tally firefox32 obsolete" data-tally="0">0/7</td>
           <td class="tally firefox33" data-tally="0">0/7</td>
           <td class="tally firefox34" data-tally="0">0/7</td>
+          <td class="tally firefox35" data-tally="0">0/7</td>
           <td class="tally chrome obsolete" data-tally="0">0/7</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/7</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/7</td>
@@ -11363,6 +11560,7 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11420,6 +11618,7 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11474,6 +11673,7 @@ test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11541,6 +11741,7 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11604,6 +11805,7 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11660,6 +11862,7 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11718,6 +11921,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11768,6 +11972,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="tally firefox32 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox33" data-tally="0">0/4</td>
           <td class="tally firefox34" data-tally="0">0/4</td>
+          <td class="tally firefox35" data-tally="0">0/4</td>
           <td class="tally chrome obsolete" data-tally="0">0/4</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
@@ -11823,6 +12028,7 @@ return typeof RegExp.prototype.match === 'function';
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11878,6 +12084,7 @@ return typeof RegExp.prototype.replace === 'function';
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11933,6 +12140,7 @@ return typeof RegExp.prototype.split === 'function';
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11988,6 +12196,7 @@ return typeof RegExp.prototype.search === 'function';
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12038,6 +12247,7 @@ return typeof RegExp.prototype.search === 'function';
           <td class="tally firefox32 obsolete" data-tally="1">2/2</td>
           <td class="tally firefox33" data-tally="1">2/2</td>
           <td class="tally firefox34" data-tally="1">2/2</td>
+          <td class="tally firefox35" data-tally="1">2/2</td>
           <td class="tally chrome obsolete" data-tally="0">0/2</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/2</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/2</td>
@@ -12092,6 +12302,7 @@ test(function(){try{return Function("\nreturn typeof Array.from === 'function';\
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12147,6 +12358,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12197,6 +12409,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
           <td class="tally firefox32 obsolete" data-tally="0.75">6/8</td>
           <td class="tally firefox33" data-tally="0.75">6/8</td>
           <td class="tally firefox34" data-tally="0.75">6/8</td>
+          <td class="tally firefox35" data-tally="0.75">6/8</td>
           <td class="tally chrome obsolete" data-tally="0">0/8</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/8</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/8</td>
@@ -12251,6 +12464,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin 
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12305,6 +12519,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12359,6 +12574,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex =
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12413,6 +12629,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12467,6 +12684,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12508,19 +12726,20 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12531,8 +12750,8 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
+          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -12575,6 +12794,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.entries ===
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12637,6 +12857,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12687,6 +12908,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td class="tally firefox32 obsolete" data-tally="1">7/7</td>
           <td class="tally firefox33" data-tally="1">7/7</td>
           <td class="tally firefox34" data-tally="1">7/7</td>
+          <td class="tally firefox35" data-tally="1">7/7</td>
           <td class="tally chrome obsolete" data-tally="0">0/7</td>
           <td class="tally chrome19dev obsolete" data-tally="0.2857142857142857">2/7</td>
           <td class="tally chrome21dev obsolete" data-tally="0.2857142857142857">2/7</td>
@@ -12741,6 +12963,7 @@ test(function(){try{return Function("\nreturn typeof Number.isFinite === 'functi
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -12795,6 +13018,7 @@ test(function(){try{return Function("\nreturn typeof Number.isInteger === 'funct
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12849,6 +13073,7 @@ test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'f
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -12903,6 +13128,7 @@ test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function'
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -12957,6 +13183,7 @@ test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number'
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13011,6 +13238,7 @@ test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER ===
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13065,6 +13293,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13115,6 +13344,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
           <td class="tally firefox32 obsolete" data-tally="1">17/17</td>
           <td class="tally firefox33" data-tally="1">17/17</td>
           <td class="tally firefox34" data-tally="1">17/17</td>
+          <td class="tally firefox35" data-tally="1">17/17</td>
           <td class="tally chrome obsolete" data-tally="0">0/17</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/17</td>
           <td class="tally chrome21dev obsolete" data-tally="0.058823529411764705">1/17</td>
@@ -13169,6 +13399,7 @@ test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13223,9 +13454,10 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[16]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[17]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -13277,6 +13509,7 @@ test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13331,6 +13564,7 @@ test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13385,6 +13619,7 @@ test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13439,6 +13674,7 @@ test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13493,6 +13729,7 @@ test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13547,6 +13784,7 @@ test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13601,6 +13839,7 @@ test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13655,6 +13894,7 @@ test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13709,6 +13949,7 @@ test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13763,6 +14004,7 @@ test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13817,6 +14059,7 @@ test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13871,6 +14114,7 @@ test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13925,6 +14169,7 @@ test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\"
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -13971,7 +14216,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[17]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[18]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -13979,6 +14224,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14033,6 +14279,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14060,10 +14307,10 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="yes ios8">Yes</td>
         </tr>
         <tr>
-          <th colspan="49" class="separator"></th>
+          <th colspan="50" class="separator"></th>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[19]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally ejs not-applicable " data-tally="0">0/5</td>
@@ -14086,6 +14333,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="tally firefox32 obsolete" data-tally="0.2">1/5</td>
           <td class="tally firefox33" data-tally="0.2">1/5</td>
           <td class="tally firefox34" data-tally="0.4">2/5</td>
+          <td class="tally firefox35" data-tally="1">5/5</td>
           <td class="tally chrome obsolete" data-tally="0.2">1/5</td>
           <td class="tally chrome19dev obsolete" data-tally="0.2">1/5</td>
           <td class="tally chrome21dev obsolete" data-tally="0.2">1/5</td>
@@ -14141,6 +14389,7 @@ test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Arra
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14200,6 +14449,7 @@ test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __prot
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14255,6 +14505,7 @@ test(function(){try{return Function("\nvar a = \"__proto__\";\nreturn !({ [a] : 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14310,6 +14561,7 @@ test(function(){try{return Function("\nvar __proto__ = [];\nreturn !({ __proto__
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14338,9 +14590,9 @@ test(function(){try{return Function("\nvar __proto__ = [];\nreturn !({ __proto__
         <tr class="subtest" data-parent="__proto___in_object_literals">
           <td><span>not a shorthand method</span></td>
 <script data-source="
-return !({ __proto__(){} }) instanceof Function;
+return !({ __proto__(){} } instanceof Function);
       ">
-test(function(){try{return Function("\nreturn !({ __proto__(){} }) instanceof Function;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn !({ __proto__(){} } instanceof Function);\n      ")()}catch(e){return false;}}());
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
@@ -14364,6 +14616,7 @@ test(function(){try{return Function("\nreturn !({ __proto__(){} }) instanceof Fu
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14391,7 +14644,7 @@ test(function(){try{return Function("\nreturn !({ __proto__(){} }) instanceof Fu
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[19]</sup></a></span></td>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[20]</sup></a></span></td>
 <script data-source="
 // Note: only available outside of strict mode.
 var passed = f() === 2 && g() === 4;
@@ -14423,6 +14676,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14473,6 +14727,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="tally firefox32 obsolete" data-tally="1">3/3</td>
           <td class="tally firefox33" data-tally="1">3/3</td>
           <td class="tally firefox34" data-tally="1">3/3</td>
+          <td class="tally firefox35" data-tally="1">3/3</td>
           <td class="tally chrome obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally chrome19dev obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally chrome21dev obsolete" data-tally="0.6666666666666666">2/3</td>
@@ -14528,6 +14783,7 @@ test(function(){try{return Function("\nvar A = function(){};\nreturn (new A())._
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14584,6 +14840,7 @@ test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototyp
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14645,6 +14902,7 @@ test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescripto
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14715,6 +14973,7 @@ return true;
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14771,6 +15030,7 @@ return typeof RegExp.prototype.compile === 'function';
           <td class="yes firefox32 obsolete">Yes</td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="yes chrome obsolete">Yes</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -14812,50 +15072,53 @@ return typeof RegExp.prototype.compile === 'function';
       <p id="fx-let-note">
         <sup>[4]</sup> Available from Firefox 2 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
+      <p id="fx-let-tdz-note">
+        <sup>[5]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
+      </p>
       <p id="map-constructor-note">
-        <sup>[5]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.
+        <sup>[6]</sup> Map and Set constructor arguments, such as <code>new Map([[key, val]])</code> or <code>new Set([obj1, obj2])</code>, are not supported.
       </p>
       <p id="weakmap-constructor-note">
-        <sup>[6]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
+        <sup>[7]</sup> WeakMap (and, except in Firefox, WeakSet) constructor arguments, such as <code>new WeakMap([[key, val]])</code> or <code>new WeakSet([obj1, obj2])</code>, are not supported.
       </p>
       <p id="fx-proxy-get-note">
-        <sup>[7]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
+        <sup>[8]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
       </p>
       <p id="fx-proxy-set-note">
-        <sup>[8]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
+        <sup>[9]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
       </p>
       <p id="fx-proxy-getown-note">
-        <sup>[9]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+        <sup>[10]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
       </p>
       <p id="fx-proxy-ownkeys-note">
-        <sup>[10]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+        <sup>[11]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
       </p>
       <p id="block-level-function-note">
-        <sup>[11]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[12]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-destructuring-note">
-        <sup>[12]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
+        <sup>[13]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[13]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[14]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[14]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[15]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[15]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[16]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[16]</sup> Available since Chrome 28
+        <sup>[17]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[17]</sup> Available since Firefox 26
+        <sup>[18]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[19]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
       <p id="hoisted-block-level-function-note">
-        <sup>[19]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
+        <sup>[20]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Also, this adds `<br>`s to some platform column names so that they aren't uncharacteristically wide compared to the others.

FF35 is in Aurora mode, so there may still be some latitude for it to change its support, at least compared to Beta. Since Nightly has several features that are deliberately disabled in Beta and Stable, I don't think it's too wise to ever make columns for it, no matter how exciting.
