### PR TITLE
Fix test code for "arrow functions: no line break between params and =>"

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -403,9 +403,9 @@ exports.tests = [
     },
     'no line break between params and <code>=></code>': {
       exec: function(){/*
-        return () => {
+        return (() => {
           try { Function("x\n => 2")(); } catch(e) { return true; }
-        }();
+        })();
       */},
       res: {
       },

--- a/es6/index.html
+++ b/es6/index.html
@@ -579,11 +579,11 @@ test(function(){try{return Function("\nvar f = (function() { return z => argumen
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>no line break between params and <code>=></code></span></td>
 <script data-source="
-return () => {
+return (() => {
   try { Function(&quot;x\n => 2&quot;)(); } catch(e) { return true; }
-}();
+})();
       ">
-test(function(){try{return Function("\nreturn () => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n}();\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n})();\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>


### PR DESCRIPTION
I think this original intermediate arrow function is invalid syntax as ES6.
