### PR TITLE
Fixed supertest fold-down conflicting with column highlighting

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -324,7 +324,7 @@ exports.tests = [
 },
 {
   name: 'arrow functions',
-  link: 'http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
   subtests: {
     '0 parameters': {
       exec: function(){/*

--- a/es6/index.html
+++ b/es6/index.html
@@ -190,7 +190,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
-          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:arrow_function_syntax">arrow functions</a></span></td>
+          <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 
           <td class="tally tr" data-tally="0.75">6/8</td>
           <td class="tally ejs" data-tally="0.75">6/8</td>

--- a/master.css
+++ b/master.css
@@ -53,7 +53,17 @@ table.one-selected td.selected {
 }
 
 /* subtests */
-
+.supertest td:first-child {
+    cursor: pointer;
+}
+.supertest td:first-child:hover {
+    left: -1px;
+    top: -1px;
+}
+.supertest td:first-child:active {
+    left: 1px;
+    top: 1px;
+}
 .subtest td:first-child {
   padding-left: 1.2em;
   font-style: italic;
@@ -169,16 +179,14 @@ td.hover.not-applicable {
 /* tooltip button/box */
 .info, .folddown {
     float: right; margin-right: 5px; display: inline-block; width: 15px; height: 15px; line-height: 15px; text-align: center;
-    cursor: default; font-family: "Courier New", Courier, monospace 
+    font-family: "Courier New", Courier, monospace;
 }
 .info {
     color: #eee;
     background: #999;
     border-radius: 20px;
     font-size: 12px;
-}
-.folddown {
-    cursor: pointer;
+    cursor: help;
 }
 .info:hover {
     background: #555 

--- a/master.js
+++ b/master.js
@@ -48,12 +48,16 @@ $(function() {
     if (subtests.length === 0) {
       return;
     }
-    // Attach dropdown buttons to those tests with subtests
-    $('<span class="folddown">&#9660;</span>')
-      .appendTo(tr.children()[0])
-      .on('click', function() {
+    // Attach dropdown indicator and onclick to those tests with subtests
+    $('<span class="folddown">&#9658;</span>')
+      .appendTo(tr.children()[0]);
+    
+    tr.on('click', function(event) {
+      if (!$(event.target).is('a')) {
         subtests.toggle();
-      });
+        tr.find(".folddown").css('transform', 'rotate(' + (subtests.is(':visible') ? '90deg' : '0deg') + ')');
+      }
+    });
       
     // Also, work out tallies for the current browser's tally features
     var tally = subtests.find(".yes" + currentBrowserSelector).length;
@@ -133,7 +137,7 @@ $(function() {
 
   $(document).on('click', function removeHighlighting(event) {
     // Don't remove all dimming if another link was clicked in this event.
-    if ($(event.target).is('[href],[href] *'))
+    if ($(event.target).is('[href],[href] *, .supertest *'))
       return;
     table.removeClass('one-selected');
   });


### PR DESCRIPTION
Also, clicking an entire supertest name cell toggles its fold-down, not just the arrow.

Additionally, said arrow now rotates to denote the fold-down status.

Fixes #297, and one of #75.
