### PR TITLE
Removed a no longer true note for Map and Set

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -23,7 +23,7 @@ exports.browsers = {
   },
   closure: {
     full: 'Closure Compiler v20140923',
-    short: 'Closure<br>Compiler',
+    short: 'Closure Compiler',
     obsolete: false, // always up-to-date version
     platformtype: 'compiler',
   },
@@ -115,10 +115,6 @@ exports.browsers = {
     full: 'Firefox',
     short: 'FF 34'
   },
-  firefox35: {
-    full: 'Firefox',
-    short: 'FF 35'
-  },
   chrome: {
     full: 'Chrome',
     short: 'CH &lt;19',
@@ -208,7 +204,7 @@ exports.browsers = {
   },
   safari71_8: {
     full: 'Safari',
-    short: 'SF 7.1,<br>SF 8',
+    short: 'SF 7.1, SF 8',
     obsolete: false
   },
   webkit: {
@@ -245,7 +241,7 @@ exports.browsers = {
   },
   nodeharmony: {
     full: 'Node 0.11.14 harmony',
-    short: 'Node<br>harmony',
+    short: 'Node harmony',
     obsolete: false, // current version
     platformtype: 'engine',
     note_id: 'harmony-flag',
@@ -582,7 +578,6 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
-        firefox11:   { val: false, note_id: 'fx-let', },
       },
     },
     'for-loop statement scope': {
@@ -595,7 +590,6 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
-        firefox11:   { val: false, note_id: 'fx-let', },
       },
     },
     'temporal dead zone': {
@@ -661,7 +655,6 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
-        firefox11:   { val: false, note_id: 'fx-let', },
         chrome19dev: true,
         nodeharmony: true,
       },
@@ -677,7 +670,6 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11:        true,
-        firefox11:   { val: false, note_id: 'fx-let', },
         chrome19dev: true,
         chrome37:    false, // this test crashes the tab
         chrome38:    true,
@@ -694,7 +686,6 @@ exports.tests = [
       res: {
         ejs:         true,
         ie11:        true,
-        firefox35:   { val: false, note_id: 'fx-let-tdz', },
         chrome19dev: true,
         nodeharmony: true,
       },
@@ -1128,7 +1119,6 @@ exports.tests = [
         }
       */},
       res: {
-        firefox35:    true,
       },
     },
     'not a computed property': {
@@ -1145,17 +1135,13 @@ exports.tests = [
         var __proto__ = [];
         return !({ __proto__ } instanceof Array);
       */},
-      res: {
-        firefox35:    true,
-      },
+      res: {},
     },
     'not a shorthand method': {
       exec: function() {/*
-        return !({ __proto__(){} } instanceof Function);
+        return !({ __proto__(){} }) instanceof Function;
       */},
-      res: {
-        firefox35:    true,
-      },
+      res: {},
     },
   },
 },
@@ -1281,8 +1267,6 @@ exports.tests = [
       res: {
         tr:          true,
         closure:     true,
-        chrome39:    true,
-        firefox35:   true,
       },
     },
   },
@@ -1398,7 +1382,6 @@ exports.tests = [
       */},
       res: {
         firefox11:   true,
-        chrome39:    true,
       },
     },
     '"u" flag': {
@@ -1699,7 +1682,7 @@ exports.tests = [
     chrome34:    { val: true, note_id: 'map-constructor' },
     chrome35:    { val: true, note_id: 'map-constructor' },
     chrome37:    { val: true, note_id: 'map-constructor' },
-    chrome39:    { val: true, note_id: 'map-constructor' },
+    chrome39:    { val: true },
     safari51:    false,
     safari6:     false,
     safari7:     false,
@@ -1757,7 +1740,7 @@ exports.tests = [
     chrome34:    { val: true, note_id: 'map-constructor' },
     chrome35:    { val: true, note_id: 'map-constructor' },
     chrome37:    { val: true, note_id: 'map-constructor' },
-    chrome39:    { val: true, note_id: 'map-constructor' },
+    chrome39:    { val: true },
     safari51:    false,
     safari6:     false,
     safari7:     false,
@@ -2674,7 +2657,6 @@ exports.tests = [
       */},
       res: {
         firefox34:    true,
-        chrome39:     true,
       },
     },
     'symbol-keyed methods': {
@@ -3111,9 +3093,7 @@ exports.tests = [
       exec: function(){/*
         return String(Symbol("foo")) === "Symbol(foo)";
       */},
-      res: {
-        chrome39:    true,
-      },
+      res: {},
     },
     'new Symbol() throws': {
       exec: function(){/*


### PR DESCRIPTION
Looks like new Map([[key, value]]) and new Set([obj1, obj2]) succeed in Chrome 38.
