### PR TITLE
Added 6to5 and IE Technical Preview result columns.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -10,21 +10,27 @@ exports.skeleton_file = 'es6/skeleton.html';
 
 exports.browsers = {
   tr: {
-    full: 'Traceur compiler',
+    full: 'Traceur',
     short: 'Traceur',
-    obsolete: false, // always up-to-date version
+    obsolete: false,
+    platformtype: 'compiler',
+  },
+  _6to5: {
+    full: '6to5',
+    short: '6to5 +<br>polyfill',
+    obsolete: false,
     platformtype: 'compiler',
   },
   ejs: {
     full: 'Echo JS',
     short: 'EJS',
-    obsolete: false, // always up-to-date version
+    obsolete: false,
     platformtype: 'compiler',
   },
   closure: {
     full: 'Closure Compiler v20141023',
     short: 'Closure<br>Compiler',
-    obsolete: false, // always up-to-date version
+    obsolete: false,
     platformtype: 'compiler',
   },
   ie10: {
@@ -36,6 +42,13 @@ exports.browsers = {
     full: 'Internet Explorer',
     short: 'IE 11',
     obsolete: false
+  },
+  ie11tp: {
+    full: 'Internet Explorer',
+    short: 'IE<br>Technical<br>Preview',
+    obsolete: false,
+    note_id: 'ie-experimental-flag',
+    note_html: 'Have to be enabled via "Experimental Web Platform Features" flag'
   },
   firefox11: {
     full: 'Firefox',
@@ -332,8 +345,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
         chrome38:    true,
       },
@@ -345,8 +360,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
         chrome38:    true,
       },
@@ -358,8 +375,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
         chrome38:    true,
       },
@@ -372,8 +391,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
       },
     },
@@ -385,7 +406,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
       },
     },
@@ -397,8 +420,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
       },
     },
@@ -408,7 +433,9 @@ exports.tests = [
         return f(6) === 5;
       */},
       res: {
+        _6to5:       true,
         closure:     true,
+        ie11tp:      true,
         firefox23:   true,
         firefox24:   false,
       },
@@ -430,6 +457,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
         chrome39:    true,
       },
@@ -447,6 +475,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -485,6 +514,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -509,6 +539,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -545,6 +576,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -580,6 +612,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -597,6 +630,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -649,6 +683,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
       },
@@ -661,6 +696,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -677,6 +713,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -736,6 +773,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         chrome37:    true,
@@ -753,6 +791,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         firefox16:   true,
@@ -764,6 +803,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         firefox18:   true,
@@ -775,6 +815,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         firefox16:   true,
@@ -811,10 +852,12 @@ exports.tests = [
   */},
   res: {
     tr:          true,
+    _6to5:       true,
     ejs:         true,
     closure:     true,
     ie10:        false,
     ie11:        false,
+    ie11tp:      true,
     firefox11:   false,
     firefox13:   false,
     firefox16:   true,
@@ -865,8 +908,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox27:   true,
         safari71_8:  true,
         webkit:      true,
@@ -879,8 +924,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox16:   true,
         safari71_8:  true,
         webkit:      true,
@@ -893,7 +940,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox27:   true,
       },
     },
@@ -903,7 +952,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox17:   true,
       },
     },
@@ -920,8 +971,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
     'is block-scoped': {
@@ -933,6 +986,7 @@ exports.tests = [
         return typeof C === "function" && typeof D === "undefined";
       */},
       res: {
+        ie11tp:      true,
       },
     },
     'class expression': {
@@ -941,8 +995,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
     'constructor': {
@@ -955,8 +1011,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
     'prototype methods': {
@@ -970,8 +1028,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
     'static methods': {
@@ -985,8 +1045,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
     'implicit strict mode': {
@@ -999,6 +1061,8 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
+        ie11tp:      true,
       },
     },
     'extends': {
@@ -1009,8 +1073,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
       },
     },
   },
@@ -1030,7 +1096,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'in methods': {
@@ -1044,7 +1112,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'is statically bound': {
@@ -1062,7 +1132,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
       },
     },
   },
@@ -1078,8 +1150,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox34:   true,
         safari71_8:  true,
         webkit:      true,
@@ -1093,8 +1167,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox33:   true,
       },
     },
@@ -1104,8 +1180,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox34:   true,
         chrome39:    true,
       },
@@ -1199,10 +1277,12 @@ exports.tests = [
   */},
   res: {
     tr:          true,
+    _6to5:       true,
     ejs:         true,
     closure:     true,
     ie10:        false,
     ie11:        false,
+    ie11tp:      true,
     firefox11:   false,
     firefox13:   true,
     firefox16:   true,
@@ -1263,6 +1343,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         closure:     true,
         firefox27:   true,
         chrome21dev: true,
@@ -1286,6 +1367,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         closure:     true,
         firefox27:   true,
         chrome21dev: true,
@@ -1310,6 +1392,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         closure:     true,
         chrome39:    true,
         firefox35:   true,
@@ -1327,8 +1410,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox25:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -1340,8 +1425,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox25:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -1385,8 +1472,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
+        ie11tp:      true,
         firefox34:   true,
       },
     },
@@ -1437,6 +1526,8 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
+        ie11tp:      true,
       },
     },
   },
@@ -1483,6 +1574,7 @@ exports.tests = [
       res: {
         ejs:         true,
         firefox11:   true,
+        ie11tp:      true,
         chrome:      true,
         safari6:     true,
         webkit:      true,
@@ -1627,10 +1719,11 @@ exports.tests = [
   },
   (function(){
     var methods = {
-    '.from':                  {},
-    '.of':                    {},
+    '.from':                  { ie11tp: true, },
+    '.of':                    { ie11tp: true, },
     '.prototype.subarray':    {
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome:      true,
         safari6:     true,
@@ -1640,26 +1733,26 @@ exports.tests = [
         nodeharmony: true,
         ios7:        true,
     },
-    '.prototype.join':        {},
-    '.prototype.indexOf':     {},
-    '.prototype.lastIndexOf': {},
-    '.prototype.slice':       {},
-    '.prototype.every':       {},
-    '.prototype.filter':      {},
-    '.prototype.forEach':     {},
-    '.prototype.map':         {},
-    '.prototype.reduce':      {},
-    '.prototype.reduceRight': {},
-    '.prototype.reverse':     {},
-    '.prototype.some':        {},
-    '.prototype.sort':        {},
-    '.prototype.copyWithin':  { firefox34: true },
-    '.prototype.find':        {},
-    '.prototype.findIndex':   {},
-    '.prototype.fill':        {},
-    '.prototype.keys':        { chrome38: true },
-    '.prototype.values':      { chrome38: true },
-    '.prototype.entries':     { chrome38: true },
+    '.prototype.join':        { ie11tp: true, },
+    '.prototype.indexOf':     { ie11tp: true, },
+    '.prototype.lastIndexOf': { ie11tp: true, },
+    '.prototype.slice':       { ie11tp: true, },
+    '.prototype.every':       { ie11tp: true, },
+    '.prototype.filter':      { ie11tp: true, },
+    '.prototype.forEach':     { ie11tp: true, },
+    '.prototype.map':         { ie11tp: true, },
+    '.prototype.reduce':      { ie11tp: true, },
+    '.prototype.reduceRight': { ie11tp: true, },
+    '.prototype.reverse':     { ie11tp: true, },
+    '.prototype.some':        { ie11tp: true, },
+    '.prototype.sort':        { ie11tp: true, },
+    '.prototype.copyWithin':  { ie11tp: true, firefox34: true },
+    '.prototype.find':        { ie11tp: true, },
+    '.prototype.findIndex':   { ie11tp: true, },
+    '.prototype.fill':        { ie11tp: true, },
+    '.prototype.keys':        { ie11tp: true, chrome38: true },
+    '.prototype.values':      { ie11tp: true, chrome38: true },
+    '.prototype.entries':     { ie11tp: true, chrome38: true },
     };
     var eqFn = ' === "function"';
     var obj = {};
@@ -1698,6 +1791,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox16:   true,
@@ -1719,7 +1813,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome38:    true,
       },
@@ -1735,6 +1831,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox23:   true,
@@ -1751,6 +1848,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox16:   true,
@@ -1767,6 +1865,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox23:   true,
@@ -1783,6 +1882,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox25:   true,
@@ -1799,7 +1899,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
         safari71_8:  true,
         ios8:        true,
@@ -1813,7 +1915,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
         safari71_8:  true,
         ios8:        true,
@@ -1827,7 +1931,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
         safari71_8:  true,
         ios8:        true,
@@ -1853,6 +1959,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox16:   true,
@@ -1874,7 +1981,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome38:    true,
       },
@@ -1892,6 +2001,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox23:   true,
@@ -1909,6 +2019,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox16:   true,
@@ -1925,6 +2036,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox23:   true,
@@ -1941,6 +2053,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11:        true,
         firefox25:   true,
@@ -1957,7 +2070,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox24:   true,
         safari71_8:  true,
         ios8:        true,
@@ -1971,7 +2086,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox24:   true,
         safari71_8:  true,
         ios8:        true,
@@ -1985,7 +2102,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox24:   true,
         safari71_8:  true,
         ios8:        true,
@@ -2028,6 +2147,7 @@ exports.tests = [
                weakmap.has(key2) && weakmap.get(key2) === 456;
       */},
       res: {
+        ie11tp:      true,
         chrome38:    true,
       },
     },
@@ -2080,6 +2200,7 @@ exports.tests = [
         return weakset.has(obj1);
       */},
       res: {
+        ie11tp:      true,
         firefox34:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -2093,6 +2214,7 @@ exports.tests = [
         return weakset.has(obj1) && weakset.has(obj2);
       */},
       res: {
+        ie11tp:      true,
         firefox34:   true,
         chrome38:    true,
       },
@@ -2104,6 +2226,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         firefox34:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -2116,6 +2239,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         firefox34:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -2139,6 +2263,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   {
           val: true,
           note_id: 'fx-proxy-get',
@@ -2161,6 +2286,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   {
           val: true,
           note_id: 'fx-proxy-set',
@@ -2182,6 +2308,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   true,
       },    
     },
@@ -2198,6 +2325,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   true,
       },    
     },
@@ -2220,6 +2348,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   {
           val: false,
           note_id: 'fx-proxy-getown',
@@ -2246,6 +2375,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         firefox18:   true,
       },    
     },
@@ -2262,6 +2392,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     '"setPrototypeOf" handler': {
@@ -2282,6 +2413,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     '"isExtensible" handler': {
@@ -2299,6 +2431,7 @@ exports.tests = [
       */},
       res: {
         firefox31:   true,
+        ie11tp:      true,
       },
     },
     '"preventExtensions" handler': {
@@ -2317,6 +2450,7 @@ exports.tests = [
       */},
       res: {
         firefox23:   true,
+        ie11tp:      true,
       },
     },
     '"enumerate" handler': {
@@ -2336,6 +2470,7 @@ exports.tests = [
         return passed;
       */},
       res: {
+        ie11tp:      true,
       },
     },
     '"ownKeys" handler': {
@@ -2376,6 +2511,7 @@ exports.tests = [
         return passed;
       */},
       res: {
+        ie11tp:      true,
         firefox18:   true,
       },
     },
@@ -2392,6 +2528,7 @@ exports.tests = [
         return passed;
       */},
       res: {
+        ie11tp:      true,
         firefox18:   true,
       },
     },
@@ -2408,6 +2545,7 @@ exports.tests = [
         return passed;
       */},
       res: {
+        ie11tp:      true,
         firefox34:   true,
       },
     },
@@ -2423,6 +2561,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.set': {
@@ -2433,6 +2572,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.has': {
@@ -2441,6 +2581,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.deleteProperty': {
@@ -2451,6 +2592,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.getOwnPropertyDescriptor': {
@@ -2462,6 +2604,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.defineProperty': {
@@ -2472,6 +2615,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.getPrototypeOf': {
@@ -2480,6 +2624,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.setPrototypeOf': {
@@ -2490,6 +2635,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.isExtensible': {
@@ -2499,6 +2645,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.preventExtensions': {
@@ -2509,6 +2656,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.enumerate': {
@@ -2526,6 +2674,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.ownKeys': {
@@ -2535,6 +2684,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.apply': {
@@ -2543,6 +2693,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
     'Reflect.construct': {
@@ -2551,6 +2702,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
       },
     },
   },
@@ -2683,6 +2835,7 @@ exports.tests = [
       */},
       res: (temp.destructuringResults = {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
@@ -2718,6 +2871,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
@@ -2735,6 +2889,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         closure:     true,
         firefox34:   true,
       },
@@ -2772,10 +2927,12 @@ exports.tests = [
   */},
   res: {
     tr:          true,
+    _6to5:       true,
     ejs:         true,
     closure:     false,
     ie10:        false,
     ie11:        false,
+    ie11tp:      true,
     firefox11:   false,
     firefox13:   false,
     firefox16:   false,
@@ -2840,6 +2997,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         firefox23:   true,
         chrome19dev: true,
         konq49:      true,
@@ -2857,6 +3015,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         chrome34:    true,
         nodeharmony: true,
       },
@@ -3160,7 +3319,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox34:   true,
       },
     },
@@ -3170,7 +3331,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox29:   true,
         chrome38:    true,
       },
@@ -3187,7 +3350,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox29:   true,
         chrome38:    true,
       },
@@ -3199,6 +3364,7 @@ exports.tests = [
           && "\u1e09".normalize("NFD") === "c\u0327\u0301";
       */},
       res: {
+        ie11tp:      true,
         firefox31:   true,
         chrome34:    true,
       },
@@ -3210,7 +3376,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox24:   true,
         chrome30:    true,
         nodeharmony: true,
@@ -3223,7 +3391,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox17:   true,
         chrome30:    true,
         webkit:      true,
@@ -3237,7 +3407,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox17:   true,
         chrome30:    true,
         webkit:      true,
@@ -3251,6 +3423,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         firefox18:   true,
         chrome30:    true,
@@ -3328,10 +3501,12 @@ exports.tests = [
   */},
   res: {
     tr:          true,
+    _6to5:       true,
     ejs:         true,
     closure:     true,
     ie10:        false,
     ie11:        false,
+    ie11tp:      true,
     firefox11:   false,
     firefox13:   false,
     firefox16:   false,
@@ -3384,8 +3559,10 @@ exports.tests = [
         object[symbol] = value;
         return object[symbol] === value;
       */},
-      res:(temp.basicSymbolResults = {
+      res: (temp.basicSymbolResults = {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         chrome30:    true, // Actually Chrome 29
         nodeharmony: true,
       }),
@@ -3394,7 +3571,12 @@ exports.tests = [
       exec: function(){/*
         return typeof Symbol() === "symbol";
       */},
-      res: temp.basicSymbolResults,
+      res: (temp.noPolyfillSymbolResults = {
+        ejs:         true,
+        ie11tp:      true,
+        chrome30:    true, // Actually Chrome 29
+        nodeharmony: true,
+      }),
     },
     'symbol keys are hidden to pre-ES6 code': {
       exec: function(){/*
@@ -3412,7 +3594,7 @@ exports.tests = [
         
         return passed;
       */},
-      res: temp.basicSymbolResults,
+      res: temp.noPolyfillSymbolResults,
     },
     'Object.defineProperty support': {
       exec: function(){/*
@@ -3448,6 +3630,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        ie11tp:      true,
         chrome38:    true,
         nodeharmony: true,
       },
@@ -3470,6 +3653,8 @@ exports.tests = [
         }
       */},
       res: {
+        _6to5:      true,
+        ie11tp:     true,
         chrome35:   true,
       },
     },
@@ -3483,6 +3668,8 @@ exports.tests = [
           symbolObject.valueOf() === symbol;
       */},
       res: {
+        _6to5:      true,
+        ie11tp:     true,
         chrome30:   true,
         chrome35:   false,
       },
@@ -3503,6 +3690,7 @@ exports.tests = [
     closure:     false,
     ie10:        false,
     ie11:        false,
+    ie11tp:      true,
     firefox11:   false,
     firefox13:   false,
     firefox16:   false,
@@ -3596,6 +3784,7 @@ exports.tests = [
         return c === "foo";
       */},
       res: {
+        ie11tp:      true,
         chrome37:    true,
         ejs:         true,
       },
@@ -3635,6 +3824,7 @@ exports.tests = [
         }
       */},
       res: {
+        ie11tp:      true,
         chrome38:    true,
       },
     },
@@ -3734,7 +3924,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox32:   true,
       }
     },
@@ -3745,7 +3937,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox25:   true,
         chrome39:    true,
       },
@@ -3762,6 +3956,8 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox32:   true,
       },
     },
@@ -3771,7 +3967,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox25:   true,
         chrome30:    true,
         safari71_8:  true,
@@ -3786,7 +3984,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox25:   true,
         chrome30:    true,
         safari71_8:  true,
@@ -3801,7 +4001,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox31:   true,
         chrome36:    true,
         safari71_8:  true,
@@ -3816,7 +4018,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox28:   true,
         chrome30:    true,
         safari71_8:  true,
@@ -3831,7 +4035,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox17:   {
           val: false,
           note_id: 'fx-array-prototype-values',
@@ -3857,7 +4063,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox28:   true,
         chrome30:    true,
         safari71_8:  true,
@@ -3879,6 +4087,7 @@ exports.tests = [
         return true;
       */},
       res: {
+        ie11tp:      true,
         chrome38:    true,
       },
     },
@@ -3894,7 +4103,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome19dev: true,
         webkit:      true,
@@ -3909,7 +4120,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome34:    true,
         webkit:      true,
@@ -3923,7 +4136,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox32:   true,
         chrome34:    true,
         webkit:      true,
@@ -3937,7 +4152,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox16:   true,
         chrome19dev: true,
         webkit:      true,
@@ -3952,7 +4169,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         webkit:      true,
@@ -3965,7 +4184,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox31:   true,
         chrome34:    true,
         webkit:      true,
@@ -3979,7 +4200,9 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
+        ie11tp:      true,
         firefox31:   true,
         chrome34:    true,
         webkit:      true,
@@ -3996,12 +4219,16 @@ exports.tests = [
     var methods = {
       'clz32': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox31:   true,
         chrome35:    true,
         nodeharmony: true,
       },
       'imul': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox23:   true,
         chrome21dev: {
           val: true,
@@ -4017,6 +4244,8 @@ exports.tests = [
       },
       'sign': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome33:    true,
         webkit:      true,
@@ -4025,6 +4254,8 @@ exports.tests = [
       },
       'log10': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4035,6 +4266,8 @@ exports.tests = [
       },
       'log2': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4045,6 +4278,8 @@ exports.tests = [
       },
       'log1p': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome35:    true,
         safari71_8:  true,
@@ -4055,6 +4290,8 @@ exports.tests = [
       },
       'expm1': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome35:    true,
         safari71_8:  true,
@@ -4064,6 +4301,8 @@ exports.tests = [
       },
       'cosh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4074,6 +4313,8 @@ exports.tests = [
       },
       'sinh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4084,6 +4325,8 @@ exports.tests = [
       },
       'tanh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4094,6 +4337,8 @@ exports.tests = [
       },
       'acosh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4104,6 +4349,8 @@ exports.tests = [
       },
       'asinh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4113,6 +4360,8 @@ exports.tests = [
       },
       'atanh': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4123,6 +4372,8 @@ exports.tests = [
       },
       'hypot': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox27:   true,
         chrome34:    true,
         safari71_8:  true,
@@ -4133,6 +4384,8 @@ exports.tests = [
       },
       'trunc': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome33:    true,
         safari71_8:  true,
@@ -4143,6 +4396,8 @@ exports.tests = [
       },
       'fround': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox27:   {
           val: true,
           note_id: 'fx-fround',
@@ -4158,6 +4413,8 @@ exports.tests = [
       },
       'cbrt': {
         ejs:         true,
+        _6to5:       true,
+        ie11tp:      true,
         firefox25:   true,
         chrome34:    true,
         safari71_8:  true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -68,8 +68,8 @@
       <thead>
         <tr>
           <th colspan="3"  class="platformtype"></th>
-          <th colspan="3"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
-          <th colspan="14" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="4"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
+          <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
           <th colspan="4"  class="platformtype" id="engine-header" style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
         </tr>
@@ -77,11 +77,13 @@
           <th class="test-name">Feature name</th>
           <th class="current">Current browser</th>
           <th></th>
-          <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></th>
+          <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></th>
+          <th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr></th>
           <th class="platform ejs compiler"><a href="#ejs" class="browser-name"><abbr title="Echo JS">EJS</abbr></th>
           <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141023">Closure<br>Compiler</abbr></th>
           <th class="platform ie10 desktop"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></th>
           <th class="platform ie11 desktop"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></th>
+          <th class="platform ie11tp desktop"><a href="#ie11tp" class="browser-name"><abbr title="Internet Explorer">IE<br>Technical<br>Preview</abbr><a href="#ie-experimental-flag-note"><sup>[1]</sup></a></th>
           <th class="platform firefox11 obsolete desktop"><a href="#firefox11" class="browser-name"><abbr title="Firefox">FF 11-12</abbr></th>
           <th class="platform firefox13 obsolete desktop"><a href="#firefox13" class="browser-name"><abbr title="Firefox">FF 13</abbr></th>
           <th class="platform firefox16 obsolete desktop"><a href="#firefox16" class="browser-name"><abbr title="Firefox">FF 16</abbr></th>
@@ -100,28 +102,28 @@
           <th class="platform firefox34 desktop"><a href="#firefox34" class="browser-name"><abbr title="Firefox">FF 34</abbr></th>
           <th class="platform firefox35 desktop"><a href="#firefox35" class="browser-name"><abbr title="Firefox">FF 35</abbr></th>
           <th class="platform chrome obsolete desktop"><a href="#chrome" class="browser-name"><abbr title="Chrome">CH &lt;19</abbr></th>
-          <th class="platform chrome19dev obsolete desktop"><a href="#chrome19dev" class="browser-name"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome21dev obsolete desktop"><a href="#chrome21dev" class="browser-name"><abbr title="Chrome">CH 21-29</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome30 obsolete desktop"><a href="#chrome30" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;30,<br>OP&nbsp;17</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome31 obsolete desktop"><a href="#chrome31" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;31,<br>OP&nbsp;18</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome33 obsolete desktop"><a href="#chrome33" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;32-33,<br>OP&nbsp;19-20</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome34 obsolete desktop"><a href="#chrome34" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;34,<br>OP&nbsp;21</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome35 obsolete desktop"><a href="#chrome35" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;35,<br>OP&nbsp;22</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome36 obsolete desktop"><a href="#chrome36" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;36,<br>OP&nbsp;23</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome37 obsolete desktop"><a href="#chrome37" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;37,<br>OP&nbsp;24</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome38 desktop"><a href="#chrome38" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;38,<br>OP&nbsp;25</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-          <th class="platform chrome39 desktop"><a href="#chrome39" class="browser-name"><abbr title="Chrome, Opera">CH 39,<br>OP&nbsp;26</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
+          <th class="platform chrome19dev obsolete desktop"><a href="#chrome19dev" class="browser-name"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome21dev obsolete desktop"><a href="#chrome21dev" class="browser-name"><abbr title="Chrome">CH 21-29</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome30 obsolete desktop"><a href="#chrome30" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;30,<br>OP&nbsp;17</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome31 obsolete desktop"><a href="#chrome31" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;31,<br>OP&nbsp;18</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome33 obsolete desktop"><a href="#chrome33" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;32-33,<br>OP&nbsp;19-20</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome34 obsolete desktop"><a href="#chrome34" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;34,<br>OP&nbsp;21</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome35 obsolete desktop"><a href="#chrome35" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;35,<br>OP&nbsp;22</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome36 obsolete desktop"><a href="#chrome36" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;36,<br>OP&nbsp;23</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome37 obsolete desktop"><a href="#chrome37" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;37,<br>OP&nbsp;24</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome38 desktop"><a href="#chrome38" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;38,<br>OP&nbsp;25</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome39 desktop"><a href="#chrome39" class="browser-name"><abbr title="Chrome, Opera">CH 39,<br>OP&nbsp;26</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
           <th class="platform safari51 obsolete desktop"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></th>
           <th class="platform safari6 desktop"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></th>
           <th class="platform safari7 desktop"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 7.0</abbr></th>
           <th class="platform safari71_8 desktop"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></th>
           <th class="platform webkit desktop"><a href="#webkit" class="browser-name"><abbr title="WebKit r173886">WK</abbr></th>
           <th class="platform opera desktop"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></th>
-          <th class="platform konq49 desktop"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[2]</sup></a></th>
+          <th class="platform konq49 desktop"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[3]</sup></a></th>
           <th class="platform rhino17 engine"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></th>
           <th class="platform phantom engine"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></th>
           <th class="platform node engine"><a href="#node" class="browser-name"><abbr title="Node 0.10">Node</abbr></th>
-          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node<br>harmony</abbr><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node<br>harmony</abbr><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
           <th class="platform ios7 mobile"><a href="#ios7" class="browser-name"><abbr title="iOS Safari">iOS7</abbr></th>
           <th class="platform ios8 mobile"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS8</abbr></th>
         </tr>
@@ -142,10 +144,12 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -193,10 +197,12 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 
           <td class="tally tr" data-tally="0.7777777777777778">7/9</td>
+          <td class="tally _6to5" data-tally="0.7777777777777778">7/9</td>
           <td class="tally ejs" data-tally="0.7777777777777778">7/9</td>
           <td class="tally closure" data-tally="0.6666666666666666">6/9</td>
           <td class="tally ie10" data-tally="0">0/9</td>
           <td class="tally ie11" data-tally="0">0/9</td>
+          <td class="tally ie11tp" data-tally="0.8888888888888888">8/9</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/9</td>
@@ -248,10 +254,12 @@ test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}cat
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -304,10 +312,12 @@ test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fe
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -360,10 +370,12 @@ test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w +
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -417,10 +429,12 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -474,10 +488,12 @@ test(function(){try{return Function("\nvar d = { x : \"foo\", y : function() { r
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -531,10 +547,12 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -587,10 +605,12 @@ test(function(){try{return Function("\nvar f = (function() { return z => argumen
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -644,10 +664,12 @@ test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -700,10 +722,12 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -751,10 +775,12 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
           <td id="const"><span><a class="anchor" href="#const">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">const</a></span></td>
 
           <td class="tally tr" data-tally="0.75">6/8</td>
+          <td class="tally _6to5" data-tally="0.5">4/8</td>
           <td class="tally ejs" data-tally="1">8/8</td>
           <td class="tally closure" data-tally="0.75">6/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="1">8/8</td>
+          <td class="tally ie11tp" data-tally="1">8/8</td>
           <td class="tally firefox11 obsolete" data-tally="0.375">3/8</td>
           <td class="tally firefox13 obsolete" data-tally="0.375">3/8</td>
           <td class="tally firefox16 obsolete" data-tally="0.375">3/8</td>
@@ -807,10 +833,12 @@ test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -863,10 +891,12 @@ test(function(){try{return Function("\n{ const bar = 456; }\nreturn (function(){
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -923,10 +953,12 @@ test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -980,10 +1012,12 @@ test(function(){try{return Function("\nvar passed = (function(){ try { qux; } ca
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1037,10 +1071,12 @@ test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -1094,10 +1130,12 @@ test(function(){try{return Function("\n'use strict';\n{ const bar = 456; }\nretu
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1155,10 +1193,12 @@ test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  F
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -1213,10 +1253,12 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1264,10 +1306,12 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td id="let"><span><a class="anchor" href="#let">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">let</a></span></td>
 
           <td class="tally tr" data-tally="0.8">8/10</td>
+          <td class="tally _6to5" data-tally="0.6">6/10</td>
           <td class="tally ejs" data-tally="1">10/10</td>
           <td class="tally closure" data-tally="0.8">8/10</td>
           <td class="tally ie10" data-tally="0">0/10</td>
           <td class="tally ie11" data-tally="0.8">8/10</td>
+          <td class="tally ie11tp" data-tally="0.8">8/10</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/10</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/10</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/10</td>
@@ -1320,27 +1364,29 @@ test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n  
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1376,27 +1422,29 @@ test(function(){try{return Function("\n{ let bar = 456; }\nreturn (function(){ t
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1432,27 +1480,29 @@ test(function(){try{return Function("\nfor(let baz = 0; false;) {}\nreturn (func
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1489,10 +1539,12 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1509,7 +1561,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
-          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1555,10 +1607,12 @@ test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1612,27 +1666,29 @@ test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (fo
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1669,27 +1725,29 @@ test(function(){try{return Function("\n'use strict';\n{ let bar = 456; }\nreturn
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1726,27 +1784,29 @@ test(function(){try{return Function("\n'use strict';\nfor(let baz = 0; false;) {
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[4]</sup></a></td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1784,10 +1844,12 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1804,7 +1866,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33">No</td>
           <td class="no firefox34">No</td>
-          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[5]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1851,10 +1913,12 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -1902,10 +1966,12 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
           <td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 
           <td class="tally tr" data-tally="0.75">3/4</td>
+          <td class="tally _6to5" data-tally="0.75">3/4</td>
           <td class="tally ejs" data-tally="0.75">3/4</td>
           <td class="tally closure" data-tally="0.75">3/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="0">0/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0.5">2/4</td>
@@ -1957,10 +2023,12 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -2012,10 +2080,12 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2067,10 +2137,12 @@ test(function(){try{return Function("\nreturn (function (a, b = a) { return b ==
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -2136,10 +2208,12 @@ test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    e
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2192,10 +2266,12 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -2243,10 +2319,12 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
 
           <td class="tally tr" data-tally="1">4/4</td>
+          <td class="tally _6to5" data-tally="1">4/4</td>
           <td class="tally ejs" data-tally="1">4/4</td>
           <td class="tally closure" data-tally="0.5">2/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="1">4/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0.25">1/4</td>
@@ -2298,10 +2376,12 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n    
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2353,10 +2433,12 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -2408,10 +2490,12 @@ test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n    
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2463,10 +2547,12 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2514,10 +2600,12 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td id="class"><span><a class="anchor" href="#class">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
 
           <td class="tally tr" data-tally="0.875">7/8</td>
+          <td class="tally _6to5" data-tally="0.875">7/8</td>
           <td class="tally ejs" data-tally="0.75">6/8</td>
           <td class="tally closure" data-tally="0.75">6/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
+          <td class="tally ie11tp" data-tally="1">8/8</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/8</td>
@@ -2570,10 +2658,12 @@ test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"functio
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2629,10 +2719,12 @@ test(function(){try{return Function("\nclass C {}\n{\n  class D {}\n}\nreturn ty
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2684,10 +2776,12 @@ test(function(){try{return Function("\nreturn typeof class C {} === \"function\"
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2743,10 +2837,12 @@ test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2803,10 +2899,12 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  method()
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2863,10 +2961,12 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  static m
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2922,10 +3022,12 @@ test(function(){try{return Function("\nvar c = class C {\n  static method() { re
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2979,10 +3081,12 @@ test(function(){try{return Function("\nclass C extends Array {}\nreturn Array.is
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3030,10 +3134,12 @@ test(function(){try{return Function("\nclass C extends Array {}\nreturn Array.is
           <td id="super"><span><a class="anchor" href="#super">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword">super</a></span></td>
 
           <td class="tally tr" data-tally="1">3/3</td>
+          <td class="tally _6to5" data-tally="1">3/3</td>
           <td class="tally ejs" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="0">0/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
+          <td class="tally ie11tp" data-tally="1">3/3</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/3</td>
@@ -3090,10 +3196,12 @@ test(function(){try{return Function("\nclass B extends class {\n  constructor(a)
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3150,10 +3258,12 @@ test(function(){try{return Function("\nclass B extends class {\n  qux(a) { retur
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3214,10 +3324,12 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3265,10 +3377,12 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
           <td id="object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser">object literal extensions</a></span></td>
 
           <td class="tally tr" data-tally="1">3/3</td>
+          <td class="tally _6to5" data-tally="1">3/3</td>
           <td class="tally ejs" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="1">3/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
+          <td class="tally ie11tp" data-tally="1">3/3</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/3</td>
@@ -3321,10 +3435,12 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3377,10 +3493,12 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3432,10 +3550,12 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3490,10 +3610,12 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -3541,10 +3663,12 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td id="generators"><span><a class="anchor" href="#generators">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
 
           <td class="tally tr" data-tally="1">3/3</td>
+          <td class="tally _6to5" data-tally="1">3/3</td>
           <td class="tally ejs" data-tally="0">0/3</td>
           <td class="tally closure" data-tally="1">3/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
+          <td class="tally ie11tp" data-tally="0">0/3</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/3</td>
@@ -3606,10 +3730,12 @@ test(function(){try{return Function("\nfunction* generator(){\n  yield 5; yield 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3672,10 +3798,12 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3739,10 +3867,12 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3790,10 +3920,12 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
 
           <td class="tally tr" data-tally="1">4/4</td>
+          <td class="tally _6to5" data-tally="0.5">2/4</td>
           <td class="tally ejs" data-tally="1">4/4</td>
           <td class="tally closure" data-tally="1">4/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="0.5">2/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/4</td>
@@ -3845,10 +3977,12 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      "
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3900,10 +4034,12 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      "
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -3955,10 +4091,12 @@ test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}c
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -4010,10 +4148,12 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -4061,10 +4201,12 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
           <td id="template_strings"><span><a class="anchor" href="#template_strings">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">template strings</a></span></td>
 
           <td class="tally tr" data-tally="1">2/2</td>
+          <td class="tally _6to5" data-tally="0.5">1/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="1">2/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
+          <td class="tally ie11tp" data-tally="0.5">1/2</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/2</td>
@@ -4118,10 +4260,12 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -4184,10 +4328,12 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -4235,10 +4381,12 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky">RegExp "y" and "u" flags</a></span></td>
 
           <td class="tally tr" data-tally="0.5">1/2</td>
+          <td class="tally _6to5" data-tally="0.5">1/2</td>
           <td class="tally ejs" data-tally="0">0/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
+          <td class="tally ie11tp" data-tally="0.5">1/2</td>
           <td class="tally firefox11 obsolete" data-tally="0.5">1/2</td>
           <td class="tally firefox13 obsolete" data-tally="0.5">1/2</td>
           <td class="tally firefox16 obsolete" data-tally="0.5">1/2</td>
@@ -4294,10 +4442,12 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4349,10 +4499,12 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -4400,10 +4552,12 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td id="typed_arrays"><span><a class="anchor" href="#typed_arrays">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects">typed arrays</a></span></td>
 
           <td class="tally tr" data-tally="0">0/40</td>
+          <td class="tally _6to5" data-tally="0">0/40</td>
           <td class="tally ejs" data-tally="0.45">18/40</td>
           <td class="tally closure" data-tally="0">0/40</td>
           <td class="tally ie10" data-tally="0.4">16/40</td>
           <td class="tally ie11" data-tally="0.4">16/40</td>
+          <td class="tally ie11tp" data-tally="1">40/40</td>
           <td class="tally firefox11 obsolete" data-tally="0.225">9/40</td>
           <td class="tally firefox13 obsolete" data-tally="0.225">9/40</td>
           <td class="tally firefox16 obsolete" data-tally="0.45">18/40</td>
@@ -4457,10 +4611,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4514,10 +4670,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4571,10 +4729,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4628,10 +4788,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4685,10 +4847,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4742,10 +4906,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4799,10 +4965,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4856,10 +5024,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4913,10 +5083,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -4971,10 +5143,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5029,10 +5203,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5087,10 +5263,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5145,10 +5323,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5203,10 +5383,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5261,10 +5443,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5319,10 +5503,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5377,10 +5563,12 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5440,10 +5628,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.from === \"functi
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5503,10 +5693,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5566,10 +5758,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarra
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -5629,10 +5823,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5692,10 +5888,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5755,10 +5953,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastInd
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5818,10 +6018,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5881,10 +6083,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -5944,10 +6148,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6007,10 +6213,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6070,10 +6278,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map ===
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6133,10 +6343,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6196,10 +6408,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceR
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6259,10 +6473,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6322,10 +6538,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6385,10 +6603,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6448,10 +6668,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWit
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6511,10 +6733,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6574,10 +6798,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findInd
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6637,10 +6863,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6700,10 +6928,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys ==
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6763,10 +6993,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6826,10 +7058,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -6877,10 +7111,12 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
           <td id="Map"><span><a class="anchor" href="#Map">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
 
           <td class="tally tr" data-tally="1">9/9</td>
+          <td class="tally _6to5" data-tally="1">9/9</td>
           <td class="tally ejs" data-tally="1">9/9</td>
           <td class="tally closure" data-tally="0">0/9</td>
           <td class="tally ie10" data-tally="0">0/9</td>
           <td class="tally ie11" data-tally="0.5555555555555556">5/9</td>
+          <td class="tally ie11tp" data-tally="1">9/9</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox16 obsolete" data-tally="0.3333333333333333">3/9</td>
@@ -6937,10 +7173,12 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -6997,10 +7235,12 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar map =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -7057,10 +7297,12 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7112,10 +7354,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.delete === \"
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -7167,10 +7411,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.clear === \"f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7222,10 +7468,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.forEach === \
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7277,10 +7525,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.keys === \"fu
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7332,10 +7582,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.values === \"
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7387,10 +7639,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7438,10 +7692,12 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
           <td id="Set"><span><a class="anchor" href="#Set">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
 
           <td class="tally tr" data-tally="1">9/9</td>
+          <td class="tally _6to5" data-tally="1">9/9</td>
           <td class="tally ejs" data-tally="1">9/9</td>
           <td class="tally closure" data-tally="0">0/9</td>
           <td class="tally ie10" data-tally="0">0/9</td>
           <td class="tally ie11" data-tally="0.5555555555555556">5/9</td>
+          <td class="tally ie11tp" data-tally="1">9/9</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/9</td>
           <td class="tally firefox16 obsolete" data-tally="0.3333333333333333">3/9</td>
@@ -7499,10 +7755,12 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -7558,10 +7816,12 @@ test(function(){try{return Function("\nvar obj1 = {};\nvar obj2 = {};\nvar set =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -7620,10 +7880,12 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7675,10 +7937,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.delete === \"
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -7730,10 +7994,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.clear === \"f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7785,10 +8051,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.forEach === \
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7840,10 +8108,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.keys === \"fu
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7895,10 +8165,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.values === \"
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -7950,10 +8222,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8001,10 +8275,12 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
           <td id="WeakMap"><span><a class="anchor" href="#WeakMap">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
 
           <td class="tally tr" data-tally="0.5">2/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="0.5">2/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0.75">3/4</td>
+          <td class="tally ie11tp" data-tally="1">4/4</td>
           <td class="tally firefox11 obsolete" data-tally="0.5">2/4</td>
           <td class="tally firefox13 obsolete" data-tally="0.5">2/4</td>
           <td class="tally firefox16 obsolete" data-tally="0.5">2/4</td>
@@ -8061,10 +8337,12 @@ test(function(){try{return Function("\nvar key = {};\nvar weakmap = new WeakMap(
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -8121,10 +8399,12 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar weakm
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8176,10 +8456,12 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -8231,10 +8513,12 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.clear ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8282,10 +8566,12 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.clear ===
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
 
           <td class="tally tr" data-tally="0.5">2/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="0.5">2/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="1">4/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/4</td>
@@ -8343,10 +8629,12 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8401,10 +8689,12 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8456,10 +8746,12 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8511,10 +8803,12 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.clear ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8562,10 +8856,12 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.clear ===
           <td id="Proxy"><span><a class="anchor" href="#Proxy">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
 
           <td class="tally tr" data-tally="0">0/15</td>
+          <td class="tally _6to5" data-tally="0">0/15</td>
           <td class="tally ejs" data-tally="0.5333333333333333">8/15</td>
           <td class="tally closure" data-tally="0">0/15</td>
           <td class="tally ie10" data-tally="0">0/15</td>
           <td class="tally ie11" data-tally="0">0/15</td>
+          <td class="tally ie11tp" data-tally="0.9333333333333333">14/15</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/15</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/15</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/15</td>
@@ -8623,27 +8919,29 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
-          <td class="yes firefox35">Yes<a href="#fx-proxy-get-note"><sup>[6]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox35">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8686,27 +8984,29 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox33">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox35">Yes<a href="#fx-proxy-set-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox33">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox35">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -8748,10 +9048,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8810,10 +9112,12 @@ test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -8878,21 +9182,23 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32 obsolete">Yes</td>
@@ -8944,10 +9250,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9006,10 +9314,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nv
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9073,10 +9383,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nva
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9137,10 +9449,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9202,10 +9516,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9269,10 +9585,12 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nf
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9333,24 +9651,26 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
           <td class="yes firefox33">Yes</td>
           <td class="yes firefox34">Yes</td>
           <td class="yes firefox35">Yes</td>
@@ -9398,10 +9718,12 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9461,10 +9783,12 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9524,10 +9848,12 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9575,10 +9901,12 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
           <td id="Reflect"><span><a class="anchor" href="#Reflect">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
 
           <td class="tally tr" data-tally="0">0/14</td>
+          <td class="tally _6to5" data-tally="0">0/14</td>
           <td class="tally ejs" data-tally="1">14/14</td>
           <td class="tally closure" data-tally="0">0/14</td>
           <td class="tally ie10" data-tally="0">0/14</td>
           <td class="tally ie11" data-tally="0">0/14</td>
+          <td class="tally ie11tp" data-tally="1">14/14</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/14</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/14</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/14</td>
@@ -9630,10 +9958,12 @@ test(function(){try{return Function("\nreturn Reflect.get({ qux: 987 }, \"qux\")
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9687,10 +10017,12 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.set(obj, \"quux\",
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9742,10 +10074,12 @@ test(function(){try{return Function("\nreturn Reflect.has({ qux: 987 }, \"qux\")
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9799,10 +10133,12 @@ test(function(){try{return Function("\nvar obj = { bar: 456 };\nReflect.deletePr
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9857,10 +10193,12 @@ test(function(){try{return Function("\nvar obj = { baz: 789 };\nvar desc = Refle
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9914,10 +10252,12 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.defineProperty(obj
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -9969,10 +10309,12 @@ test(function(){try{return Function("\nreturn Reflect.getPrototypeOf([]) === Arr
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10026,10 +10368,12 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.setPrototypeOf(obj
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10082,10 +10426,12 @@ test(function(){try{return Function("\nreturn Reflect.isExtensible({}) &&\n  !Re
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10139,10 +10485,12 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.preventExtensions(
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10203,10 +10551,12 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nvar iterat
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10259,10 +10609,12 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nreturn Ref
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10314,10 +10666,12 @@ test(function(){try{return Function("\nreturn Reflect.apply(Array.prototype.push
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10369,10 +10723,12 @@ test(function(){try{return Function("\nreturn +Reflect.construct(Date, [1995, 8,
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10417,7 +10773,7 @@ test(function(){try{return Function("\nreturn +Reflect.construct(Date, [1995, 8,
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[10]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span></td>
 <script data-source="
 'use strict';
 {
@@ -10429,10 +10785,12 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10480,10 +10838,12 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
           <td id="destructuring"><span><a class="anchor" href="#destructuring">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
 
           <td class="tally tr" data-tally="1">7/7</td>
+          <td class="tally _6to5" data-tally="0.7142857142857143">5/7</td>
           <td class="tally ejs" data-tally="0.5714285714285714">4/7</td>
           <td class="tally closure" data-tally="1">7/7</td>
           <td class="tally ie10" data-tally="0">0/7</td>
           <td class="tally ie11" data-tally="0">0/7</td>
+          <td class="tally ie11tp" data-tally="0">0/7</td>
           <td class="tally firefox11 obsolete" data-tally="0.5714285714285714">4/7</td>
           <td class="tally firefox13 obsolete" data-tally="0.5714285714285714">4/7</td>
           <td class="tally firefox16 obsolete" data-tally="0.5714285714285714">4/7</td>
@@ -10536,10 +10896,12 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -10572,7 +10934,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -10581,7 +10943,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>object destructuring</span></td>
 <script data-source="
@@ -10592,10 +10954,12 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -10628,7 +10992,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -10637,7 +11001,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>combined destructuring</span></td>
 <script data-source="
@@ -10648,10 +11012,12 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -10684,7 +11050,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -10693,7 +11059,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>destructuring parameters</span></td>
 <script data-source="
@@ -10706,10 +11072,12 @@ test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -10764,10 +11132,12 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10820,10 +11190,12 @@ test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undef
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10878,10 +11250,12 @@ test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10935,10 +11309,12 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -10986,10 +11362,12 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
           <td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 
           <td class="tally tr" data-tally="0.75">3/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="1">4/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0.25">1/4</td>
+          <td class="tally ie11tp" data-tally="0.75">3/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/4</td>
@@ -11042,10 +11420,12 @@ test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true},
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11099,10 +11479,12 @@ test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11157,10 +11539,12 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11212,10 +11596,12 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11263,10 +11649,12 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
           <td id="function_name_property"><span><a class="anchor" href="#function_name_property">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function "name" property</a></span></td>
 
           <td class="tally tr" data-tally="0">0/16</td>
+          <td class="tally _6to5" data-tally="0">0/16</td>
           <td class="tally ejs" data-tally="0">0/16</td>
           <td class="tally closure" data-tally="0">0/16</td>
           <td class="tally ie10" data-tally="0">0/16</td>
           <td class="tally ie11" data-tally="0">0/16</td>
+          <td class="tally ie11tp" data-tally="0">0/16</td>
           <td class="tally firefox11 obsolete" data-tally="0.1875">3/16</td>
           <td class="tally firefox13 obsolete" data-tally="0.1875">3/16</td>
           <td class="tally firefox16 obsolete" data-tally="0.1875">3/16</td>
@@ -11320,10 +11708,12 @@ test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'f
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -11376,10 +11766,12 @@ test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -11431,10 +11823,12 @@ test(function(){try{return Function("\nreturn (new Function).name === \"anonymou
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -11488,10 +11882,12 @@ test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).n
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11545,10 +11941,12 @@ test(function(){try{return Function("\nvar foo = function() {};\nvar bar = funct
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11604,10 +12002,12 @@ test(function(){try{return Function("\nvar o = { foo: function(){}, bar: functio
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11662,10 +12062,12 @@ test(function(){try{return Function("\nvar o = { get foo(){}, set foo(){} };\nva
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11718,10 +12120,12 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11781,10 +12185,12 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol(\"foo\");\n
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11839,10 +12245,12 @@ test(function(){try{return Function("\nclass foo {};\nclass bar { static name() 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11895,10 +12303,12 @@ test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -11955,10 +12365,12 @@ test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12014,10 +12426,12 @@ test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12070,10 +12484,12 @@ test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12126,10 +12542,12 @@ test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12184,10 +12602,12 @@ test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDes
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12240,10 +12660,12 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12291,10 +12713,12 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
           <td id="String_static_methods"><span><a class="anchor" href="#String_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-constructor">String static methods</a></span></td>
 
           <td class="tally tr" data-tally="1">2/2</td>
+          <td class="tally _6to5" data-tally="1">2/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
+          <td class="tally ie11tp" data-tally="1">2/2</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/2</td>
@@ -12346,10 +12770,12 @@ test(function(){try{return Function("\nreturn typeof String.raw === 'function';\
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12401,10 +12827,12 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12452,10 +12880,12 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
 
           <td class="tally tr" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally _6to5" data-tally="0.8333333333333334">5/6</td>
           <td class="tally ejs" data-tally="0.8333333333333334">5/6</td>
           <td class="tally closure" data-tally="0">0/6</td>
           <td class="tally ie10" data-tally="0">0/6</td>
           <td class="tally ie11" data-tally="0">0/6</td>
+          <td class="tally ie11tp" data-tally="0.8333333333333334">5/6</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/6</td>
@@ -12507,10 +12937,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.codePointA
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12564,10 +12996,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.normalize 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12620,10 +13054,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.repeat ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12676,10 +13112,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.startsWith
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12732,10 +13170,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.endsWith =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12788,10 +13228,12 @@ test(function(){try{return Function("\nreturn typeof String.prototype.contains =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12844,10 +13286,12 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -12895,10 +13339,12 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td id="Symbol"><span><a class="anchor" href="#Symbol">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
 
           <td class="tally tr" data-tally="0">0/8</td>
+          <td class="tally _6to5" data-tally="0.5">4/8</td>
           <td class="tally ejs" data-tally="0.625">5/8</td>
           <td class="tally closure" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
+          <td class="tally ie11tp" data-tally="0.875">7/8</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/8</td>
@@ -12954,10 +13400,12 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13009,10 +13457,12 @@ test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13076,10 +13526,12 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13140,10 +13592,12 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13208,10 +13662,12 @@ test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13263,10 +13719,12 @@ test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symb
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13323,10 +13781,12 @@ test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symb
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13383,10 +13843,12 @@ test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject 
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13441,10 +13903,12 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13492,10 +13956,12 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
 
           <td class="tally tr" data-tally="0">0/7</td>
+          <td class="tally _6to5" data-tally="0">0/7</td>
           <td class="tally ejs" data-tally="0.5714285714285714">4/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
           <td class="tally ie10" data-tally="0">0/7</td>
           <td class="tally ie11" data-tally="0">0/7</td>
+          <td class="tally ie11tp" data-tally="0.2857142857142857">2/7</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/7</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/7</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/7</td>
@@ -13552,10 +14018,12 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13610,10 +14078,12 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13665,10 +14135,12 @@ test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13733,10 +14205,12 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13797,10 +14271,12 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13854,10 +14330,12 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13913,10 +14391,12 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -13964,10 +14444,12 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
           <td class="tally tr" data-tally="0">0/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="0">0/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="0">0/4</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/4</td>
@@ -14020,10 +14502,12 @@ return typeof RegExp.prototype.match === 'function';
       }())</script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14076,10 +14560,12 @@ return typeof RegExp.prototype.replace === 'function';
       }())</script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14132,10 +14618,12 @@ return typeof RegExp.prototype.split === 'function';
       }())</script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14188,10 +14676,12 @@ return typeof RegExp.prototype.search === 'function';
       }())</script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14239,10 +14729,12 @@ return typeof RegExp.prototype.search === 'function';
           <td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
 
           <td class="tally tr" data-tally="1">2/2</td>
+          <td class="tally _6to5" data-tally="1">2/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
+          <td class="tally ie11tp" data-tally="1">2/2</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/2</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/2</td>
@@ -14294,10 +14786,12 @@ test(function(){try{return Function("\nreturn typeof Array.from === 'function';\
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14350,10 +14844,12 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14401,10 +14897,12 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
           <td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
 
           <td class="tally tr" data-tally="0.75">6/8</td>
+          <td class="tally _6to5" data-tally="0.875">7/8</td>
           <td class="tally ejs" data-tally="0.875">7/8</td>
           <td class="tally closure" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
+          <td class="tally ie11tp" data-tally="1">8/8</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/8</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/8</td>
@@ -14456,10 +14954,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin 
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14511,10 +15011,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14566,10 +15068,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex =
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14621,10 +15125,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14676,10 +15182,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14731,27 +15239,29 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[12]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[12]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[12]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[12]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[12]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[13]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14762,8 +15272,8 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[14]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[14]</sup></a></td>
+          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -14786,10 +15296,12 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.entries ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14849,10 +15361,12 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
 </script>
 
           <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -14900,10 +15414,12 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td id="Number_properties"><span><a class="anchor" href="#Number_properties">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isfinite-number">Number properties</a></span></td>
 
           <td class="tally tr" data-tally="1">7/7</td>
+          <td class="tally _6to5" data-tally="1">7/7</td>
           <td class="tally ejs" data-tally="1">7/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
           <td class="tally ie10" data-tally="0">0/7</td>
           <td class="tally ie11" data-tally="0">0/7</td>
+          <td class="tally ie11tp" data-tally="1">7/7</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/7</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/7</td>
           <td class="tally firefox16 obsolete" data-tally="0.42857142857142855">3/7</td>
@@ -14955,10 +15471,12 @@ test(function(){try{return Function("\nreturn typeof Number.isFinite === 'functi
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -15010,10 +15528,12 @@ test(function(){try{return Function("\nreturn typeof Number.isInteger === 'funct
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -15065,10 +15585,12 @@ test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'f
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15120,10 +15642,12 @@ test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function'
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -15175,10 +15699,12 @@ test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number'
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15230,10 +15756,12 @@ test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15285,10 +15813,12 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
 </script>
 
           <td class="yes tr">Yes</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15336,10 +15866,12 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
           <td id="Math_methods"><span><a class="anchor" href="#Math_methods">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-math">Math methods</a></span></td>
 
           <td class="tally tr" data-tally="0">0/17</td>
+          <td class="tally _6to5" data-tally="1">17/17</td>
           <td class="tally ejs" data-tally="1">17/17</td>
           <td class="tally closure" data-tally="0">0/17</td>
           <td class="tally ie10" data-tally="0">0/17</td>
           <td class="tally ie11" data-tally="0">0/17</td>
+          <td class="tally ie11tp" data-tally="1">17/17</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/17</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/17</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/17</td>
@@ -15391,10 +15923,12 @@ test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15446,10 +15980,12 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15469,7 +16005,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[15]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[16]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -15501,10 +16037,12 @@ test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15556,10 +16094,12 @@ test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15611,10 +16151,12 @@ test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15666,10 +16208,12 @@ test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15721,10 +16265,12 @@ test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15776,10 +16322,12 @@ test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15831,10 +16379,12 @@ test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15886,10 +16436,12 @@ test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15941,10 +16493,12 @@ test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -15996,10 +16550,12 @@ test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16051,10 +16607,12 @@ test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16106,10 +16664,12 @@ test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16161,10 +16721,12 @@ test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\"
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16216,10 +16778,12 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16228,7 +16792,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[16]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[17]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -16271,10 +16835,12 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
 </script>
 
           <td class="no tr">No</td>
+          <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16319,16 +16885,18 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="yes ios8">Yes</td>
         </tr>
         <tr>
-          <th colspan="50" class="separator"></th>
+          <th colspan="52" class="separator"></th>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[17]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
+          <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally ejs not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/5</td>
           <td class="tally ie10" data-tally="0">0/5</td>
           <td class="tally ie11" data-tally="0.2">1/5</td>
+          <td class="tally ie11tp" data-tally="0.2">1/5</td>
           <td class="tally firefox11 obsolete" data-tally="0.2">1/5</td>
           <td class="tally firefox13 obsolete" data-tally="0.2">1/5</td>
           <td class="tally firefox16 obsolete" data-tally="0.2">1/5</td>
@@ -16381,10 +16949,12 @@ test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Arra
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -16441,10 +17011,12 @@ test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __prot
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16500,10 +17072,12 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16559,10 +17133,12 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16617,10 +17193,12 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16665,7 +17243,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[18]</sup></a></span></td>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[19]</sup></a></span></td>
 <script data-source="
 // Note: only available outside of strict mode.
 var passed = f() === 2 && g() === 4;
@@ -16677,10 +17255,12 @@ test(function(){try{return Function("\n// Note: only available outside of strict
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="yes ie10">Yes</td>
           <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16728,10 +17308,12 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/3</td>
+          <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally ejs not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="1">3/3</td>
+          <td class="tally ie11tp" data-tally="1">3/3</td>
           <td class="tally firefox11 obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally firefox13 obsolete" data-tally="0.6666666666666666">2/3</td>
           <td class="tally firefox16 obsolete" data-tally="0.6666666666666666">2/3</td>
@@ -16784,10 +17366,12 @@ test(function(){try{return Function("\nvar A = function(){};\nreturn (new A())._
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -16841,10 +17425,12 @@ test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototyp
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -16903,10 +17489,12 @@ test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescripto
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -16966,10 +17554,12 @@ test(function(){try{return Function("\nvar i, names = [\"anchor\", \"big\", \"bo
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="yes tr not-applicable ">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="yes ejs not-applicable ">Yes</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -17022,10 +17612,12 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="yes tr not-applicable ">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
           <td class="yes firefox11 obsolete">Yes</td>
           <td class="yes firefox13 obsolete">Yes</td>
           <td class="yes firefox16 obsolete">Yes</td>
@@ -17072,59 +17664,62 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
       </tbody>
     </table>
     <div id="footnotes">
+      <p id="ie-experimental-flag-note">
+        <sup>[1]</sup> Have to be enabled via "Experimental Web Platform Features" flag
+      </p>
       <p id="experimental-flag-note">
-        <sup>[1]</sup> Have to be enabled via "Experimental Javascript features" flag
+        <sup>[2]</sup> Have to be enabled via "Experimental Javascript features" flag
       </p>
       <p id="khtml-note">
-        <sup>[2]</sup> Results are only applicable for the KHTML rendering engine.
+        <sup>[3]</sup> Results are only applicable for the KHTML rendering engine.
       </p>
       <p id="harmony-flag-note">
-        <sup>[3]</sup> Have to be enabled via --harmony flag
+        <sup>[4]</sup> Have to be enabled via --harmony flag
       </p>
       <p id="fx-let-note">
-        <sup>[4]</sup> Available from Firefox 2 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
+        <sup>[5]</sup> Available from Firefox 2 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
       <p id="fx-let-tdz-note">
-        <sup>[5]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
+        <sup>[6]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
       <p id="fx-proxy-get-note">
-        <sup>[6]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
+        <sup>[7]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
       </p>
       <p id="fx-proxy-set-note">
-        <sup>[7]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
+        <sup>[8]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
       </p>
       <p id="fx-proxy-getown-note">
-        <sup>[8]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+        <sup>[9]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
       </p>
       <p id="fx-proxy-ownkeys-note">
-        <sup>[9]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+        <sup>[10]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
       </p>
       <p id="block-level-function-note">
-        <sup>[10]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[11]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-destructuring-note">
-        <sup>[11]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
+        <sup>[12]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[12]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[13]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[13]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[14]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[14]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[15]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[15]</sup> Available since Chrome 28
+        <sup>[16]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[16]</sup> Available since Firefox 26
+        <sup>[17]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[17]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
       <p id="hoisted-block-level-function-note">
-        <sup>[18]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
+        <sup>[19]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -68,8 +68,8 @@
       <thead>
         <tr>
           <th colspan="3"  class="platformtype"></th>
-          <th colspan="3"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
-          <th colspan="14" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="4"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
+          <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
           <th colspan="4"  class="platformtype" id="engine-header" style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
         </tr>


### PR DESCRIPTION
6to5's results for certain tests that used eval() (such as const early errors) required some manual confirmation, and some of the block-scope checks were regarded more leniently due to concerns raised in #305, but for the most part they are based off the [test file](https://rawgit.com/webbedspace/compat-table/compiler-testing/es6/compilers/6to5-polyfill.html) in #309.

Closes #306 and #281, and also supplants #282 (which has a few problems separating compiled/polyfilled vs. native results).
