### PR TITLE
Changed the block-scoping tests to check shadowing

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -493,8 +493,9 @@ exports.tests = [
     },
     'is block-scoped': {
       exec: function() {/*
+        const bar = 123;
         { const bar = 456; }
-        return (function(){ try { bar; } catch(e) { return true; }}());
+        return bar === 123;
       */},
       res: {
         tr:          true,
@@ -552,8 +553,9 @@ exports.tests = [
     'is block-scoped (strict mode)': {
       exec: function() {/*
         'use strict';
+        const bar = 123;
         { const bar = 456; }
-        return (function(){ try { bar; } catch(e) { return true; }}());
+        return bar === 123;
       */},
       res: {
         tr:          true,
@@ -625,8 +627,9 @@ exports.tests = [
     },
     'is block-scoped': {
       exec: function(){/*
+        let bar = 123;
         { let bar = 456; }
-        return (function(){ try { bar; } catch(e) { return true; }}());
+        return bar === 123;
       */},
       res: {
         tr:          true,
@@ -639,8 +642,9 @@ exports.tests = [
     },
     'for-loop statement scope': {
       exec: function(){/*
+        let baz = 1;
         for(let baz = 0; false; false) {}
-        return (function(){ try { baz; } catch(e) { return true; }}());
+        return baz === 1;
       */},
       res: {
         tr:          true,
@@ -708,8 +712,9 @@ exports.tests = [
     'is block-scoped (strict mode)': {
       exec: function(){/*
         'use strict';
+        let bar = 123;
         { let bar = 456; }
-        return (function(){ try { bar; } catch(e) { return true; }}());
+        return bar === 123;
       */},
       res: {
         tr:          true,
@@ -725,8 +730,9 @@ exports.tests = [
     'for-loop statement scope (strict mode)': {
       exec: function(){/*
         'use strict';
+        let baz = 1;
         for(let baz = 0; false; false) {}
-        return (function(){ try { baz; } catch(e) { return true; }}());
+        return baz === 1;
       */},
       res: {
         tr:          true,
@@ -1030,10 +1036,12 @@ exports.tests = [
     'is block-scoped': {
       exec: function () {/*
         class C {}
+        var c1 = C;
         {
-          class D {}
+          class C {}
+          var c2 = C;
         }
-        return typeof C === "function" && typeof D === "undefined";
+        return C === c1;
       */},
       res: {
         ie11tp:      true,
@@ -2950,12 +2958,14 @@ exports.tests = [
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
   exec: function () {/*
     'use strict';
+    function f() { return 1; }
     {
-      function f(){}
+      function f() { return 2; }
     }
-    return typeof f === "undefined";
+    return f() === 1;
   */},
   res: {
+    tr:          true,
     ejs:         false,
     closure:     true,
     ie10:        false,

--- a/es6/compilers/6to5-polyfill.html
+++ b/es6/compilers/6to5-polyfill.html
@@ -216,21 +216,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  {
-    var bar = 456;
-  }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: unknown: Line 3: bar is read-only
+  1  | (function(){
+  2  | const bar = 123;
+> 3  | { const bar = 456; }
+     |        ^
+  4  | return bar === 123;
+  5  |       })*/">
+test(function(){try{return Function("/* Error during compilation: unknown: Line 3: bar is read-only\n  1  | (function(){\n  2  | const bar = 123;\n> 3  | { const bar = 456; }\n     |        ^\n  4  | return bar === 123;\n  5  |       })*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -271,22 +264,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  &quot;use strict&quot;;
-  {
-    var bar = 456;
-  }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: unknown: Line 4: bar is read-only
+  2  | 'use strict';
+  3  | const bar = 123;
+> 4  | { const bar = 456; }
+     |        ^
+  5  | return bar === 123;
+  6  |       })*/">
+test(function(){try{return Function("/* Error during compilation: unknown: Line 4: bar is read-only\n  2  | 'use strict';\n  3  | const bar = 123;\n> 4  | { const bar = 456; }\n     |        ^\n  5  | return bar === 123;\n  6  |       })*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -334,18 +319,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 <script data-source="&quot;use strict&quot;;
 
 (function () {
+  var bar = 123;
   {
-    var bar = 456;
+    var _bar = 456;
   }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var bar = 123;\n  {\n    var _bar = 456;\n  }\n  return bar === 123;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -353,16 +333,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  for (var baz = 0; false; false) {}
-  return (function () {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var _baz = 0; false; false) {}
+  return baz === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  for (var baz = 0; false; false) {}\n  return (function () {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var baz = 1;\n  for (var _baz = 0; false; false) {}\n  return baz === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -430,18 +405,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
 (function () {
   &quot;use strict&quot;;
+  var bar = 123;
   {
-    var bar = 456;
+    var _bar = 456;
   }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  var bar = 123;\n  {\n    var _bar = 456;\n  }\n  return bar === 123;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -450,16 +420,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
 (function () {
   &quot;use strict&quot;;
-  for (var baz = 0; false; false) {}
-  return (function () {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var _baz = 0; false; false) {}
+  return baz === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  for (var baz = 0; false; false) {}\n  return (function () {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  var baz = 1;\n  for (var _baz = 0; false; false) {}\n  return baz === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -733,14 +698,18 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = f
 (function () {
   var _C = function _C() {};
 
+  var c1 = _C;
   {
+    var c2;
     (function () {
-      var _D = function _D() {};
+      var _C = function _C() {};
+
+      c2 = _C;
     })();
   }
-  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return _C === c1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  var c1 = _C;\n  {\n    var c2;\n    (function () {\n      var _C = function _C() {};\n\n      c2 = _C;\n    })();\n  }\n  return _C === c1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -2736,12 +2705,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Ref
 
 (function () {
   &quot;use strict&quot;;
-  {
-    function f() {}
+  function f() {
+    return 1;
   }
-  return typeof f === &quot;undefined&quot;;
+  {
+    function f() {
+      return 2;
+    }
+  }
+  return f() === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    function f() {}\n  }\n  return typeof f === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  function f() {\n    return 1;\n  }\n  {\n    function f() {\n      return 2;\n    }\n  }\n  return f() === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/6to5.html
+++ b/es6/compilers/6to5.html
@@ -214,21 +214,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  {
-    var bar = 456;
-  }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: unknown: Line 3: bar is read-only
+  1  | (function(){
+  2  | const bar = 123;
+> 3  | { const bar = 456; }
+     |        ^
+  4  | return bar === 123;
+  5  |       })*/">
+test(function(){try{return Function("/* Error during compilation: unknown: Line 3: bar is read-only\n  1  | (function(){\n  2  | const bar = 123;\n> 3  | { const bar = 456; }\n     |        ^\n  4  | return bar === 123;\n  5  |       })*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -269,22 +262,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  &quot;use strict&quot;;
-  {
-    var bar = 456;
-  }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: unknown: Line 4: bar is read-only
+  2  | 'use strict';
+  3  | const bar = 123;
+> 4  | { const bar = 456; }
+     |        ^
+  5  | return bar === 123;
+  6  |       })*/">
+test(function(){try{return Function("/* Error during compilation: unknown: Line 4: bar is read-only\n  2  | 'use strict';\n  3  | const bar = 123;\n> 4  | { const bar = 456; }\n     |        ^\n  5  | return bar === 123;\n  6  |       })*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -332,18 +317,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 <script data-source="&quot;use strict&quot;;
 
 (function () {
+  var bar = 123;
   {
-    var bar = 456;
+    var _bar = 456;
   }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var bar = 123;\n  {\n    var _bar = 456;\n  }\n  return bar === 123;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -351,16 +331,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  for (var baz = 0; false; false) {}
-  return (function () {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var _baz = 0; false; false) {}
+  return baz === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  for (var baz = 0; false; false) {}\n  return (function () {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var baz = 1;\n  for (var _baz = 0; false; false) {}\n  return baz === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -428,18 +403,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
 (function () {
   &quot;use strict&quot;;
+  var bar = 123;
   {
-    var bar = 456;
+    var _bar = 456;
   }
-  return (function () {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    var bar = 456;\n  }\n  return (function () {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  var bar = 123;\n  {\n    var _bar = 456;\n  }\n  return bar === 123;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -448,16 +418,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 
 (function () {
   &quot;use strict&quot;;
-  for (var baz = 0; false; false) {}
-  return (function () {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var _baz = 0; false; false) {}
+  return baz === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  for (var baz = 0; false; false) {}\n  return (function () {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  var baz = 1;\n  for (var _baz = 0; false; false) {}\n  return baz === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -731,14 +696,18 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = f
 (function () {
   var _C = function _C() {};
 
+  var c1 = _C;
   {
+    var c2;
     (function () {
-      var _D = function _D() {};
+      var _C = function _C() {};
+
+      c2 = _C;
     })();
   }
-  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return _C === c1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  var c1 = _C;\n  {\n    var c2;\n    (function () {\n      var _C = function _C() {};\n\n      c2 = _C;\n    })();\n  }\n  return _C === c1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -2734,12 +2703,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Ref
 
 (function () {
   &quot;use strict&quot;;
-  {
-    function f() {}
+  function f() {
+    return 1;
   }
-  return typeof f === &quot;undefined&quot;;
+  {
+    function f() {
+      return 2;
+    }
+  }
+  return f() === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  {\n    function f() {}\n  }\n  return typeof f === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use strict\";\n  function f() {\n    return 1;\n  }\n  {\n    function f() {\n      return 2;\n    }\n  }\n  return f() === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/es6-transpiler.html
+++ b/es6/compilers/es6-transpiler.html
@@ -158,8 +158,12 @@ test(function(){try{return eval("(function(){\nvar foo = 123;\nreturn (foo === 1
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="(function(){
+var bar = 123;
+{ var bar$0 = 456; }
+return bar === 123;
+      })">
+test(function(){try{return eval("(function(){\nvar bar = 123;\n{ var bar$0 = 456; }\nreturn bar === 123;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -217,14 +221,22 @@ test(function(){try{return eval("(function(){\nvar foo = 123;\nreturn (foo === 1
 
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="(function(){
+var bar = 123;
+{ var bar$0 = 456; }
+return bar === 123;
+      })">
+test(function(){try{return eval("(function(){\nvar bar = 123;\n{ var bar$0 = 456; }\nreturn bar === 123;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="(function(){
+var baz = 1;
+for(var baz$0 = 0; false; false) {}
+return baz === 1;
+      })">
+test(function(){try{return eval("(function(){\nvar baz = 1;\nfor(var baz$0 = 0; false; false) {}\nreturn baz === 1;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -404,8 +416,16 @@ test(function(){try{return eval("(function(){\nvar C = (function(){\"use strict\
 
         <tr class="subtest" data-parent="class">
           <td><span>is block-scoped</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="(function(){var PRS$0 = (function(o,t){o[&quot;__proto__&quot;]={&quot;a&quot;:t};return o[&quot;a&quot;]===t})({},{});var DP$0 = Object.defineProperty;var GOPD$0 = Object.getOwnPropertyDescriptor;var MIXIN$0 = function(t,s){for(var p in s){if(s.hasOwnProperty(p)){DP$0(t,p,GOPD$0(s,p));}}return t};
+var C = (function(){&quot;use strict&quot;;function C() {}DP$0(C,&quot;prototype&quot;,{&quot;configurable&quot;:false,&quot;enumerable&quot;:false,&quot;writable&quot;:false});;return C;})();
+var c1 = C;
+{
+  var C = (function(){&quot;use strict&quot;;function C() {}DP$0(C,&quot;prototype&quot;,{&quot;configurable&quot;:false,&quot;enumerable&quot;:false,&quot;writable&quot;:false});;return C;})();
+  var c2 = C;
+}
+return C === c1;
+      })">
+test(function(){try{return eval("(function(){var PRS$0 = (function(o,t){o[\"__proto__\"]={\"a\":t};return o[\"a\"]===t})({},{});var DP$0 = Object.defineProperty;var GOPD$0 = Object.getOwnPropertyDescriptor;var MIXIN$0 = function(t,s){for(var p in s){if(s.hasOwnProperty(p)){DP$0(t,p,GOPD$0(s,p));}}return t};\nvar C = (function(){\"use strict\";function C() {}DP$0(C,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return C;})();\nvar c1 = C;\n{\n  var C = (function(){\"use strict\";function C() {}DP$0(C,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return C;})();\n  var c2 = C;\n}\nreturn C === c1;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">

--- a/es6/compilers/esnext.html
+++ b/es6/compilers/esnext.html
@@ -187,10 +187,11 @@ test(function(){try{return eval("((function() {\nconst foo = 123;\nreturn (foo =
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
 <script data-source="((function() {
+const bar = 123;
 { const bar = 456; }
-return (function() { try { bar; } catch(e) { return true; }}());
+return bar === 123;
       }))">
-test(function(){try{return eval("((function() {\n{ const bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -223,10 +224,11 @@ test(function(){try{return eval("((function() {\n\"use strict\";\nconst foo = 12
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="((function() {
 'use strict';
+const bar = 123;
 { const bar = 456; }
-return (function() { try { bar; } catch(e) { return true; }}());
+return bar === 123;
       }))">
-test(function(){try{return eval("((function() {\n'use strict';\n{ const bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\n'use strict';\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -262,19 +264,21 @@ test(function(){try{return eval("((function() {\nlet foo = 123;\nreturn (foo ===
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped</span></td>
 <script data-source="((function() {
+let bar = 123;
 { let bar = 456; }
-return (function() { try { bar; } catch(e) { return true; }}());
+return bar === 123;
       }))">
-test(function(){try{return eval("((function() {\n{ let bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
 <script data-source="((function() {
+let baz = 1;
 for(let baz = 0; false; false) {}
-return (function() { try { baz; } catch(e) { return true; }}());
+return baz === 1;
       }))">
-test(function(){try{return eval("((function() {\nfor(let baz = 0; false; false) {}\nreturn (function() { try { baz; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -320,20 +324,22 @@ test(function(){try{return eval("((function() {\n'use strict';\nlet foo = 123;\n
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="((function() {
 'use strict';
+let bar = 123;
 { let bar = 456; }
-return (function() { try { bar; } catch(e) { return true; }}());
+return bar === 123;
       }))">
-test(function(){try{return eval("((function() {\n'use strict';\n{ let bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\n'use strict';\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope (strict mode)</span></td>
 <script data-source="((function() {
 'use strict';
+let baz = 1;
 for(let baz = 0; false; false) {}
-return (function() { try { baz; } catch(e) { return true; }}());
+return baz === 1;
       }))">
-test(function(){try{return eval("((function() {\n'use strict';\nfor(let baz = 0; false; false) {}\nreturn (function() { try { baz; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\n'use strict';\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -740,16 +746,19 @@ test(function(){try{return eval("((function() {\n      var C = function() {\n   
     return C;
   }();
 
+  var c1 = C;
   {
-    var D = function() {
+    var C = function() {
       &quot;use strict&quot;;
-      function D() {}
-      return D;
+      function C() {}
+      return C;
     }();
+
+    var c2 = C;
   }
-  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return C === c1;
 }))">
-test(function(){try{return eval("((function() {\n  var C = function() {\n    \"use strict\";\n    function C() {}\n    return C;\n  }();\n\n  {\n    var D = function() {\n      \"use strict\";\n      function D() {}\n      return D;\n    }();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n}))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\n  var C = function() {\n    \"use strict\";\n    function C() {}\n    return C;\n  }();\n\n  var c1 = C;\n  {\n    var C = function() {\n      \"use strict\";\n      function C() {}\n      return C;\n    }();\n\n    var c2 = C;\n  }\n  return C === c1;\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -2722,12 +2731,13 @@ test(function(){try{return eval("((function() {\nreturn Reflect.construct(functi
           <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[1]</sup></a></span></td>
 <script data-source="((function() {
 'use strict';
+function f() { return 1; }
 {
-  function f() {}
+  function f() { return 2; }
 }
-return typeof f === &quot;undefined&quot;;
+return f() === 1;
   }))">
-test(function(){try{return eval("((function() {\n'use strict';\n{\n  function f() {}\n}\nreturn typeof f === \"undefined\";\n  }))")()}catch(e){return false;}}());
+test(function(){try{return eval("((function() {\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/traceur.html
+++ b/es6/compilers/traceur.html
@@ -2790,19 +2790,14 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var foo = 123
           <td><span>is block-scoped</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
+  var bar = 123;
   {
-    var bar = 456;
+    var bar$__0 = 456;
   }
-  return (function() {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  {\n    var bar = 456;\n  }\n  return (function() {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var bar = 123;\n  {\n    var bar$__0 = 456;\n  }\n  return bar === 123;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -2846,19 +2841,14 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  \"use strict\
 <script data-source="&quot;use strict&quot;;
 (function() {
   'use strict';
+  var bar = 123;
   {
-    var bar = 456;
+    var bar$__0 = 456;
   }
-  return (function() {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  {\n    var bar = 456;\n  }\n  return (function() {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  var bar = 123;\n  {\n    var bar$__0 = 456;\n  }\n  return bar === 123;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -2905,36 +2895,26 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var foo = 123
           <td><span>is block-scoped</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
+  var bar = 123;
   {
-    var bar = 456;
+    var bar$__0 = 456;
   }
-  return (function() {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  {\n    var bar = 456;\n  }\n  return (function() {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var bar = 123;\n  {\n    var bar$__0 = 456;\n  }\n  return bar === 123;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  for (var baz = 0; false; false) {}
-  return (function() {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var baz$__0 = 0; false; false) {}
+  return baz === 1;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  for (var baz = 0; false; false) {}\n  return (function() {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var baz = 1;\n  for (var baz$__0 = 0; false; false) {}\n  return baz === 1;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -3005,19 +2985,14 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';
 <script data-source="&quot;use strict&quot;;
 (function() {
   'use strict';
+  var bar = 123;
   {
-    var bar = 456;
+    var bar$__0 = 456;
   }
-  return (function() {
-    try {
-      bar;
-    } catch (e) {
-      return true;
-    }
-  }());
+  return bar === 123;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  {\n    var bar = 456;\n  }\n  return (function() {\n    try {\n      bar;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  var bar = 123;\n  {\n    var bar$__0 = 456;\n  }\n  return bar === 123;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -3025,17 +3000,12 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';
 <script data-source="&quot;use strict&quot;;
 (function() {
   'use strict';
-  for (var baz = 0; false; false) {}
-  return (function() {
-    try {
-      baz;
-    } catch (e) {
-      return true;
-    }
-  }());
+  var baz = 1;
+  for (var baz$__0 = 0; false; false) {}
+  return baz === 1;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  for (var baz = 0; false; false) {}\n  return (function() {\n    try {\n      baz;\n    } catch (e) {\n      return true;\n    }\n  }());\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  var baz = 1;\n  for (var baz$__0 = 0; false; false) {}\n  return baz === 1;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -3288,14 +3258,16 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var C = funct
 (function() {
   var C = function C() {};
   ($traceurRuntime.createClass)(C, {}, {});
+  var c1 = C;
   {
-    var D = function D() {};
-    ($traceurRuntime.createClass)(D, {}, {});
+    var C = function C() {};
+    ($traceurRuntime.createClass)(C, {}, {});
+    var c2 = C;
   }
-  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return C === c1;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var C = function C() {};\n  ($traceurRuntime.createClass)(C, {}, {});\n  {\n    var D = function D() {};\n    ($traceurRuntime.createClass)(D, {}, {});\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var C = function C() {};\n  ($traceurRuntime.createClass)(C, {}, {});\n  var c1 = C;\n  {\n    var C = function C() {};\n    ($traceurRuntime.createClass)(C, {}, {});\n    var c2 = C;\n  }\n  return C === c1;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -5228,13 +5200,18 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return Reflec
 <script data-source="&quot;use strict&quot;;
 (function() {
   'use strict';
-  {
-    var f = function() {};
+  function f() {
+    return 1;
   }
-  return typeof f === &quot;undefined&quot;;
+  {
+    var f$__0 = function() {
+      return 2;
+    };
+  }
+  return f() === 1;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  {\n    var f = function() {};\n  }\n  return typeof f === \"undefined\";\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  'use strict';\n  function f() {\n    return 1;\n  }\n  {\n    var f$__0 = function() {\n      return 2;\n    };\n  }\n  return f() === 1;\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/typescript.html
+++ b/es6/compilers/typescript.html
@@ -182,9 +182,10 @@ test(function(){try{return Function("/* Error during compilation: \n(2,1): error
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
 <script data-source="/* Error during compilation: 
-(2,3): error TS1129: Statement expected.
+(2,1): error TS1129: Statement expected.
+(3,3): error TS1129: Statement expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,1): error TS1129: Statement expected.\n(3,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -212,9 +213,10 @@ test(function(){try{return Function("/* Error during compilation: \n(3,1): error
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="/* Error during compilation: 
-(3,3): error TS1129: Statement expected.
+(3,1): error TS1129: Statement expected.
+(4,3): error TS1129: Statement expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(3,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(3,1): error TS1129: Statement expected.\n(4,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -246,19 +248,21 @@ test(function(){try{return Function("/* Error during compilation: \n(2,5): error
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped</span></td>
 <script data-source="/* Error during compilation: 
-(2,7): error TS1005: ';' expected.
+(2,5): error TS1005: ';' expected.
+(3,7): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,7): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,5): error TS1005: ';' expected.\n(3,7): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
 <script data-source="/* Error during compilation: 
-(2,9): error TS1005: ';' expected.
-(2,23): error TS1005: ')' expected.
-(2,30): error TS1005: ';' expected.
+(2,5): error TS1005: ';' expected.
+(3,9): error TS1005: ';' expected.
+(3,23): error TS1005: ')' expected.
+(3,30): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,9): error TS1005: ';' expected.\n(2,23): error TS1005: ')' expected.\n(2,30): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,5): error TS1005: ';' expected.\n(3,9): error TS1005: ';' expected.\n(3,23): error TS1005: ')' expected.\n(3,30): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -294,18 +298,20 @@ test(function(){try{return Function("/* Error during compilation: \n(3,1): error
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="/* Error during compilation: 
-(3,3): error TS1129: Statement expected.
+(3,1): error TS1129: Statement expected.
+(4,3): error TS1129: Statement expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(3,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(3,1): error TS1129: Statement expected.\n(4,3): error TS1129: Statement expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope (strict mode)</span></td>
 <script data-source="/* Error during compilation: 
-(3,5): error TS1109: Expression expected.
-(3,30): error TS1005: ';' expected.
+(3,1): error TS1129: Statement expected.
+(4,5): error TS1109: Expression expected.
+(4,30): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(3,5): error TS1109: Expression expected.\n(3,30): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(3,1): error TS1129: Statement expected.\n(4,5): error TS1109: Expression expected.\n(4,30): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
@@ -495,13 +501,13 @@ test(function(){try{return Function("/* Error during compilation: \n(2,1): error
           <td><span>is block-scoped</span></td>
 <script data-source="/* Error during compilation: 
 (2,1): error TS1129: Statement expected.
-(4,3): error TS1129: Statement expected.
-(5,1): error TS1128: Declaration or statement expected.
-(6,1): error TS1108: A 'return' statement can only be used within a function body.
-(7,7): error TS1128: Declaration or statement expected.
-(7,8): error TS1128: Declaration or statement expected.
+(5,3): error TS1129: Statement expected.
+(7,1): error TS1128: Declaration or statement expected.
+(8,1): error TS1108: A 'return' statement can only be used within a function body.
+(9,7): error TS1128: Declaration or statement expected.
+(9,8): error TS1128: Declaration or statement expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,1): error TS1129: Statement expected.\n(4,3): error TS1129: Statement expected.\n(5,1): error TS1128: Declaration or statement expected.\n(6,1): error TS1108: A 'return' statement can only be used within a function body.\n(7,7): error TS1128: Declaration or statement expected.\n(7,8): error TS1128: Declaration or statement expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,1): error TS1129: Statement expected.\n(5,3): error TS1129: Statement expected.\n(7,1): error TS1128: Declaration or statement expected.\n(8,1): error TS1108: A 'return' statement can only be used within a function body.\n(9,7): error TS1128: Declaration or statement expected.\n(9,8): error TS1128: Declaration or statement expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -2014,16 +2020,11 @@ test(function(){try{return Function("/* Error during compilation: \n(2,8): error
         </tr>
         <tr>
           <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[1]</sup></a></span></td>
-<script data-source="(function () {
-    'use strict';
-    {
-        function f() {
-        }
-    }
-    return typeof f === &quot;undefined&quot;;
-});
-">
-test(function(){try{return eval("(function () {\n    'use strict';\n    {\n        function f() {\n        }\n    }\n    return typeof f === \"undefined\";\n});\n")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: 
+(3,10): error TS2393: Duplicate function implementation.
+(5,12): error TS2393: Duplicate function implementation.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(3,10): error TS2393: Duplicate function implementation.\n(5,12): error TS2393: Duplicate function implementation.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/index.html
+++ b/es6/index.html
@@ -899,10 +899,11 @@ test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
 <script data-source="
+const bar = 123;
 { const bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
+return bar === 123;
       ">
-test(function(){try{return Function("\n{ const bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -1138,10 +1139,11 @@ test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="
 'use strict';
+const bar = 123;
 { const bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
+return bar === 123;
       ">
-test(function(){try{return Function("\n'use strict';\n{ const bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\n'use strict';\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -1430,10 +1432,11 @@ test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n  
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped</span></td>
 <script data-source="
+let bar = 123;
 { let bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
+return bar === 123;
       ">
-test(function(){try{return Function("\n{ let bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -1488,10 +1491,11 @@ test(function(){try{return Function("\n{ let bar = 456; }\nreturn (function(){ t
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
 <script data-source="
+let baz = 1;
 for(let baz = 0; false; false) {}
-return (function(){ try { baz; } catch(e) { return true; }}());
+return baz === 1;
       ">
-test(function(){try{return Function("\nfor(let baz = 0; false; false) {}\nreturn (function(){ try { baz; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -1733,10 +1737,11 @@ test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (fo
           <td><span>is block-scoped (strict mode)</span></td>
 <script data-source="
 'use strict';
+let bar = 123;
 { let bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
+return bar === 123;
       ">
-test(function(){try{return Function("\n'use strict';\n{ let bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\n'use strict';\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -1792,10 +1797,11 @@ test(function(){try{return Function("\n'use strict';\n{ let bar = 456; }\nreturn
           <td><span>for-loop statement scope (strict mode)</span></td>
 <script data-source="
 'use strict';
+let baz = 1;
 for(let baz = 0; false; false) {}
-return (function(){ try { baz; } catch(e) { return true; }}());
+return baz === 1;
       ">
-test(function(){try{return Function("\n'use strict';\nfor(let baz = 0; false; false) {}\nreturn (function(){ try { baz; } catch(e) { return true; }}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\n'use strict';\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -3015,12 +3021,14 @@ test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"functio
           <td><span>is block-scoped</span></td>
 <script data-source="
 class C {}
+var c1 = C;
 {
-  class D {}
+  class C {}
+  var c2 = C;
 }
-return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+return C === c1;
       ">
-test(function(){try{return Function("\nclass C {}\n{\n  class D {}\n}\nreturn typeof C === \"function\" && typeof D === \"undefined\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nclass C {}\nvar c1 = C;\n{\n  class C {}\n  var c2 = C;\n}\nreturn C === c1;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -11880,15 +11888,16 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
           <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span></td>
 <script data-source="
 'use strict';
+function f() { return 1; }
 {
-  function f(){}
+  function f() { return 2; }
 }
-return typeof f === &quot;undefined&quot;;
+return f() === 1;
   ">
-test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nreturn typeof f === \"undefined\";\n  ")()}catch(e){return false;}}());
+test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")()}catch(e){return false;}}());
 </script>
 
-          <td class="no tr">No</td>
+          <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>


### PR DESCRIPTION
Shadowing (where an inner scope's same named variable shadows an outer-scope identifier, but doesn't replace it) is arguably a more commonplace feature of block-scoping, and the compilers tend to support it even if they don't support identifiers fully leaving scope (as in e.g. temporal dead zone). This closes #305.

The compilers had in fact already taken this into their account for their results, mostly. This corrects Traceur's result for BLFD.
