### PR TITLE
Fixed several test code bugs

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1247,8 +1247,10 @@ exports.tests = [
   exec: function () {/*
     // Note: only available outside of strict mode.
     { function f() { return 1; } }
-      function g() { return 1; } { function g() { return 2; } }
-    { function h() { return 1; } } function h() { return 2; }
+      function g() { return 1; }
+    { function g() { return 2; } }
+    { function h() { return 1; } }
+      function h() { return 2; }
 
     return f() === 1 && g() === 2 && h() === 1;
   */},
@@ -1502,6 +1504,7 @@ exports.tests = [
         tr:          true,
         _6to5:       true,
         closure:     true,
+        firefox27:   true,
         chrome21dev: true,
         nodeharmony: true,
       },

--- a/es6/compilers/6to5-polyfill.html
+++ b/es6/compilers/6to5-polyfill.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="../../master.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="../../master.js"></script>
-    <script>(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){if(typeof Symbol==="undefined"){require("es6-symbol/implement")}require("es6-shim");require("./transformation/transformers/generators/runtime")},{"./transformation/transformers/generators/runtime":2,"es6-shim":4,"es6-symbol/implement":5}],2:[function(require,module,exports){(function(global){if(typeof global.regeneratorRuntime==="object"){return}var hasOwn=Object.prototype.hasOwnProperty;var iteratorSymbol=typeof Symbol==="function"&&Symbol.iterator||"@@iterator";var runtime=global.regeneratorRuntime=exports;var wrap=runtime.wrap=function wrap(innerFn,outerFn,self,tryList){return new Generator(innerFn,outerFn,self||null,tryList||[])};var GenStateSuspendedStart="suspendedStart";var GenStateSuspendedYield="suspendedYield";var GenStateExecuting="executing";var GenStateCompleted="completed";var ContinueSentinel={};var GF=function GeneratorFunction(){};var GFp=function GeneratorFunctionPrototype(){};var Gp=GFp.prototype=Generator.prototype;(GFp.constructor=GF).prototype=Gp.constructor=GFp;var GFName="GeneratorFunction";if(GF.name!==GFName)GF.name=GFName;if(GF.name!==GFName)throw new Error(GFName+" renamed?");runtime.isGeneratorFunction=function(genFun){var ctor=genFun&&genFun.constructor;return ctor?GF.name===ctor.name:false};runtime.mark=function(genFun){genFun.__proto__=GFp;genFun.prototype=Object.create(Gp);return genFun};runtime.async=function(innerFn,outerFn,self,tryList){return new Promise(function(resolve,reject){var generator=wrap(innerFn,outerFn,self,tryList);var callNext=step.bind(generator.next);var callThrow=step.bind(generator["throw"]);function step(arg){var info;var value;try{info=this(arg);value=info.value}catch(error){return reject(error)}if(info.done){resolve(value)}else{Promise.resolve(value).then(callNext,callThrow)}}callNext()})};function Generator(innerFn,outerFn,self,tryList){var generator=outerFn?Object.create(outerFn.prototype):this;var context=new Context(tryList);var state=GenStateSuspendedStart;function invoke(method,arg){if(state===GenStateExecuting){throw new Error("Generator is already running")}if(state===GenStateCompleted){throw new Error("Generator has already finished")}while(true){var delegate=context.delegate;var info;if(delegate){try{info=delegate.iterator[method](arg);method="next";arg=undefined}catch(uncaught){context.delegate=null;method="throw";arg=uncaught;continue}if(info.done){context[delegate.resultName]=info.value;context.next=delegate.nextLoc}else{state=GenStateSuspendedYield;return info}context.delegate=null}if(method==="next"){if(state===GenStateSuspendedStart&&typeof arg!=="undefined"){throw new TypeError("attempt to send "+JSON.stringify(arg)+" to newborn generator")}if(state===GenStateSuspendedYield){context.sent=arg}else{delete context.sent}}else if(method==="throw"){if(state===GenStateSuspendedStart){state=GenStateCompleted;throw arg}if(context.dispatchException(arg)){method="next";arg=undefined}}else if(method==="return"){context.abrupt("return",arg)}state=GenStateExecuting;try{var value=innerFn.call(self,context);state=context.done?GenStateCompleted:GenStateSuspendedYield;info={value:value,done:context.done};if(value===ContinueSentinel){if(context.delegate&&method==="next"){arg=undefined}}else{return info}}catch(thrown){state=GenStateCompleted;if(method==="next"){context.dispatchException(thrown)}else{arg=thrown}}}}generator.next=invoke.bind(generator,"next");generator["throw"]=invoke.bind(generator,"throw");generator["return"]=invoke.bind(generator,"return");return generator}Gp[iteratorSymbol]=function(){return this};Gp.toString=function(){return"[object Generator]"};function pushTryEntry(triple){var entry={tryLoc:triple[0]};if(1 in triple){entry.catchLoc=triple[1]}if(2 in triple){entry.finallyLoc=triple[2]}this.tryEntries.push(entry)}function resetTryEntry(entry,i){var record=entry.completion||{};record.type=i===0?"normal":"return";delete record.arg;entry.completion=record}function Context(tryList){this.tryEntries=[{tryLoc:"root"}];tryList.forEach(pushTryEntry,this);this.reset()}runtime.keys=function(object){var keys=[];for(var key in object){keys.push(key)}keys.reverse();return function next(){while(keys.length){var key=keys.pop();if(key in object){next.value=key;next.done=false;return next}}next.done=true;return next}};function values(iterable){var iterator=iterable;if(iteratorSymbol in iterable){iterator=iterable[iteratorSymbol]()}else if(!isNaN(iterable.length)){var i=-1;iterator=function next(){while(++i<iterable.length){if(i in iterable){next.value=iterable[i];next.done=false;return next}}next.done=true;return next};iterator.next=iterator}return iterator}runtime.values=values;Context.prototype={constructor:Context,reset:function(){this.prev=0;this.next=0;this.sent=undefined;this.done=false;this.delegate=null;this.tryEntries.forEach(resetTryEntry);for(var tempIndex=0,tempName;hasOwn.call(this,tempName="t"+tempIndex)||tempIndex<20;++tempIndex){this[tempName]=null}},stop:function(){this.done=true;var rootEntry=this.tryEntries[0];var rootRecord=rootEntry.completion;if(rootRecord.type==="throw"){throw rootRecord.arg}return this.rval},dispatchException:function(exception){if(this.done){throw exception}var context=this;function handle(loc,caught){record.type="throw";record.arg=exception;context.next=loc;return!!caught}for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];var record=entry.completion;if(entry.tryLoc==="root"){return handle("end")}if(entry.tryLoc<=this.prev){var hasCatch=hasOwn.call(entry,"catchLoc");var hasFinally=hasOwn.call(entry,"finallyLoc");if(hasCatch&&hasFinally){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}else if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else if(hasCatch){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}}else if(hasFinally){if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else{throw new Error("try statement without catch or finally")}}}},_findFinallyEntry:function(finallyLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc<=this.prev&&hasOwn.call(entry,"finallyLoc")&&(entry.finallyLoc===finallyLoc||this.prev<entry.finallyLoc)){return entry}}},abrupt:function(type,arg){var entry=this._findFinallyEntry();var record=entry?entry.completion:{};record.type=type;record.arg=arg;if(entry){this.next=entry.finallyLoc}else{this.complete(record)}return ContinueSentinel},complete:function(record){if(record.type==="throw"){throw record.arg}if(record.type==="break"||record.type==="continue"){this.next=record.arg}else if(record.type==="return"){this.rval=record.arg;this.next="end"}return ContinueSentinel},finish:function(finallyLoc){var entry=this._findFinallyEntry(finallyLoc);return this.complete(entry.completion)},"catch":function(tryLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc===tryLoc){var record=entry.completion;var thrown;if(record.type==="throw"){thrown=record.arg;resetTryEntry(entry,i)}return thrown}}throw new Error("illegal catch attempt")},delegateYield:function(iterable,resultName,nextLoc){this.delegate={iterator:values(iterable),resultName:resultName,nextLoc:nextLoc};return ContinueSentinel}}}).call(this,typeof global!=="undefined"?global:typeof self!=="undefined"?self:typeof window!=="undefined"?window:{})},{}],3:[function(require,module,exports){var process=module.exports={};process.nextTick=function(){var canSetImmediate=typeof window!=="undefined"&&window.setImmediate;var canMutationObserver=typeof window!=="undefined"&&window.MutationObserver;var canPost=typeof window!=="undefined"&&window.postMessage&&window.addEventListener;if(canSetImmediate){return function(f){return window.setImmediate(f)}}var queue=[];if(canMutationObserver){var hiddenDiv=document.createElement("div");var observer=new MutationObserver(function(){var queueList=queue.slice();queue.length=0;queueList.forEach(function(fn){fn()})});observer.observe(hiddenDiv,{attributes:true});return function nextTick(fn){if(!queue.length){hiddenDiv.setAttribute("yes","no")}queue.push(fn)}}if(canPost){window.addEventListener("message",function(ev){var source=ev.source;if((source===window||source===null)&&ev.data==="process-tick"){ev.stopPropagation();if(queue.length>0){var fn=queue.shift();fn()}}},true);return function nextTick(fn){queue.push(fn);window.postMessage("process-tick","*")}}return function nextTick(fn){setTimeout(fn,0)}}();process.title="browser";process.browser=true;process.env={};process.argv=[];function noop(){}process.on=noop;process.addListener=noop;process.once=noop;process.off=noop;process.removeListener=noop;process.removeAllListeners=noop;process.emit=noop;process.binding=function(name){throw new Error("process.binding is not supported")};process.cwd=function(){return"/"};process.chdir=function(dir){throw new Error("process.chdir is not supported")}},{}],4:[function(require,module,exports){(function(process){(function(root,factory){if(typeof define==="function"&&define.amd){define(factory)}else if(typeof exports==="object"){module.exports=factory()}else{root.returnExports=factory()}})(this,function(){"use strict";var isCallableWithoutNew=function(func){try{func()}catch(e){return false}return true};var supportsSubclassing=function(C,f){try{var Sub=function(){C.apply(this,arguments)};if(!Sub.__proto__){return false}Object.setPrototypeOf(Sub,C);Sub.prototype=Object.create(C.prototype,{constructor:{value:C}});return f(Sub)}catch(e){return false}};var arePropertyDescriptorsSupported=function(){try{Object.defineProperty({},"x",{});return true}catch(e){return false}};var startsWithRejectsRegex=function(){var rejectsRegex=false;if(String.prototype.startsWith){try{"/a/".startsWith(/a/)}catch(e){rejectsRegex=true}}return rejectsRegex};var getGlobal=new Function("return this;");var globals=getGlobal();var global_isFinite=globals.isFinite;var supportsDescriptors=!!Object.defineProperty&&arePropertyDescriptorsSupported();var startsWithIsCompliant=startsWithRejectsRegex();var _slice=Array.prototype.slice;var _indexOf=String.prototype.indexOf;var _toString=Object.prototype.toString;var _hasOwnProperty=Object.prototype.hasOwnProperty;var ArrayIterator;var defineProperty=function(object,name,value,force){if(!force&&name in object){return}if(supportsDescriptors){Object.defineProperty(object,name,{configurable:true,enumerable:false,writable:true,value:value})}else{object[name]=value}};var defineProperties=function(object,map){Object.keys(map).forEach(function(name){var method=map[name];defineProperty(object,name,method,false)})};var create=Object.create||function(prototype,properties){function Type(){}Type.prototype=prototype;var object=new Type;if(typeof properties!=="undefined"){defineProperties(object,properties)}return object};var $iterator$=typeof Symbol==="function"&&Symbol.iterator||"_es6shim_iterator_";if(globals.Set&&typeof(new globals.Set)["@@iterator"]==="function"){$iterator$="@@iterator"}var addIterator=function(prototype,impl){if(!impl){impl=function iterator(){return this}}var o={};o[$iterator$]=impl;defineProperties(prototype,o);if(!prototype[$iterator$]&&typeof $iterator$==="symbol"){prototype[$iterator$]=impl}};var isArguments=function isArguments(value){var str=_toString.call(value);var result=str==="[object Arguments]";if(!result){result=str!=="[object Array]"&&value!==null&&typeof value==="object"&&typeof value.length==="number"&&value.length>=0&&_toString.call(value.callee)==="[object Function]"}return result};var emulateES6construct=function(o){if(!ES.TypeIsObject(o)){throw new TypeError("bad object")}if(!o._es6construct){if(o.constructor&&ES.IsCallable(o.constructor["@@create"])){o=o.constructor["@@create"](o)}defineProperties(o,{_es6construct:true})}return o};var ES={CheckObjectCoercible:function(x,optMessage){if(x==null){throw new TypeError(optMessage||"Cannot call method on "+x)}return x},TypeIsObject:function(x){return x!=null&&Object(x)===x},ToObject:function(o,optMessage){return Object(ES.CheckObjectCoercible(o,optMessage))},IsCallable:function(x){return typeof x==="function"&&_toString.call(x)==="[object Function]"},ToInt32:function(x){return x>>0},ToUint32:function(x){return x>>>0},ToInteger:function(value){var number=+value;if(Number.isNaN(number)){return 0}if(number===0||!Number.isFinite(number)){return number}return(number>0?1:-1)*Math.floor(Math.abs(number))},ToLength:function(value){var len=ES.ToInteger(value);if(len<=0){return 0}if(len>Number.MAX_SAFE_INTEGER){return Number.MAX_SAFE_INTEGER}return len},SameValue:function(a,b){if(a===b){if(a===0){return 1/a===1/b}return true}return Number.isNaN(a)&&Number.isNaN(b)},SameValueZero:function(a,b){return a===b||Number.isNaN(a)&&Number.isNaN(b)},IsIterable:function(o){return ES.TypeIsObject(o)&&(typeof o[$iterator$]!=="undefined"||isArguments(o))},GetIterator:function(o){if(isArguments(o)){return new ArrayIterator(o,"value")}var it=o[$iterator$]();if(!ES.TypeIsObject(it)){throw new TypeError("bad iterator")}return it},IteratorNext:function(it){var result=arguments.length>1?it.next(arguments[1]):it.next();if(!ES.TypeIsObject(result)){throw new TypeError("bad iterator")}return result},Construct:function(C,args){var obj;if(ES.IsCallable(C["@@create"])){obj=C["@@create"]()}else{obj=create(C.prototype||null)}defineProperties(obj,{_es6construct:true});var result=C.apply(obj,args);return ES.TypeIsObject(result)?result:obj}};var numberConversion=function(){function roundToEven(n){var w=Math.floor(n),f=n-w;if(f<.5){return w}if(f>.5){return w+1}return w%2?w+1:w}function packIEEE754(v,ebits,fbits){var bias=(1<<ebits-1)-1,s,e,f,ln,i,bits,str,bytes;if(v!==v){e=(1<<ebits)-1;f=Math.pow(2,fbits-1);s=0}else if(v===Infinity||v===-Infinity){e=(1<<ebits)-1;f=0;s=v<0?1:0}else if(v===0){e=0;f=0;s=1/v===-Infinity?1:0}else{s=v<0;v=Math.abs(v);if(v>=Math.pow(2,1-bias)){e=Math.min(Math.floor(Math.log(v)/Math.LN2),1023);f=roundToEven(v/Math.pow(2,e)*Math.pow(2,fbits));if(f/Math.pow(2,fbits)>=2){e=e+1;f=1}if(e>bias){e=(1<<ebits)-1;f=0}else{e=e+bias;f=f-Math.pow(2,fbits)}}else{e=0;f=roundToEven(v/Math.pow(2,1-bias-fbits))}}bits=[];for(i=fbits;i;i-=1){bits.push(f%2?1:0);f=Math.floor(f/2)}for(i=ebits;i;i-=1){bits.push(e%2?1:0);e=Math.floor(e/2)}bits.push(s?1:0);bits.reverse();str=bits.join("");bytes=[];while(str.length){bytes.push(parseInt(str.slice(0,8),2));str=str.slice(8)}return bytes}function unpackIEEE754(bytes,ebits,fbits){var bits=[],i,j,b,str,bias,s,e,f;for(i=bytes.length;i;i-=1){b=bytes[i-1];for(j=8;j;j-=1){bits.push(b%2?1:0);b=b>>1}}bits.reverse();str=bits.join("");bias=(1<<ebits-1)-1;s=parseInt(str.slice(0,1),2)?-1:1;e=parseInt(str.slice(1,1+ebits),2);f=parseInt(str.slice(1+ebits),2);if(e===(1<<ebits)-1){return f!==0?NaN:s*Infinity}else if(e>0){return s*Math.pow(2,e-bias)*(1+f/Math.pow(2,fbits))}else if(f!==0){return s*Math.pow(2,-(bias-1))*(f/Math.pow(2,fbits))}else{return s<0?-0:0}}function unpackFloat64(b){return unpackIEEE754(b,11,52)}function packFloat64(v){return packIEEE754(v,11,52)}function unpackFloat32(b){return unpackIEEE754(b,8,23)}function packFloat32(v){return packIEEE754(v,8,23)}var conversions={toFloat32:function(num){return unpackFloat32(packFloat32(num))}};if(typeof Float32Array!=="undefined"){var float32array=new Float32Array(1);conversions.toFloat32=function(num){float32array[0]=num;return float32array[0]}}return conversions}();defineProperties(String,{fromCodePoint:function(_){var points=_slice.call(arguments,0,arguments.length);var result=[];var next;for(var i=0,length=points.length;i<length;i++){next=Number(points[i]);if(!ES.SameValue(next,ES.ToInteger(next))||next<0||next>1114111){throw new RangeError("Invalid code point "+next)}if(next<65536){result.push(String.fromCharCode(next))}else{next-=65536;result.push(String.fromCharCode((next>>10)+55296));result.push(String.fromCharCode(next%1024+56320))}}return result.join("")},raw:function(callSite){var substitutions=_slice.call(arguments,1,arguments.length);var cooked=ES.ToObject(callSite,"bad callSite");var rawValue=cooked.raw;var raw=ES.ToObject(rawValue,"bad raw value");var len=Object.keys(raw).length;var literalsegments=ES.ToLength(len);if(literalsegments===0){return""}var stringElements=[];var nextIndex=0;var nextKey,next,nextSeg,nextSub;while(nextIndex<literalsegments){nextKey=String(nextIndex);next=raw[nextKey];nextSeg=String(next);stringElements.push(nextSeg);if(nextIndex+1>=literalsegments){break}next=substitutions[nextKey];if(typeof next==="undefined"){break}nextSub=String(next);stringElements.push(nextSub);nextIndex++}return stringElements.join("")}});if(String.fromCodePoint.length!==1){var originalFromCodePoint=String.fromCodePoint;defineProperty(String,"fromCodePoint",function(_){return originalFromCodePoint.apply(this,arguments)},true)}var StringShims={repeat:function(){var repeat=function(s,times){if(times<1){return""}if(times%2){return repeat(s,times-1)+s}var half=repeat(s,times/2);return half+half};return function(times){var thisStr=String(ES.CheckObjectCoercible(this));times=ES.ToInteger(times);if(times<0||times===Infinity){throw new RangeError("Invalid String#repeat value")}return repeat(thisStr,times)}}(),startsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "startsWith" with a regex')}searchStr=String(searchStr);var startArg=arguments.length>1?arguments[1]:void 0;var start=Math.max(ES.ToInteger(startArg),0);return thisStr.slice(start,start+searchStr.length)===searchStr},endsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "endsWith" with a regex')}searchStr=String(searchStr);var thisLen=thisStr.length;var posArg=arguments.length>1?arguments[1]:void 0;var pos=typeof posArg==="undefined"?thisLen:ES.ToInteger(posArg);var end=Math.min(Math.max(pos,0),thisLen);return thisStr.slice(end-searchStr.length,end)===searchStr},contains:function(searchString){var position=arguments.length>1?arguments[1]:void 0;return _indexOf.call(this,searchString,position)!==-1},codePointAt:function(pos){var thisStr=String(ES.CheckObjectCoercible(this));var position=ES.ToInteger(pos);var length=thisStr.length;if(position<0||position>=length){return}var first=thisStr.charCodeAt(position);var isEnd=position+1===length;if(first<55296||first>56319||isEnd){return first}var second=thisStr.charCodeAt(position+1);if(second<56320||second>57343){return first}return(first-55296)*1024+(second-56320)+65536}};defineProperties(String.prototype,StringShims);var hasStringTrimBug="".trim().length!==1;if(hasStringTrimBug){var originalStringTrim=String.prototype.trim;delete String.prototype.trim;var ws=["  \n\f\r   ᠎    ","         　\u2028","\u2029﻿"].join("");var trimRegexp=new RegExp("(^["+ws+"]+)|(["+ws+"]+$)","g");defineProperties(String.prototype,{trim:function(){if(typeof this==="undefined"||this===null){throw new TypeError("can't convert "+this+" to object")}return String(this).replace(trimRegexp,"")}})}var StringIterator=function(s){this._s=String(ES.CheckObjectCoercible(s));this._i=0};StringIterator.prototype.next=function(){var s=this._s,i=this._i;if(typeof s==="undefined"||i>=s.length){this._s=void 0;return{value:void 0,done:true}}var first=s.charCodeAt(i),second,len;if(first<55296||first>56319||i+1==s.length){len=1}else{second=s.charCodeAt(i+1);len=second<56320||second>57343?1:2}this._i=i+len;return{value:s.substr(i,len),done:false}};addIterator(StringIterator.prototype);addIterator(String.prototype,function(){return new StringIterator(this)});if(!startsWithIsCompliant){String.prototype.startsWith=StringShims.startsWith;String.prototype.endsWith=StringShims.endsWith}var ArrayShims={from:function(iterable){var mapFn=arguments.length>1?arguments[1]:void 0;var list=ES.ToObject(iterable,"bad iterable");if(typeof mapFn!=="undefined"&&!ES.IsCallable(mapFn)){throw new TypeError("Array.from: when provided, the second argument must be a function")}var hasThisArg=arguments.length>2;var thisArg=hasThisArg?arguments[2]:void 0;var usingIterator=ES.IsIterable(list);var length;var result,i,value;if(usingIterator){i=0;result=ES.IsCallable(this)?Object(new this):[];var it=usingIterator?ES.GetIterator(list):null;var iterationValue;do{iterationValue=ES.IteratorNext(it);if(!iterationValue.done){value=iterationValue.value;if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}i+=1}}while(!iterationValue.done);length=i}else{length=ES.ToLength(list.length);result=ES.IsCallable(this)?Object(new this(length)):new Array(length);for(i=0;i<length;++i){value=list[i];if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}}}result.length=length;return result},of:function(){return Array.from(arguments)}};defineProperties(Array,ArrayShims);var arrayFromSwallowsNegativeLengths=function(){try{return Array.from({length:-1}).length===0}catch(e){return false}};if(!arrayFromSwallowsNegativeLengths()){defineProperty(Array,"from",ArrayShims.from,true)}ArrayIterator=function(array,kind){this.i=0;this.array=array;this.kind=kind};defineProperties(ArrayIterator.prototype,{next:function(){var i=this.i,array=this.array;if(!(this instanceof ArrayIterator)){throw new TypeError("Not an ArrayIterator")}if(typeof array!=="undefined"){var len=ES.ToLength(array.length);for(;i<len;i++){var kind=this.kind;var retval;if(kind==="key"){retval=i}else if(kind==="value"){retval=array[i]}else if(kind==="entry"){retval=[i,array[i]]}this.i=i+1;return{value:retval,done:false}}}this.array=void 0;return{value:void 0,done:true}}});addIterator(ArrayIterator.prototype);var ArrayPrototypeShims={copyWithin:function(target,start){var end=arguments[2];var o=ES.ToObject(this);var len=ES.ToLength(o.length);target=ES.ToInteger(target);start=ES.ToInteger(start);var to=target<0?Math.max(len+target,0):Math.min(target,len);var from=start<0?Math.max(len+start,0):Math.min(start,len);end=typeof end==="undefined"?len:ES.ToInteger(end);var fin=end<0?Math.max(len+end,0):Math.min(end,len);var count=Math.min(fin-from,len-to);var direction=1;if(from<to&&to<from+count){direction=-1;from+=count-1;to+=count-1}while(count>0){if(_hasOwnProperty.call(o,from)){o[to]=o[from]}else{delete o[from]}from+=direction;to+=direction;count-=1}return o},fill:function(value){var start=arguments.length>1?arguments[1]:void 0;var end=arguments.length>2?arguments[2]:void 0;var O=ES.ToObject(this);var len=ES.ToLength(O.length);start=ES.ToInteger(typeof start==="undefined"?0:start);end=ES.ToInteger(typeof end==="undefined"?len:end);var relativeStart=start<0?Math.max(len+start,0):Math.min(start,len);var relativeEnd=end<0?len+end:end;for(var i=relativeStart;i<len&&i<relativeEnd;++i){O[i]=value}return O},find:function find(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#find: predicate must be a function")}var thisArg=arguments[1];for(var i=0,value;i<length;i++){value=list[i];if(predicate.call(thisArg,value,i,list)){return value}}return},findIndex:function findIndex(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#findIndex: predicate must be a function")}var thisArg=arguments[1];for(var i=0;i<length;i++){if(predicate.call(thisArg,list[i],i,list)){return i}}return-1},keys:function(){return new ArrayIterator(this,"key")},values:function(){return new ArrayIterator(this,"value")},entries:function(){return new ArrayIterator(this,"entry")}};if(Array.prototype.keys&&!ES.IsCallable([1].keys().next)){delete Array.prototype.keys}if(Array.prototype.entries&&!ES.IsCallable([1].entries().next)){delete Array.prototype.entries}defineProperties(Array.prototype,ArrayPrototypeShims);addIterator(Array.prototype,function(){return this.values()});if(Object.getPrototypeOf){addIterator(Object.getPrototypeOf([].values()))}var maxSafeInteger=Math.pow(2,53)-1;defineProperties(Number,{MAX_SAFE_INTEGER:maxSafeInteger,MIN_SAFE_INTEGER:-maxSafeInteger,EPSILON:2.220446049250313e-16,parseInt:globals.parseInt,parseFloat:globals.parseFloat,isFinite:function(value){return typeof value==="number"&&global_isFinite(value)},isInteger:function(value){return Number.isFinite(value)&&ES.ToInteger(value)===value},isSafeInteger:function(value){return Number.isInteger(value)&&Math.abs(value)<=Number.MAX_SAFE_INTEGER},isNaN:function(value){return value!==value}});if(![,1].find(function(item,idx){return idx===0})){defineProperty(Array.prototype,"find",ArrayPrototypeShims.find,true)}if([,1].findIndex(function(item,idx){return idx===0})!==0){defineProperty(Array.prototype,"findIndex",ArrayPrototypeShims.findIndex,true)}if(supportsDescriptors){defineProperties(Object,{getPropertyDescriptor:function(subject,name){var pd=Object.getOwnPropertyDescriptor(subject,name);var proto=Object.getPrototypeOf(subject);while(typeof pd==="undefined"&&proto!==null){pd=Object.getOwnPropertyDescriptor(proto,name);proto=Object.getPrototypeOf(proto)}return pd},getPropertyNames:function(subject){var result=Object.getOwnPropertyNames(subject);var proto=Object.getPrototypeOf(subject);var addProperty=function(property){if(result.indexOf(property)===-1){result.push(property)}};while(proto!==null){Object.getOwnPropertyNames(proto).forEach(addProperty);proto=Object.getPrototypeOf(proto)}return result}});defineProperties(Object,{assign:function(target,source){if(!ES.TypeIsObject(target)){throw new TypeError("target must be an object")}return Array.prototype.reduce.call(arguments,function(target,source){return Object.keys(Object(source)).reduce(function(target,key){target[key]=source[key];return target},target)})},is:function(a,b){return ES.SameValue(a,b)},setPrototypeOf:function(Object,magic){var set;var checkArgs=function(O,proto){if(!ES.TypeIsObject(O)){throw new TypeError("cannot set prototype on a non-object")}if(!(proto===null||ES.TypeIsObject(proto))){throw new TypeError("can only set prototype to an object or null"+proto)}};var setPrototypeOf=function(O,proto){checkArgs(O,proto);set.call(O,proto);return O};try{set=Object.getOwnPropertyDescriptor(Object.prototype,magic).set;set.call({},null)}catch(e){if(Object.prototype!=={}[magic]){return}set=function(proto){this[magic]=proto};setPrototypeOf.polyfill=setPrototypeOf(setPrototypeOf({},null),Object.prototype)instanceof Object}return setPrototypeOf}(Object,"__proto__")})}if(Object.setPrototypeOf&&Object.getPrototypeOf&&Object.getPrototypeOf(Object.setPrototypeOf({},null))!==null&&Object.getPrototypeOf(Object.create(null))===null){(function(){var FAKENULL=Object.create(null);var gpo=Object.getPrototypeOf,spo=Object.setPrototypeOf;Object.getPrototypeOf=function(o){var result=gpo(o);return result===FAKENULL?null:result};Object.setPrototypeOf=function(o,p){if(p===null){p=FAKENULL}return spo(o,p)};Object.setPrototypeOf.polyfill=false})()}try{Object.keys("foo")}catch(e){var originalObjectKeys=Object.keys;Object.keys=function(obj){return originalObjectKeys(ES.ToObject(obj))}}var MathShims={acosh:function(value){value=Number(value);if(Number.isNaN(value)||value<1){return NaN}if(value===1){return 0}if(value===Infinity){return value}return Math.log(value+Math.sqrt(value*value-1))},asinh:function(value){value=Number(value);if(value===0||!global_isFinite(value)){return value}return value<0?-Math.asinh(-value):Math.log(value+Math.sqrt(value*value+1))},atanh:function(value){value=Number(value);if(Number.isNaN(value)||value<-1||value>1){return NaN}if(value===-1){return-Infinity}if(value===1){return Infinity}if(value===0){return value}return.5*Math.log((1+value)/(1-value))},cbrt:function(value){value=Number(value);if(value===0){return value}var negate=value<0,result;if(negate){value=-value}result=Math.pow(value,1/3);return negate?-result:result},clz32:function(value){value=Number(value);var number=ES.ToUint32(value);if(number===0){return 32}return 32-number.toString(2).length},cosh:function(value){value=Number(value);if(value===0){return 1}if(Number.isNaN(value)){return NaN}if(!global_isFinite(value)){return Infinity}if(value<0){value=-value}if(value>21){return Math.exp(value)/2}return(Math.exp(value)+Math.exp(-value))/2},expm1:function(value){value=Number(value);if(value===-Infinity){return-1}if(!global_isFinite(value)||value===0){return value}return Math.exp(value)-1},hypot:function(x,y){var anyNaN=false;var allZero=true;var anyInfinity=false;var numbers=[];Array.prototype.every.call(arguments,function(arg){var num=Number(arg);if(Number.isNaN(num)){anyNaN=true}else if(num===Infinity||num===-Infinity){anyInfinity=true}else if(num!==0){allZero=false}if(anyInfinity){return false}else if(!anyNaN){numbers.push(Math.abs(num))}return true});if(anyInfinity){return Infinity}if(anyNaN){return NaN}if(allZero){return 0}numbers.sort(function(a,b){return b-a});var largest=numbers[0];var divided=numbers.map(function(number){return number/largest});var sum=divided.reduce(function(sum,number){return sum+=number*number},0);return largest*Math.sqrt(sum)},log2:function(value){return Math.log(value)*Math.LOG2E},log10:function(value){return Math.log(value)*Math.LOG10E},log1p:function(value){value=Number(value);if(value<-1||Number.isNaN(value)){return NaN}if(value===0||value===Infinity){return value}if(value===-1){return-Infinity}var result=0;var n=50;if(value<0||value>1){return Math.log(1+value)}for(var i=1;i<n;i++){if(i%2===0){result-=Math.pow(value,i)/i}else{result+=Math.pow(value,i)/i}}return result},sign:function(value){var number=+value;if(number===0){return number}if(Number.isNaN(number)){return number}return number<0?-1:1},sinh:function(value){value=Number(value);if(!global_isFinite(value)||value===0){return value}return(Math.exp(value)-Math.exp(-value))/2},tanh:function(value){value=Number(value);if(Number.isNaN(value)||value===0){return value}if(value===Infinity){return 1}if(value===-Infinity){return-1}return(Math.exp(value)-Math.exp(-value))/(Math.exp(value)+Math.exp(-value))},trunc:function(value){var number=Number(value);return number<0?-Math.floor(-number):Math.floor(number)},imul:function(x,y){x=ES.ToUint32(x);y=ES.ToUint32(y);var ah=x>>>16&65535;var al=x&65535;var bh=y>>>16&65535;var bl=y&65535;return al*bl+(ah*bl+al*bh<<16>>>0)|0},fround:function(x){if(x===0||x===Infinity||x===-Infinity||Number.isNaN(x)){return x}var num=Number(x);return numberConversion.toFloat32(num)}};defineProperties(Math,MathShims);if(Math.imul(4294967295,5)!==-5){Math.imul=MathShims.imul}var PromiseShim=function(){var Promise,Promise$prototype;ES.IsPromise=function(promise){if(!ES.TypeIsObject(promise)){return false}if(!promise._promiseConstructor){return false}if(typeof promise._status==="undefined"){return false}return true};var PromiseCapability=function(C){if(!ES.IsCallable(C)){throw new TypeError("bad promise constructor")}var capability=this;var resolver=function(resolve,reject){capability.resolve=resolve;capability.reject=reject};capability.promise=ES.Construct(C,[resolver]);if(!capability.promise._es6construct){throw new TypeError("bad promise constructor")}if(!(ES.IsCallable(capability.resolve)&&ES.IsCallable(capability.reject))){throw new TypeError("bad promise constructor")}};var setTimeout=globals.setTimeout;var makeZeroTimeout;if(typeof window!=="undefined"&&ES.IsCallable(window.postMessage)){makeZeroTimeout=function(){var timeouts=[];var messageName="zero-timeout-message";var setZeroTimeout=function(fn){timeouts.push(fn);window.postMessage(messageName,"*")};var handleMessage=function(event){if(event.source==window&&event.data==messageName){event.stopPropagation();
-if(timeouts.length===0){return}var fn=timeouts.shift();fn()}};window.addEventListener("message",handleMessage,true);return setZeroTimeout}}var makePromiseAsap=function(){var P=globals.Promise;return P&&P.resolve&&function(task){return P.resolve().then(task)}};var enqueue=ES.IsCallable(globals.setImmediate)?globals.setImmediate.bind(globals):typeof process==="object"&&process.nextTick?process.nextTick:makePromiseAsap()||(ES.IsCallable(makeZeroTimeout)?makeZeroTimeout():function(task){setTimeout(task,0)});var triggerPromiseReactions=function(reactions,x){reactions.forEach(function(reaction){enqueue(function(){var handler=reaction.handler;var capability=reaction.capability;var resolve=capability.resolve;var reject=capability.reject;try{var result=handler(x);if(result===capability.promise){throw new TypeError("self resolution")}var updateResult=updatePromiseFromPotentialThenable(result,capability);if(!updateResult){resolve(result)}}catch(e){reject(e)}})})};var updatePromiseFromPotentialThenable=function(x,capability){if(!ES.TypeIsObject(x)){return false}var resolve=capability.resolve;var reject=capability.reject;try{var then=x.then;if(!ES.IsCallable(then)){return false}then.call(x,resolve,reject)}catch(e){reject(e)}return true};var promiseResolutionHandler=function(promise,onFulfilled,onRejected){return function(x){if(x===promise){return onRejected(new TypeError("self resolution"))}var C=promise._promiseConstructor;var capability=new PromiseCapability(C);var updateResult=updatePromiseFromPotentialThenable(x,capability);if(updateResult){return capability.promise.then(onFulfilled,onRejected)}else{return onFulfilled(x)}}};Promise=function(resolver){var promise=this;promise=emulateES6construct(promise);if(!promise._promiseConstructor){throw new TypeError("bad promise")}if(typeof promise._status!=="undefined"){throw new TypeError("promise already initialized")}if(!ES.IsCallable(resolver)){throw new TypeError("not a valid resolver")}promise._status="unresolved";promise._resolveReactions=[];promise._rejectReactions=[];var resolve=function(resolution){if(promise._status!=="unresolved"){return}var reactions=promise._resolveReactions;promise._result=resolution;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-resolution";triggerPromiseReactions(reactions,resolution)};var reject=function(reason){if(promise._status!=="unresolved"){return}var reactions=promise._rejectReactions;promise._result=reason;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-rejection";triggerPromiseReactions(reactions,reason)};try{resolver(resolve,reject)}catch(e){reject(e)}return promise};Promise$prototype=Promise.prototype;defineProperties(Promise,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Promise$prototype;obj=obj||create(prototype);defineProperties(obj,{_status:void 0,_result:void 0,_resolveReactions:void 0,_rejectReactions:void 0,_promiseConstructor:void 0});obj._promiseConstructor=constructor;return obj}});var _promiseAllResolver=function(index,values,capability,remaining){var done=false;return function(x){if(done){return}done=true;values[index]=x;if(--remaining.count===0){var resolve=capability.resolve;resolve(values)}}};Promise.all=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);var values=[],remaining={count:1};for(var index=0;;index++){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);var resolveElement=_promiseAllResolver(index,values,capability,remaining);remaining.count++;nextPromise.then(resolveElement,capability.reject)}if(--remaining.count===0){resolve(values)}}catch(e){reject(e)}return capability.promise};Promise.race=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);nextPromise.then(resolve,reject)}}catch(e){reject(e)}return capability.promise};Promise.reject=function(reason){var C=this;var capability=new PromiseCapability(C);var reject=capability.reject;reject(reason);return capability.promise};Promise.resolve=function(v){var C=this;if(ES.IsPromise(v)){var constructor=v._promiseConstructor;if(constructor===C){return v}}var capability=new PromiseCapability(C);var resolve=capability.resolve;resolve(v);return capability.promise};Promise.prototype["catch"]=function(onRejected){return this.then(void 0,onRejected)};Promise.prototype.then=function(onFulfilled,onRejected){var promise=this;if(!ES.IsPromise(promise)){throw new TypeError("not a promise")}var C=this.constructor;var capability=new PromiseCapability(C);if(!ES.IsCallable(onRejected)){onRejected=function(e){throw e}}if(!ES.IsCallable(onFulfilled)){onFulfilled=function(x){return x}}var resolutionHandler=promiseResolutionHandler(promise,onFulfilled,onRejected);var resolveReaction={capability:capability,handler:resolutionHandler};var rejectReaction={capability:capability,handler:onRejected};switch(promise._status){case"unresolved":promise._resolveReactions.push(resolveReaction);promise._rejectReactions.push(rejectReaction);break;case"has-resolution":triggerPromiseReactions([resolveReaction],promise._result);break;case"has-rejection":triggerPromiseReactions([rejectReaction],promise._result);break;default:throw new TypeError("unexpected")}return capability.promise};return Promise}();defineProperties(globals,{Promise:PromiseShim});var promiseSupportsSubclassing=supportsSubclassing(globals.Promise,function(S){return S.resolve(42)instanceof S});var promiseIgnoresNonFunctionThenCallbacks=function(){try{globals.Promise.reject(42).then(null,5).then(null,function(){});return true}catch(ex){return false}}();var promiseRequiresObjectContext=function(){try{Promise.call(3,function(){})}catch(e){return true}return false}();if(!promiseSupportsSubclassing||!promiseIgnoresNonFunctionThenCallbacks||!promiseRequiresObjectContext){globals.Promise=PromiseShim}var testOrder=function(a){var b=Object.keys(a.reduce(function(o,k){o[k]=true;return o},{}));return a.join(":")===b.join(":")};var preservesInsertionOrder=testOrder(["z","a","bb"]);var preservesNumericInsertionOrder=testOrder(["z",1,"a","3",2]);if(supportsDescriptors){var fastkey=function fastkey(key){if(!preservesInsertionOrder){return null}var type=typeof key;if(type==="string"){return"$"+key}else if(type==="number"){if(!preservesNumericInsertionOrder){return"n"+key}return key}return null};var emptyObject=function emptyObject(){return Object.create?Object.create(null):{}};var collectionShims={Map:function(){var empty={};function MapEntry(key,value){this.key=key;this.value=value;this.next=null;this.prev=null}MapEntry.prototype.isRemoved=function(){return this.key===empty};function MapIterator(map,kind){this.head=map._head;this.i=this.head;this.kind=kind}MapIterator.prototype={next:function(){var i=this.i,kind=this.kind,head=this.head,result;if(typeof this.i==="undefined"){return{value:void 0,done:true}}while(i.isRemoved()&&i!==head){i=i.prev}while(i.next!==head){i=i.next;if(!i.isRemoved()){if(kind==="key"){result=i.key}else if(kind==="value"){result=i.value}else{result=[i.key,i.value]}this.i=i;return{value:result,done:false}}}this.i=void 0;return{value:void 0,done:true}}};addIterator(MapIterator.prototype);function Map(iterable){var map=this;map=emulateES6construct(map);if(!map._es6map){throw new TypeError("bad map")}var head=new MapEntry(null,null);head.next=head.prev=head;defineProperties(map,{_head:head,_storage:emptyObject(),_size:0});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=map.set;if(!ES.IsCallable(adder)){throw new TypeError("bad map")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;if(!ES.TypeIsObject(nextItem)){throw new TypeError("expected iterable of pairs")}adder.call(map,nextItem[0],nextItem[1])}}return map}var Map$prototype=Map.prototype;defineProperties(Map,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Map$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6map:true});return obj}});Object.defineProperty(Map.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._size==="undefined"){throw new TypeError("size method called on incompatible Map")}return this._size}});defineProperties(Map.prototype,{get:function(key){var fkey=fastkey(key);if(fkey!==null){var entry=this._storage[fkey];if(entry){return entry.value}else{return}}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return i.value}}return},has:function(key){var fkey=fastkey(key);if(fkey!==null){return typeof this._storage[fkey]!=="undefined"}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return true}}return false},set:function(key,value){var head=this._head,i=head,entry;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]!=="undefined"){this._storage[fkey].value=value;return}else{entry=this._storage[fkey]=new MapEntry(key,value);i=head.prev}}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.value=value;return}}entry=entry||new MapEntry(key,value);if(ES.SameValue(-0,key)){entry.key=+0}entry.next=this._head;entry.prev=this._head.prev;entry.prev.next=entry;entry.next.prev=entry;this._size+=1;return this},"delete":function(key){var head=this._head,i=head;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]==="undefined"){return false}i=this._storage[fkey].prev;delete this._storage[fkey]}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.key=i.value=empty;i.prev.next=i.next;i.next.prev=i.prev;this._size-=1;return true}}return false},clear:function(){this._size=0;this._storage=emptyObject();var head=this._head,i=head,p=i.next;while((i=p)!==head){i.key=i.value=empty;p=i.next;i.next=i.prev=head}head.next=head.prev=head},keys:function(){return new MapIterator(this,"key")},values:function(){return new MapIterator(this,"value")},entries:function(){return new MapIterator(this,"key+value")},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var it=this.entries();for(var entry=it.next();!entry.done;entry=it.next()){callback.call(context,entry.value[1],entry.value[0],this)}}});addIterator(Map.prototype,function(){return this.entries()});return Map}(),Set:function(){var SetShim=function Set(iterable){var set=this;set=emulateES6construct(set);if(!set._es6set){throw new TypeError("bad set")}defineProperties(set,{"[[SetData]]":null,_storage:emptyObject()});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=set.add;if(!ES.IsCallable(adder)){throw new TypeError("bad set")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;adder.call(set,nextItem)}}return set};var Set$prototype=SetShim.prototype;defineProperties(SetShim,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Set$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6set:true});return obj}});var ensureMap=function ensureMap(set){if(!set["[[SetData]]"]){var m=set["[[SetData]]"]=new collectionShims.Map;Object.keys(set._storage).forEach(function(k){if(k.charCodeAt(0)===36){k=k.slice(1)}else if(k.charAt(0)==="n"){k=+k.slice(1)}else{k=+k}m.set(k,k)});set._storage=null}};Object.defineProperty(SetShim.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._storage==="undefined"){throw new TypeError("size method called on incompatible Set")}ensureMap(this);return this["[[SetData]]"].size}});defineProperties(SetShim.prototype,{has:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){return!!this._storage[fkey]}ensureMap(this);return this["[[SetData]]"].has(key)},add:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){this._storage[fkey]=true;return}ensureMap(this);this["[[SetData]]"].set(key,key);return this},"delete":function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){var hasFKey=_hasOwnProperty.call(this._storage,fkey);return delete this._storage[fkey]&&hasFKey}ensureMap(this);return this["[[SetData]]"]["delete"](key)},clear:function(){if(this._storage){this._storage=emptyObject();return}return this["[[SetData]]"].clear()},keys:function(){ensureMap(this);return this["[[SetData]]"].keys()},values:function(){ensureMap(this);return this["[[SetData]]"].values()},entries:function(){ensureMap(this);return this["[[SetData]]"].entries()},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var entireSet=this;ensureMap(this);this["[[SetData]]"].forEach(function(value,key){callback.call(context,key,key,entireSet)})}});addIterator(SetShim.prototype,function(){return this.values()});return SetShim}()};defineProperties(globals,collectionShims);if(globals.Map||globals.Set){if(typeof globals.Map.prototype.clear!=="function"||(new globals.Set).size!==0||(new globals.Map).size!==0||typeof globals.Map.prototype.keys!=="function"||typeof globals.Set.prototype.keys!=="function"||typeof globals.Map.prototype.forEach!=="function"||typeof globals.Set.prototype.forEach!=="function"||isCallableWithoutNew(globals.Map)||isCallableWithoutNew(globals.Set)||!supportsSubclassing(globals.Map,function(M){var m=new M([]);m.set(42,42);return m instanceof M})){globals.Map=collectionShims.Map;globals.Set=collectionShims.Set}}addIterator(Object.getPrototypeOf((new globals.Map).keys()));addIterator(Object.getPrototypeOf((new globals.Set).keys()))}return globals})}).call(this,require("_process"))},{_process:3}],5:[function(require,module,exports){"use strict";if(!require("./is-implemented")()){Object.defineProperty(require("es5-ext/global"),"Symbol",{value:require("./polyfill"),configurable:true,enumerable:false,writable:true})}},{"./is-implemented":6,"./polyfill":21,"es5-ext/global":8}],6:[function(require,module,exports){"use strict";module.exports=function(){var symbol;if(typeof Symbol!=="function")return false;symbol=Symbol("test symbol");try{String(symbol)}catch(e){return false}if(typeof Symbol.iterator==="symbol")return true;if(typeof Symbol.isConcatSpreadable!=="object")return false;if(typeof Symbol.isRegExp!=="object")return false;if(typeof Symbol.iterator!=="object")return false;if(typeof Symbol.toPrimitive!=="object")return false;if(typeof Symbol.toStringTag!=="object")return false;if(typeof Symbol.unscopables!=="object")return false;return true}},{}],7:[function(require,module,exports){"use strict";var assign=require("es5-ext/object/assign"),normalizeOpts=require("es5-ext/object/normalize-options"),isCallable=require("es5-ext/object/is-callable"),contains=require("es5-ext/string/#/contains"),d;d=module.exports=function(dscr,value){var c,e,w,options,desc;if(arguments.length<2||typeof dscr!=="string"){options=value;value=dscr;dscr=null}else{options=arguments[2]}if(dscr==null){c=w=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e");w=contains.call(dscr,"w")}desc={value:value,configurable:c,enumerable:e,writable:w};return!options?desc:assign(normalizeOpts(options),desc)};d.gs=function(dscr,get,set){var c,e,options,desc;if(typeof dscr!=="string"){options=set;set=get;get=dscr;dscr=null}else{options=arguments[3]}if(get==null){get=undefined}else if(!isCallable(get)){options=get;get=set=undefined}else if(set==null){set=undefined}else if(!isCallable(set)){options=set;set=undefined}if(dscr==null){c=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e")}desc={get:get,set:set,configurable:c,enumerable:e};return!options?desc:assign(normalizeOpts(options),desc)}},{"es5-ext/object/assign":9,"es5-ext/object/is-callable":12,"es5-ext/object/normalize-options":16,"es5-ext/string/#/contains":18}],8:[function(require,module,exports){"use strict";module.exports=new Function("return this")()},{}],9:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.assign:require("./shim")},{"./is-implemented":10,"./shim":11}],10:[function(require,module,exports){"use strict";module.exports=function(){var assign=Object.assign,obj;if(typeof assign!=="function")return false;obj={foo:"raz"};assign(obj,{bar:"dwa"},{trzy:"trzy"});return obj.foo+obj.bar+obj.trzy==="razdwatrzy"}},{}],11:[function(require,module,exports){"use strict";var keys=require("../keys"),value=require("../valid-value"),max=Math.max;module.exports=function(dest,src){var error,i,l=max(arguments.length,2),assign;dest=Object(value(dest));assign=function(key){try{dest[key]=src[key]}catch(e){if(!error)error=e}};for(i=1;i<l;++i){src=arguments[i];keys(src).forEach(assign)}if(error!==undefined)throw error;return dest}},{"../keys":13,"../valid-value":17}],12:[function(require,module,exports){"use strict";module.exports=function(obj){return typeof obj==="function"}},{}],13:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.keys:require("./shim")},{"./is-implemented":14,"./shim":15}],14:[function(require,module,exports){"use strict";module.exports=function(){try{Object.keys("primitive");return true}catch(e){return false}}},{}],15:[function(require,module,exports){"use strict";var keys=Object.keys;module.exports=function(object){return keys(object==null?object:Object(object))}},{}],16:[function(require,module,exports){"use strict";var assign=require("./assign"),forEach=Array.prototype.forEach,create=Object.create,getPrototypeOf=Object.getPrototypeOf,process;process=function(src,obj){var proto=getPrototypeOf(src);return assign(proto?process(proto,obj):obj,src)};module.exports=function(options){var result=create(null);forEach.call(arguments,function(options){if(options==null)return;process(Object(options),result)});return result}},{"./assign":9}],17:[function(require,module,exports){"use strict";module.exports=function(value){if(value==null)throw new TypeError("Cannot use null or undefined");return value}},{}],18:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?String.prototype.contains:require("./shim")},{"./is-implemented":19,"./shim":20}],19:[function(require,module,exports){"use strict";var str="razdwatrzy";module.exports=function(){if(typeof str.contains!=="function")return false;return str.contains("dwa")===true&&str.contains("foo")===false}},{}],20:[function(require,module,exports){"use strict";var indexOf=String.prototype.indexOf;module.exports=function(searchString){return indexOf.call(this,searchString,arguments[1])>-1}},{}],21:[function(require,module,exports){"use strict";var d=require("d"),create=Object.create,defineProperties=Object.defineProperties,generateName,Symbol;generateName=function(){var created=create(null);return function(desc){var postfix=0;while(created[desc+(postfix||"")])++postfix;desc+=postfix||"";created[desc]=true;return"@@"+desc}}();module.exports=Symbol=function(description){var symbol;if(this instanceof Symbol){throw new TypeError("TypeError: Symbol is not a constructor")}symbol=create(Symbol.prototype);description=description===undefined?"":String(description);return defineProperties(symbol,{__description__:d("",description),__name__:d("",generateName(description))})};Object.defineProperties(Symbol,{create:d("",Symbol("create")),hasInstance:d("",Symbol("hasInstance")),isConcatSpreadable:d("",Symbol("isConcatSpreadable")),isRegExp:d("",Symbol("isRegExp")),iterator:d("",Symbol("iterator")),toPrimitive:d("",Symbol("toPrimitive")),toStringTag:d("",Symbol("toStringTag")),unscopables:d("",Symbol("unscopables"))});defineProperties(Symbol.prototype,{properToString:d(function(){return"Symbol ("+this.__description__+")"}),toString:d("",function(){return this.__name__})});Object.defineProperty(Symbol.prototype,Symbol.toPrimitive,d("",function(hint){throw new TypeError("Conversion of symbol objects is not allowed")}));Object.defineProperty(Symbol.prototype,Symbol.toStringTag,d("c","Symbol"))},{d:7}]},{},[1]);</script>
+    <script>(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){(function(global){var ensureSymbol=function(key){Symbol[key]=Symbol[key]||Symbol()};var ensureProto=function(Constructor,key,val){var proto=Constructor.prototype;proto[key]=proto[key]||val};if(typeof Symbol==="undefined"){require("es6-symbol/implement")}require("es6-shim");require("./transformation/transformers/es6-generators/runtime");ensureSymbol("referenceGet");ensureSymbol("referenceSet");ensureSymbol("referenceDelete");ensureProto(Function,Symbol.referenceGet,function(){return this});ensureProto(Map,Symbol.referenceGet,Map.prototype.get);ensureProto(Map,Symbol.referenceSet,Map.prototype.set);ensureProto(Map,Symbol.referenceDelete,Map.prototype.delete);if(global.WeakMap){ensureProto(WeakMap,Symbol.referenceGet,WeakMap.prototype.get);ensureProto(WeakMap,Symbol.referenceSet,WeakMap.prototype.set);ensureProto(WeakMap,Symbol.referenceDelete,WeakMap.prototype.delete)}}).call(this,typeof global!=="undefined"?global:typeof self!=="undefined"?self:typeof window!=="undefined"?window:{})},{"./transformation/transformers/es6-generators/runtime":2,"es6-shim":4,"es6-symbol/implement":5}],2:[function(require,module,exports){(function(global){var iteratorSymbol=typeof Symbol==="function"&&Symbol.iterator||"@@iterator";var runtime=global.regeneratorRuntime=exports;var hasOwn=Object.prototype.hasOwnProperty;var wrap=runtime.wrap=function wrap(innerFn,outerFn,self,tryList){return new Generator(innerFn,outerFn,self||null,tryList||[])};var GenStateSuspendedStart="suspendedStart";var GenStateSuspendedYield="suspendedYield";var GenStateExecuting="executing";var GenStateCompleted="completed";var ContinueSentinel={};var GF=function GeneratorFunction(){};var GFp=function GeneratorFunctionPrototype(){};var Gp=GFp.prototype=Generator.prototype;(GFp.constructor=GF).prototype=Gp.constructor=GFp;var GFName="GeneratorFunction";if(GF.name!==GFName)GF.name=GFName;if(GF.name!==GFName)throw new Error(GFName+" renamed?");runtime.isGeneratorFunction=function(genFun){var ctor=genFun&&genFun.constructor;return ctor?GF.name===ctor.name:false};runtime.mark=function(genFun){genFun.__proto__=GFp;genFun.prototype=Object.create(Gp);return genFun};runtime.async=function(innerFn,outerFn,self,tryList){return new Promise(function(resolve,reject){var generator=wrap(innerFn,outerFn,self,tryList);var callNext=step.bind(generator.next);var callThrow=step.bind(generator["throw"]);function step(arg){var info;var value;try{info=this(arg);value=info.value}catch(error){return reject(error)}if(info.done){resolve(value)}else{Promise.resolve(value).then(callNext,callThrow)}}callNext()})};function Generator(innerFn,outerFn,self,tryList){var generator=outerFn?Object.create(outerFn.prototype):this;var context=new Context(tryList);var state=GenStateSuspendedStart;function invoke(method,arg){if(state===GenStateExecuting){throw new Error("Generator is already running")}if(state===GenStateCompleted){throw new Error("Generator has already finished")}while(true){var delegate=context.delegate;var info;if(delegate){try{info=delegate.iterator[method](arg);method="next";arg=undefined}catch(uncaught){context.delegate=null;method="throw";arg=uncaught;continue}if(info.done){context[delegate.resultName]=info.value;context.next=delegate.nextLoc}else{state=GenStateSuspendedYield;return info}context.delegate=null}if(method==="next"){if(state===GenStateSuspendedStart&&typeof arg!=="undefined"){throw new TypeError("attempt to send "+JSON.stringify(arg)+" to newborn generator")}if(state===GenStateSuspendedYield){context.sent=arg}else{delete context.sent}}else if(method==="throw"){if(state===GenStateSuspendedStart){state=GenStateCompleted;throw arg}if(context.dispatchException(arg)){method="next";arg=undefined}}else if(method==="return"){context.abrupt("return",arg)}state=GenStateExecuting;try{var value=innerFn.call(self,context);state=context.done?GenStateCompleted:GenStateSuspendedYield;info={value:value,done:context.done};if(value===ContinueSentinel){if(context.delegate&&method==="next"){arg=undefined}}else{return info}}catch(thrown){state=GenStateCompleted;if(method==="next"){context.dispatchException(thrown)}else{arg=thrown}}}}generator.next=invoke.bind(generator,"next");generator["throw"]=invoke.bind(generator,"throw");generator["return"]=invoke.bind(generator,"return");return generator}Gp[iteratorSymbol]=function(){return this};Gp.toString=function(){return"[object Generator]"};function pushTryEntry(triple){var entry={tryLoc:triple[0]};if(1 in triple){entry.catchLoc=triple[1]}if(2 in triple){entry.finallyLoc=triple[2]}this.tryEntries.push(entry)}function resetTryEntry(entry,i){var record=entry.completion||{};record.type=i===0?"normal":"return";delete record.arg;entry.completion=record}function Context(tryList){this.tryEntries=[{tryLoc:"root"}];tryList.forEach(pushTryEntry,this);this.reset()}runtime.keys=function(object){var keys=[];for(var key in object){keys.push(key)}keys.reverse();return function next(){while(keys.length){var key=keys.pop();if(key in object){next.value=key;next.done=false;return next}}next.done=true;return next}};function values(iterable){var iterator=iterable;if(iteratorSymbol in iterable){iterator=iterable[iteratorSymbol]()}else if(!isNaN(iterable.length)){var i=-1;iterator=function next(){while(++i<iterable.length){if(i in iterable){next.value=iterable[i];next.done=false;return next}}next.done=true;return next};iterator.next=iterator}return iterator}runtime.values=values;Context.prototype={constructor:Context,reset:function(){this.prev=0;this.next=0;this.sent=undefined;this.done=false;this.delegate=null;this.tryEntries.forEach(resetTryEntry);for(var tempIndex=0,tempName;hasOwn.call(this,tempName="t"+tempIndex)||tempIndex<20;++tempIndex){this[tempName]=null}},stop:function(){this.done=true;var rootEntry=this.tryEntries[0];var rootRecord=rootEntry.completion;if(rootRecord.type==="throw"){throw rootRecord.arg}return this.rval},dispatchException:function(exception){if(this.done){throw exception}var context=this;function handle(loc,caught){record.type="throw";record.arg=exception;context.next=loc;return!!caught}for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];var record=entry.completion;if(entry.tryLoc==="root"){return handle("end")}if(entry.tryLoc<=this.prev){var hasCatch=hasOwn.call(entry,"catchLoc");var hasFinally=hasOwn.call(entry,"finallyLoc");if(hasCatch&&hasFinally){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}else if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else if(hasCatch){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}}else if(hasFinally){if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else{throw new Error("try statement without catch or finally")}}}},_findFinallyEntry:function(finallyLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc<=this.prev&&hasOwn.call(entry,"finallyLoc")&&(entry.finallyLoc===finallyLoc||this.prev<entry.finallyLoc)){return entry}}},abrupt:function(type,arg){var entry=this._findFinallyEntry();var record=entry?entry.completion:{};record.type=type;record.arg=arg;if(entry){this.next=entry.finallyLoc}else{this.complete(record)}return ContinueSentinel},complete:function(record){if(record.type==="throw"){throw record.arg}if(record.type==="break"||record.type==="continue"){this.next=record.arg}else if(record.type==="return"){this.rval=record.arg;this.next="end"}return ContinueSentinel},finish:function(finallyLoc){var entry=this._findFinallyEntry(finallyLoc);return this.complete(entry.completion)},"catch":function(tryLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc===tryLoc){var record=entry.completion;var thrown;if(record.type==="throw"){thrown=record.arg;resetTryEntry(entry,i)}return thrown}}throw new Error("illegal catch attempt")},delegateYield:function(iterable,resultName,nextLoc){this.delegate={iterator:values(iterable),resultName:resultName,nextLoc:nextLoc};return ContinueSentinel}}}).call(this,typeof global!=="undefined"?global:typeof self!=="undefined"?self:typeof window!=="undefined"?window:{})},{}],3:[function(require,module,exports){var process=module.exports={};process.nextTick=function(){var canSetImmediate=typeof window!=="undefined"&&window.setImmediate;var canMutationObserver=typeof window!=="undefined"&&window.MutationObserver;var canPost=typeof window!=="undefined"&&window.postMessage&&window.addEventListener;if(canSetImmediate){return function(f){return window.setImmediate(f)}}var queue=[];if(canMutationObserver){var hiddenDiv=document.createElement("div");var observer=new MutationObserver(function(){var queueList=queue.slice();queue.length=0;queueList.forEach(function(fn){fn()})});observer.observe(hiddenDiv,{attributes:true});return function nextTick(fn){if(!queue.length){hiddenDiv.setAttribute("yes","no")}queue.push(fn)}}if(canPost){window.addEventListener("message",function(ev){var source=ev.source;if((source===window||source===null)&&ev.data==="process-tick"){ev.stopPropagation();if(queue.length>0){var fn=queue.shift();fn()}}},true);return function nextTick(fn){queue.push(fn);window.postMessage("process-tick","*")}}return function nextTick(fn){setTimeout(fn,0)}}();process.title="browser";process.browser=true;process.env={};process.argv=[];function noop(){}process.on=noop;process.addListener=noop;process.once=noop;process.off=noop;process.removeListener=noop;process.removeAllListeners=noop;process.emit=noop;process.binding=function(name){throw new Error("process.binding is not supported")};process.cwd=function(){return"/"};process.chdir=function(dir){throw new Error("process.chdir is not supported")}},{}],4:[function(require,module,exports){(function(process){(function(root,factory){if(typeof define==="function"&&define.amd){define(factory)}else if(typeof exports==="object"){module.exports=factory()}else{root.returnExports=factory()}})(this,function(){"use strict";var isCallableWithoutNew=function(func){try{func()}catch(e){return false}return true};var supportsSubclassing=function(C,f){try{var Sub=function(){C.apply(this,arguments)};if(!Sub.__proto__){return false}Object.setPrototypeOf(Sub,C);Sub.prototype=Object.create(C.prototype,{constructor:{value:C}});return f(Sub)}catch(e){return false}};var arePropertyDescriptorsSupported=function(){try{Object.defineProperty({},"x",{});return true}catch(e){return false}};var startsWithRejectsRegex=function(){var rejectsRegex=false;if(String.prototype.startsWith){try{"/a/".startsWith(/a/)}catch(e){rejectsRegex=true}}return rejectsRegex};var getGlobal=new Function("return this;");var globals=getGlobal();var global_isFinite=globals.isFinite;var supportsDescriptors=!!Object.defineProperty&&arePropertyDescriptorsSupported();var startsWithIsCompliant=startsWithRejectsRegex();var _slice=Array.prototype.slice;var _indexOf=String.prototype.indexOf;var _toString=Object.prototype.toString;var _hasOwnProperty=Object.prototype.hasOwnProperty;var ArrayIterator;var defineProperty=function(object,name,value,force){if(!force&&name in object){return}if(supportsDescriptors){Object.defineProperty(object,name,{configurable:true,enumerable:false,writable:true,value:value})}else{object[name]=value}};var defineProperties=function(object,map){Object.keys(map).forEach(function(name){var method=map[name];defineProperty(object,name,method,false)})};var create=Object.create||function(prototype,properties){function Type(){}Type.prototype=prototype;var object=new Type;if(typeof properties!=="undefined"){defineProperties(object,properties)}return object};var $iterator$=typeof Symbol==="function"&&Symbol.iterator||"_es6shim_iterator_";if(globals.Set&&typeof(new globals.Set)["@@iterator"]==="function"){$iterator$="@@iterator"}var addIterator=function(prototype,impl){if(!impl){impl=function iterator(){return this}}var o={};o[$iterator$]=impl;defineProperties(prototype,o);if(!prototype[$iterator$]&&typeof $iterator$==="symbol"){prototype[$iterator$]=impl}};var isArguments=function isArguments(value){var str=_toString.call(value);var result=str==="[object Arguments]";if(!result){result=str!=="[object Array]"&&value!==null&&typeof value==="object"&&typeof value.length==="number"&&value.length>=0&&_toString.call(value.callee)==="[object Function]"}return result};var emulateES6construct=function(o){if(!ES.TypeIsObject(o)){throw new TypeError("bad object")}if(!o._es6construct){if(o.constructor&&ES.IsCallable(o.constructor["@@create"])){o=o.constructor["@@create"](o)}defineProperties(o,{_es6construct:true})}return o};var ES={CheckObjectCoercible:function(x,optMessage){if(x==null){throw new TypeError(optMessage||"Cannot call method on "+x)}return x},TypeIsObject:function(x){return x!=null&&Object(x)===x},ToObject:function(o,optMessage){return Object(ES.CheckObjectCoercible(o,optMessage))},IsCallable:function(x){return typeof x==="function"&&_toString.call(x)==="[object Function]"},ToInt32:function(x){return x>>0},ToUint32:function(x){return x>>>0},ToInteger:function(value){var number=+value;if(Number.isNaN(number)){return 0}if(number===0||!Number.isFinite(number)){return number}return(number>0?1:-1)*Math.floor(Math.abs(number))},ToLength:function(value){var len=ES.ToInteger(value);if(len<=0){return 0}if(len>Number.MAX_SAFE_INTEGER){return Number.MAX_SAFE_INTEGER}return len},SameValue:function(a,b){if(a===b){if(a===0){return 1/a===1/b}return true}return Number.isNaN(a)&&Number.isNaN(b)},SameValueZero:function(a,b){return a===b||Number.isNaN(a)&&Number.isNaN(b)},IsIterable:function(o){return ES.TypeIsObject(o)&&(typeof o[$iterator$]!=="undefined"||isArguments(o))},GetIterator:function(o){if(isArguments(o)){return new ArrayIterator(o,"value")}var itFn=o[$iterator$];if(!ES.IsCallable(itFn)){throw new TypeError("value is not an iterable")}var it=itFn.call(o);if(!ES.TypeIsObject(it)){throw new TypeError("bad iterator")}return it},IteratorNext:function(it){var result=arguments.length>1?it.next(arguments[1]):it.next();if(!ES.TypeIsObject(result)){throw new TypeError("bad iterator")}return result},Construct:function(C,args){var obj;if(ES.IsCallable(C["@@create"])){obj=C["@@create"]()}else{obj=create(C.prototype||null)}defineProperties(obj,{_es6construct:true});var result=C.apply(obj,args);return ES.TypeIsObject(result)?result:obj}};var numberConversion=function(){function roundToEven(n){var w=Math.floor(n),f=n-w;if(f<.5){return w}if(f>.5){return w+1}return w%2?w+1:w}function packIEEE754(v,ebits,fbits){var bias=(1<<ebits-1)-1,s,e,f,i,bits,str,bytes;if(v!==v){e=(1<<ebits)-1;f=Math.pow(2,fbits-1);s=0}else if(v===Infinity||v===-Infinity){e=(1<<ebits)-1;f=0;s=v<0?1:0}else if(v===0){e=0;f=0;s=1/v===-Infinity?1:0}else{s=v<0;v=Math.abs(v);if(v>=Math.pow(2,1-bias)){e=Math.min(Math.floor(Math.log(v)/Math.LN2),1023);f=roundToEven(v/Math.pow(2,e)*Math.pow(2,fbits));if(f/Math.pow(2,fbits)>=2){e=e+1;f=1}if(e>bias){e=(1<<ebits)-1;f=0}else{e=e+bias;f=f-Math.pow(2,fbits)}}else{e=0;f=roundToEven(v/Math.pow(2,1-bias-fbits))}}bits=[];for(i=fbits;i;i-=1){bits.push(f%2?1:0);f=Math.floor(f/2)}for(i=ebits;i;i-=1){bits.push(e%2?1:0);e=Math.floor(e/2)}bits.push(s?1:0);bits.reverse();str=bits.join("");bytes=[];while(str.length){bytes.push(parseInt(str.slice(0,8),2));str=str.slice(8)}return bytes}function unpackIEEE754(bytes,ebits,fbits){var bits=[],i,j,b,str,bias,s,e,f;for(i=bytes.length;i;i-=1){b=bytes[i-1];for(j=8;j;j-=1){bits.push(b%2?1:0);b=b>>1}}bits.reverse();str=bits.join("");bias=(1<<ebits-1)-1;s=parseInt(str.slice(0,1),2)?-1:1;e=parseInt(str.slice(1,1+ebits),2);f=parseInt(str.slice(1+ebits),2);if(e===(1<<ebits)-1){return f!==0?NaN:s*Infinity}else if(e>0){return s*Math.pow(2,e-bias)*(1+f/Math.pow(2,fbits))}else if(f!==0){return s*Math.pow(2,-(bias-1))*(f/Math.pow(2,fbits))}else{return s<0?-0:0}}function unpackFloat64(b){return unpackIEEE754(b,11,52)}function packFloat64(v){return packIEEE754(v,11,52)}function unpackFloat32(b){return unpackIEEE754(b,8,23)}function packFloat32(v){return packIEEE754(v,8,23)}var conversions={toFloat32:function(num){return unpackFloat32(packFloat32(num))}};if(typeof Float32Array!=="undefined"){var float32array=new Float32Array(1);conversions.toFloat32=function(num){float32array[0]=num;return float32array[0]}}return conversions}();defineProperties(String,{fromCodePoint:function(_){var points=_slice.call(arguments,0,arguments.length);var result=[];var next;for(var i=0,length=points.length;i<length;i++){next=Number(points[i]);if(!ES.SameValue(next,ES.ToInteger(next))||next<0||next>1114111){throw new RangeError("Invalid code point "+next)}if(next<65536){result.push(String.fromCharCode(next))}else{next-=65536;result.push(String.fromCharCode((next>>10)+55296));result.push(String.fromCharCode(next%1024+56320))}}return result.join("")},raw:function(callSite){var substitutions=_slice.call(arguments,1,arguments.length);var cooked=ES.ToObject(callSite,"bad callSite");var rawValue=cooked.raw;var raw=ES.ToObject(rawValue,"bad raw value");var len=Object.keys(raw).length;var literalsegments=ES.ToLength(len);if(literalsegments===0){return""}var stringElements=[];var nextIndex=0;var nextKey,next,nextSeg,nextSub;while(nextIndex<literalsegments){nextKey=String(nextIndex);next=raw[nextKey];nextSeg=String(next);stringElements.push(nextSeg);if(nextIndex+1>=literalsegments){break}next=substitutions[nextKey];if(typeof next==="undefined"){break}nextSub=String(next);stringElements.push(nextSub);nextIndex++}return stringElements.join("")}});if(String.fromCodePoint.length!==1){var originalFromCodePoint=String.fromCodePoint;defineProperty(String,"fromCodePoint",function(_){return originalFromCodePoint.apply(this,arguments)},true)}var StringShims={repeat:function(){var repeat=function(s,times){if(times<1){return""}if(times%2){return repeat(s,times-1)+s}var half=repeat(s,times/2);return half+half};return function(times){var thisStr=String(ES.CheckObjectCoercible(this));times=ES.ToInteger(times);if(times<0||times===Infinity){throw new RangeError("Invalid String#repeat value")}return repeat(thisStr,times)}}(),startsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "startsWith" with a regex')}searchStr=String(searchStr);var startArg=arguments.length>1?arguments[1]:void 0;var start=Math.max(ES.ToInteger(startArg),0);return thisStr.slice(start,start+searchStr.length)===searchStr},endsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "endsWith" with a regex')}searchStr=String(searchStr);var thisLen=thisStr.length;var posArg=arguments.length>1?arguments[1]:void 0;var pos=typeof posArg==="undefined"?thisLen:ES.ToInteger(posArg);var end=Math.min(Math.max(pos,0),thisLen);return thisStr.slice(end-searchStr.length,end)===searchStr},contains:function(searchString){var position=arguments.length>1?arguments[1]:void 0;return _indexOf.call(this,searchString,position)!==-1},codePointAt:function(pos){var thisStr=String(ES.CheckObjectCoercible(this));var position=ES.ToInteger(pos);var length=thisStr.length;if(position<0||position>=length){return}var first=thisStr.charCodeAt(position);var isEnd=position+1===length;if(first<55296||first>56319||isEnd){return first}var second=thisStr.charCodeAt(position+1);if(second<56320||second>57343){return first}return(first-55296)*1024+(second-56320)+65536}};defineProperties(String.prototype,StringShims);var hasStringTrimBug="".trim().length!==1;if(hasStringTrimBug){var originalStringTrim=String.prototype.trim;delete String.prototype.trim;var ws=["  \n\f\r   ᠎    ","         　\u2028","\u2029﻿"].join("");var trimRegexp=new RegExp("(^["+ws+"]+)|(["+ws+"]+$)","g");defineProperties(String.prototype,{trim:function(){if(typeof this==="undefined"||this===null){throw new TypeError("can't convert "+this+" to object")}return String(this).replace(trimRegexp,"")}})}var StringIterator=function(s){this._s=String(ES.CheckObjectCoercible(s));this._i=0};StringIterator.prototype.next=function(){var s=this._s,i=this._i;if(typeof s==="undefined"||i>=s.length){this._s=void 0;return{value:void 0,done:true}}var first=s.charCodeAt(i),second,len;if(first<55296||first>56319||i+1==s.length){len=1}else{second=s.charCodeAt(i+1);len=second<56320||second>57343?1:2}this._i=i+len;return{value:s.substr(i,len),done:false}};addIterator(StringIterator.prototype);addIterator(String.prototype,function(){return new StringIterator(this)});if(!startsWithIsCompliant){String.prototype.startsWith=StringShims.startsWith;String.prototype.endsWith=StringShims.endsWith}var ArrayShims={from:function(iterable){var mapFn=arguments.length>1?arguments[1]:void 0;var list=ES.ToObject(iterable,"bad iterable");if(typeof mapFn!=="undefined"&&!ES.IsCallable(mapFn)){throw new TypeError("Array.from: when provided, the second argument must be a function")}var hasThisArg=arguments.length>2;var thisArg=hasThisArg?arguments[2]:void 0;var usingIterator=ES.IsIterable(list);var length;var result,i,value;if(usingIterator){i=0;result=ES.IsCallable(this)?Object(new this):[];var it=usingIterator?ES.GetIterator(list):null;var iterationValue;do{iterationValue=ES.IteratorNext(it);if(!iterationValue.done){value=iterationValue.value;if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}i+=1}}while(!iterationValue.done);length=i}else{length=ES.ToLength(list.length);result=ES.IsCallable(this)?Object(new this(length)):new Array(length);for(i=0;i<length;++i){value=list[i];if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}}}result.length=length;return result},of:function(){return Array.from(arguments)}};defineProperties(Array,ArrayShims);var arrayFromSwallowsNegativeLengths=function(){try{return Array.from({length:-1}).length===0}catch(e){return false}};if(!arrayFromSwallowsNegativeLengths()){defineProperty(Array,"from",ArrayShims.from,true)}ArrayIterator=function(array,kind){this.i=0;this.array=array;this.kind=kind};defineProperties(ArrayIterator.prototype,{next:function(){var i=this.i,array=this.array;if(!(this instanceof ArrayIterator)){throw new TypeError("Not an ArrayIterator")}if(typeof array!=="undefined"){var len=ES.ToLength(array.length);for(;i<len;i++){var kind=this.kind;var retval;if(kind==="key"){retval=i}else if(kind==="value"){retval=array[i]}else if(kind==="entry"){retval=[i,array[i]]}this.i=i+1;return{value:retval,done:false}}}this.array=void 0;return{value:void 0,done:true}}});addIterator(ArrayIterator.prototype);var ArrayPrototypeShims={copyWithin:function(target,start){var end=arguments[2];var o=ES.ToObject(this);var len=ES.ToLength(o.length);target=ES.ToInteger(target);start=ES.ToInteger(start);var to=target<0?Math.max(len+target,0):Math.min(target,len);var from=start<0?Math.max(len+start,0):Math.min(start,len);end=typeof end==="undefined"?len:ES.ToInteger(end);var fin=end<0?Math.max(len+end,0):Math.min(end,len);var count=Math.min(fin-from,len-to);var direction=1;if(from<to&&to<from+count){direction=-1;from+=count-1;to+=count-1}while(count>0){if(_hasOwnProperty.call(o,from)){o[to]=o[from]}else{delete o[from]}from+=direction;to+=direction;count-=1}return o},fill:function(value){var start=arguments.length>1?arguments[1]:void 0;var end=arguments.length>2?arguments[2]:void 0;var O=ES.ToObject(this);var len=ES.ToLength(O.length);start=ES.ToInteger(typeof start==="undefined"?0:start);end=ES.ToInteger(typeof end==="undefined"?len:end);var relativeStart=start<0?Math.max(len+start,0):Math.min(start,len);var relativeEnd=end<0?len+end:end;for(var i=relativeStart;i<len&&i<relativeEnd;++i){O[i]=value}return O},find:function find(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#find: predicate must be a function")}var thisArg=arguments[1];for(var i=0,value;i<length;i++){value=list[i];if(predicate.call(thisArg,value,i,list)){return value}}return},findIndex:function findIndex(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#findIndex: predicate must be a function")}var thisArg=arguments[1];for(var i=0;i<length;i++){if(predicate.call(thisArg,list[i],i,list)){return i}}return-1},keys:function(){return new ArrayIterator(this,"key")},values:function(){return new ArrayIterator(this,"value")},entries:function(){return new ArrayIterator(this,"entry")}};if(Array.prototype.keys&&!ES.IsCallable([1].keys().next)){delete Array.prototype.keys}if(Array.prototype.entries&&!ES.IsCallable([1].entries().next)){delete Array.prototype.entries}if(Array.prototype.keys&&Array.prototype.entries&&!Array.prototype.values&&Array.prototype[$iterator$]){defineProperties(Array.prototype,{values:Array.prototype[$iterator$]})}defineProperties(Array.prototype,ArrayPrototypeShims);addIterator(Array.prototype,function(){return this.values()});if(Object.getPrototypeOf){addIterator(Object.getPrototypeOf([].values()))}var maxSafeInteger=Math.pow(2,53)-1;defineProperties(Number,{MAX_SAFE_INTEGER:maxSafeInteger,MIN_SAFE_INTEGER:-maxSafeInteger,EPSILON:2.220446049250313e-16,parseInt:globals.parseInt,parseFloat:globals.parseFloat,isFinite:function(value){return typeof value==="number"&&global_isFinite(value)},isInteger:function(value){return Number.isFinite(value)&&ES.ToInteger(value)===value},isSafeInteger:function(value){return Number.isInteger(value)&&Math.abs(value)<=Number.MAX_SAFE_INTEGER},isNaN:function(value){return value!==value}});if(![,1].find(function(item,idx){return idx===0})){defineProperty(Array.prototype,"find",ArrayPrototypeShims.find,true)}if([,1].findIndex(function(item,idx){return idx===0})!==0){defineProperty(Array.prototype,"findIndex",ArrayPrototypeShims.findIndex,true)}if(supportsDescriptors){defineProperties(Object,{getPropertyDescriptor:function(subject,name){var pd=Object.getOwnPropertyDescriptor(subject,name);var proto=Object.getPrototypeOf(subject);while(typeof pd==="undefined"&&proto!==null){pd=Object.getOwnPropertyDescriptor(proto,name);proto=Object.getPrototypeOf(proto)}return pd},getPropertyNames:function(subject){var result=Object.getOwnPropertyNames(subject);var proto=Object.getPrototypeOf(subject);var addProperty=function(property){if(result.indexOf(property)===-1){result.push(property)}};while(proto!==null){Object.getOwnPropertyNames(proto).forEach(addProperty);proto=Object.getPrototypeOf(proto)}return result}});defineProperties(Object,{assign:function(target,source){if(!ES.TypeIsObject(target)){throw new TypeError("target must be an object")}return Array.prototype.reduce.call(arguments,function(target,source){return Object.keys(Object(source)).reduce(function(target,key){target[key]=source[key];return target},target)})},is:function(a,b){return ES.SameValue(a,b)},setPrototypeOf:function(Object,magic){var set;var checkArgs=function(O,proto){if(!ES.TypeIsObject(O)){throw new TypeError("cannot set prototype on a non-object")}if(!(proto===null||ES.TypeIsObject(proto))){throw new TypeError("can only set prototype to an object or null"+proto)}};var setPrototypeOf=function(O,proto){checkArgs(O,proto);set.call(O,proto);return O};try{set=Object.getOwnPropertyDescriptor(Object.prototype,magic).set;set.call({},null)}catch(e){if(Object.prototype!=={}[magic]){return}set=function(proto){this[magic]=proto};setPrototypeOf.polyfill=setPrototypeOf(setPrototypeOf({},null),Object.prototype)instanceof Object}return setPrototypeOf}(Object,"__proto__")})}if(Object.setPrototypeOf&&Object.getPrototypeOf&&Object.getPrototypeOf(Object.setPrototypeOf({},null))!==null&&Object.getPrototypeOf(Object.create(null))===null){(function(){var FAKENULL=Object.create(null);var gpo=Object.getPrototypeOf,spo=Object.setPrototypeOf;Object.getPrototypeOf=function(o){var result=gpo(o);return result===FAKENULL?null:result};Object.setPrototypeOf=function(o,p){if(p===null){p=FAKENULL}return spo(o,p)};Object.setPrototypeOf.polyfill=false})()}try{Object.keys("foo")}catch(e){var originalObjectKeys=Object.keys;Object.keys=function(obj){return originalObjectKeys(ES.ToObject(obj))}}var MathShims={acosh:function(value){value=Number(value);if(Number.isNaN(value)||value<1){return NaN}if(value===1){return 0}if(value===Infinity){return value}return Math.log(value+Math.sqrt(value*value-1))},asinh:function(value){value=Number(value);if(value===0||!global_isFinite(value)){return value}return value<0?-Math.asinh(-value):Math.log(value+Math.sqrt(value*value+1))},atanh:function(value){value=Number(value);if(Number.isNaN(value)||value<-1||value>1){return NaN}if(value===-1){return-Infinity}if(value===1){return Infinity}if(value===0){return value}return.5*Math.log((1+value)/(1-value))},cbrt:function(value){value=Number(value);if(value===0){return value}var negate=value<0,result;if(negate){value=-value}result=Math.pow(value,1/3);return negate?-result:result},clz32:function(value){value=Number(value);var number=ES.ToUint32(value);if(number===0){return 32}return 32-number.toString(2).length},cosh:function(value){value=Number(value);if(value===0){return 1}if(Number.isNaN(value)){return NaN}if(!global_isFinite(value)){return Infinity}if(value<0){value=-value}if(value>21){return Math.exp(value)/2}return(Math.exp(value)+Math.exp(-value))/2},expm1:function(value){value=Number(value);if(value===-Infinity){return-1}if(!global_isFinite(value)||value===0){return value}return Math.exp(value)-1},hypot:function(x,y){var anyNaN=false;var allZero=true;var anyInfinity=false;var numbers=[];Array.prototype.every.call(arguments,function(arg){var num=Number(arg);if(Number.isNaN(num)){anyNaN=true}else if(num===Infinity||num===-Infinity){anyInfinity=true}else if(num!==0){allZero=false}if(anyInfinity){return false}else if(!anyNaN){numbers.push(Math.abs(num))}return true});if(anyInfinity){return Infinity}if(anyNaN){return NaN}if(allZero){return 0}numbers.sort(function(a,b){return b-a});var largest=numbers[0];var divided=numbers.map(function(number){return number/largest});var sum=divided.reduce(function(sum,number){return sum+=number*number},0);return largest*Math.sqrt(sum)},log2:function(value){return Math.log(value)*Math.LOG2E},log10:function(value){return Math.log(value)*Math.LOG10E},log1p:function(value){value=Number(value);if(value<-1||Number.isNaN(value)){return NaN}if(value===0||value===Infinity){return value}if(value===-1){return-Infinity}var result=0;var n=50;if(value<0||value>1){return Math.log(1+value)}for(var i=1;i<n;i++){if(i%2===0){result-=Math.pow(value,i)/i}else{result+=Math.pow(value,i)/i}}return result},sign:function(value){var number=+value;if(number===0){return number}if(Number.isNaN(number)){return number}return number<0?-1:1},sinh:function(value){value=Number(value);if(!global_isFinite(value)||value===0){return value}return(Math.exp(value)-Math.exp(-value))/2},tanh:function(value){value=Number(value);if(Number.isNaN(value)||value===0){return value}if(value===Infinity){return 1}if(value===-Infinity){return-1}return(Math.exp(value)-Math.exp(-value))/(Math.exp(value)+Math.exp(-value))},trunc:function(value){var number=Number(value);return number<0?-Math.floor(-number):Math.floor(number)},imul:function(x,y){x=ES.ToUint32(x);y=ES.ToUint32(y);var ah=x>>>16&65535;var al=x&65535;var bh=y>>>16&65535;var bl=y&65535;return al*bl+(ah*bl+al*bh<<16>>>0)|0},fround:function(x){if(x===0||x===Infinity||x===-Infinity||Number.isNaN(x)){return x}var num=Number(x);return numberConversion.toFloat32(num)}};defineProperties(Math,MathShims);if(Math.imul(4294967295,5)!==-5){Math.imul=MathShims.imul
+}var PromiseShim=function(){var Promise,Promise$prototype;ES.IsPromise=function(promise){if(!ES.TypeIsObject(promise)){return false}if(!promise._promiseConstructor){return false}if(typeof promise._status==="undefined"){return false}return true};var PromiseCapability=function(C){if(!ES.IsCallable(C)){throw new TypeError("bad promise constructor")}var capability=this;var resolver=function(resolve,reject){capability.resolve=resolve;capability.reject=reject};capability.promise=ES.Construct(C,[resolver]);if(!capability.promise._es6construct){throw new TypeError("bad promise constructor")}if(!(ES.IsCallable(capability.resolve)&&ES.IsCallable(capability.reject))){throw new TypeError("bad promise constructor")}};var setTimeout=globals.setTimeout;var makeZeroTimeout;if(typeof window!=="undefined"&&ES.IsCallable(window.postMessage)){makeZeroTimeout=function(){var timeouts=[];var messageName="zero-timeout-message";var setZeroTimeout=function(fn){timeouts.push(fn);window.postMessage(messageName,"*")};var handleMessage=function(event){if(event.source==window&&event.data==messageName){event.stopPropagation();if(timeouts.length===0){return}var fn=timeouts.shift();fn()}};window.addEventListener("message",handleMessage,true);return setZeroTimeout}}var makePromiseAsap=function(){var P=globals.Promise;return P&&P.resolve&&function(task){return P.resolve().then(task)}};var enqueue=ES.IsCallable(globals.setImmediate)?globals.setImmediate.bind(globals):typeof process==="object"&&process.nextTick?process.nextTick:makePromiseAsap()||(ES.IsCallable(makeZeroTimeout)?makeZeroTimeout():function(task){setTimeout(task,0)});var triggerPromiseReactions=function(reactions,x){reactions.forEach(function(reaction){enqueue(function(){var handler=reaction.handler;var capability=reaction.capability;var resolve=capability.resolve;var reject=capability.reject;try{var result=handler(x);if(result===capability.promise){throw new TypeError("self resolution")}var updateResult=updatePromiseFromPotentialThenable(result,capability);if(!updateResult){resolve(result)}}catch(e){reject(e)}})})};var updatePromiseFromPotentialThenable=function(x,capability){if(!ES.TypeIsObject(x)){return false}var resolve=capability.resolve;var reject=capability.reject;try{var then=x.then;if(!ES.IsCallable(then)){return false}then.call(x,resolve,reject)}catch(e){reject(e)}return true};var promiseResolutionHandler=function(promise,onFulfilled,onRejected){return function(x){if(x===promise){return onRejected(new TypeError("self resolution"))}var C=promise._promiseConstructor;var capability=new PromiseCapability(C);var updateResult=updatePromiseFromPotentialThenable(x,capability);if(updateResult){return capability.promise.then(onFulfilled,onRejected)}else{return onFulfilled(x)}}};Promise=function(resolver){var promise=this;promise=emulateES6construct(promise);if(!promise._promiseConstructor){throw new TypeError("bad promise")}if(typeof promise._status!=="undefined"){throw new TypeError("promise already initialized")}if(!ES.IsCallable(resolver)){throw new TypeError("not a valid resolver")}promise._status="unresolved";promise._resolveReactions=[];promise._rejectReactions=[];var resolve=function(resolution){if(promise._status!=="unresolved"){return}var reactions=promise._resolveReactions;promise._result=resolution;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-resolution";triggerPromiseReactions(reactions,resolution)};var reject=function(reason){if(promise._status!=="unresolved"){return}var reactions=promise._rejectReactions;promise._result=reason;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-rejection";triggerPromiseReactions(reactions,reason)};try{resolver(resolve,reject)}catch(e){reject(e)}return promise};Promise$prototype=Promise.prototype;defineProperties(Promise,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Promise$prototype;obj=obj||create(prototype);defineProperties(obj,{_status:void 0,_result:void 0,_resolveReactions:void 0,_rejectReactions:void 0,_promiseConstructor:void 0});obj._promiseConstructor=constructor;return obj}});var _promiseAllResolver=function(index,values,capability,remaining){var done=false;return function(x){if(done){return}done=true;values[index]=x;if(--remaining.count===0){var resolve=capability.resolve;resolve(values)}}};Promise.all=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);var values=[],remaining={count:1};for(var index=0;;index++){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);var resolveElement=_promiseAllResolver(index,values,capability,remaining);remaining.count++;nextPromise.then(resolveElement,capability.reject)}if(--remaining.count===0){resolve(values)}}catch(e){reject(e)}return capability.promise};Promise.race=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);nextPromise.then(resolve,reject)}}catch(e){reject(e)}return capability.promise};Promise.reject=function(reason){var C=this;var capability=new PromiseCapability(C);var reject=capability.reject;reject(reason);return capability.promise};Promise.resolve=function(v){var C=this;if(ES.IsPromise(v)){var constructor=v._promiseConstructor;if(constructor===C){return v}}var capability=new PromiseCapability(C);var resolve=capability.resolve;resolve(v);return capability.promise};Promise.prototype["catch"]=function(onRejected){return this.then(void 0,onRejected)};Promise.prototype.then=function(onFulfilled,onRejected){var promise=this;if(!ES.IsPromise(promise)){throw new TypeError("not a promise")}var C=this.constructor;var capability=new PromiseCapability(C);if(!ES.IsCallable(onRejected)){onRejected=function(e){throw e}}if(!ES.IsCallable(onFulfilled)){onFulfilled=function(x){return x}}var resolutionHandler=promiseResolutionHandler(promise,onFulfilled,onRejected);var resolveReaction={capability:capability,handler:resolutionHandler};var rejectReaction={capability:capability,handler:onRejected};switch(promise._status){case"unresolved":promise._resolveReactions.push(resolveReaction);promise._rejectReactions.push(rejectReaction);break;case"has-resolution":triggerPromiseReactions([resolveReaction],promise._result);break;case"has-rejection":triggerPromiseReactions([rejectReaction],promise._result);break;default:throw new TypeError("unexpected")}return capability.promise};return Promise}();defineProperties(globals,{Promise:PromiseShim});var promiseSupportsSubclassing=supportsSubclassing(globals.Promise,function(S){return S.resolve(42)instanceof S});var promiseIgnoresNonFunctionThenCallbacks=function(){try{globals.Promise.reject(42).then(null,5).then(null,function(){});return true}catch(ex){return false}}();var promiseRequiresObjectContext=function(){try{Promise.call(3,function(){})}catch(e){return true}return false}();if(!promiseSupportsSubclassing||!promiseIgnoresNonFunctionThenCallbacks||!promiseRequiresObjectContext){globals.Promise=PromiseShim}var testOrder=function(a){var b=Object.keys(a.reduce(function(o,k){o[k]=true;return o},{}));return a.join(":")===b.join(":")};var preservesInsertionOrder=testOrder(["z","a","bb"]);var preservesNumericInsertionOrder=testOrder(["z",1,"a","3",2]);if(supportsDescriptors){var fastkey=function fastkey(key){if(!preservesInsertionOrder){return null}var type=typeof key;if(type==="string"){return"$"+key}else if(type==="number"){if(!preservesNumericInsertionOrder){return"n"+key}return key}return null};var emptyObject=function emptyObject(){return Object.create?Object.create(null):{}};var collectionShims={Map:function(){var empty={};function MapEntry(key,value){this.key=key;this.value=value;this.next=null;this.prev=null}MapEntry.prototype.isRemoved=function(){return this.key===empty};function MapIterator(map,kind){this.head=map._head;this.i=this.head;this.kind=kind}MapIterator.prototype={next:function(){var i=this.i,kind=this.kind,head=this.head,result;if(typeof this.i==="undefined"){return{value:void 0,done:true}}while(i.isRemoved()&&i!==head){i=i.prev}while(i.next!==head){i=i.next;if(!i.isRemoved()){if(kind==="key"){result=i.key}else if(kind==="value"){result=i.value}else{result=[i.key,i.value]}this.i=i;return{value:result,done:false}}}this.i=void 0;return{value:void 0,done:true}}};addIterator(MapIterator.prototype);function Map(iterable){var map=this;if(!ES.TypeIsObject(map)){throw new TypeError("Map does not accept arguments when called as a function")}map=emulateES6construct(map);if(!map._es6map){throw new TypeError("bad map")}var head=new MapEntry(null,null);head.next=head.prev=head;defineProperties(map,{_head:head,_storage:emptyObject(),_size:0});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=map.set;if(!ES.IsCallable(adder)){throw new TypeError("bad map")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;if(!ES.TypeIsObject(nextItem)){throw new TypeError("expected iterable of pairs")}adder.call(map,nextItem[0],nextItem[1])}}return map}var Map$prototype=Map.prototype;defineProperties(Map,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Map$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6map:true});return obj}});Object.defineProperty(Map.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._size==="undefined"){throw new TypeError("size method called on incompatible Map")}return this._size}});defineProperties(Map.prototype,{get:function(key){var fkey=fastkey(key);if(fkey!==null){var entry=this._storage[fkey];if(entry){return entry.value}else{return}}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return i.value}}return},has:function(key){var fkey=fastkey(key);if(fkey!==null){return typeof this._storage[fkey]!=="undefined"}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return true}}return false},set:function(key,value){var head=this._head,i=head,entry;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]!=="undefined"){this._storage[fkey].value=value;return this}else{entry=this._storage[fkey]=new MapEntry(key,value);i=head.prev}}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.value=value;return this}}entry=entry||new MapEntry(key,value);if(ES.SameValue(-0,key)){entry.key=+0}entry.next=this._head;entry.prev=this._head.prev;entry.prev.next=entry;entry.next.prev=entry;this._size+=1;return this},"delete":function(key){var head=this._head,i=head;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]==="undefined"){return false}i=this._storage[fkey].prev;delete this._storage[fkey]}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.key=i.value=empty;i.prev.next=i.next;i.next.prev=i.prev;this._size-=1;return true}}return false},clear:function(){this._size=0;this._storage=emptyObject();var head=this._head,i=head,p=i.next;while((i=p)!==head){i.key=i.value=empty;p=i.next;i.next=i.prev=head}head.next=head.prev=head},keys:function(){return new MapIterator(this,"key")},values:function(){return new MapIterator(this,"value")},entries:function(){return new MapIterator(this,"key+value")},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var it=this.entries();for(var entry=it.next();!entry.done;entry=it.next()){callback.call(context,entry.value[1],entry.value[0],this)}}});addIterator(Map.prototype,function(){return this.entries()});return Map}(),Set:function(){var SetShim=function Set(iterable){var set=this;if(!ES.TypeIsObject(set)){throw new TypeError("Set does not accept arguments when called as a function")}set=emulateES6construct(set);if(!set._es6set){throw new TypeError("bad set")}defineProperties(set,{"[[SetData]]":null,_storage:emptyObject()});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=set.add;if(!ES.IsCallable(adder)){throw new TypeError("bad set")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;adder.call(set,nextItem)}}return set};var Set$prototype=SetShim.prototype;defineProperties(SetShim,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Set$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6set:true});return obj}});var ensureMap=function ensureMap(set){if(!set["[[SetData]]"]){var m=set["[[SetData]]"]=new collectionShims.Map;Object.keys(set._storage).forEach(function(k){if(k.charCodeAt(0)===36){k=k.slice(1)}else if(k.charAt(0)==="n"){k=+k.slice(1)}else{k=+k}m.set(k,k)});set._storage=null}};Object.defineProperty(SetShim.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._storage==="undefined"){throw new TypeError("size method called on incompatible Set")}ensureMap(this);return this["[[SetData]]"].size}});defineProperties(SetShim.prototype,{has:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){return!!this._storage[fkey]}ensureMap(this);return this["[[SetData]]"].has(key)},add:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){this._storage[fkey]=true;return this}ensureMap(this);this["[[SetData]]"].set(key,key);return this},"delete":function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){var hasFKey=_hasOwnProperty.call(this._storage,fkey);return delete this._storage[fkey]&&hasFKey}ensureMap(this);return this["[[SetData]]"]["delete"](key)},clear:function(){if(this._storage){this._storage=emptyObject();return}return this["[[SetData]]"].clear()},keys:function(){ensureMap(this);return this["[[SetData]]"].keys()},values:function(){ensureMap(this);return this["[[SetData]]"].values()},entries:function(){ensureMap(this);return this["[[SetData]]"].entries()},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var entireSet=this;ensureMap(this);this["[[SetData]]"].forEach(function(value,key){callback.call(context,key,key,entireSet)})}});addIterator(SetShim.prototype,function(){return this.values()});return SetShim}()};defineProperties(globals,collectionShims);if(globals.Map||globals.Set){if(typeof globals.Map.prototype.clear!=="function"||(new globals.Set).size!==0||(new globals.Map).size!==0||typeof globals.Map.prototype.keys!=="function"||typeof globals.Set.prototype.keys!=="function"||typeof globals.Map.prototype.forEach!=="function"||typeof globals.Set.prototype.forEach!=="function"||isCallableWithoutNew(globals.Map)||isCallableWithoutNew(globals.Set)||!supportsSubclassing(globals.Map,function(M){var m=new M([]);m.set(42,42);return m instanceof M})){globals.Map=collectionShims.Map;globals.Set=collectionShims.Set}}addIterator(Object.getPrototypeOf((new globals.Map).keys()));addIterator(Object.getPrototypeOf((new globals.Set).keys()))}return globals})}).call(this,require("_process"))},{_process:3}],5:[function(require,module,exports){"use strict";if(!require("./is-implemented")()){Object.defineProperty(require("es5-ext/global"),"Symbol",{value:require("./polyfill"),configurable:true,enumerable:false,writable:true})}},{"./is-implemented":6,"./polyfill":21,"es5-ext/global":8}],6:[function(require,module,exports){"use strict";module.exports=function(){var symbol;if(typeof Symbol!=="function")return false;symbol=Symbol("test symbol");try{String(symbol)}catch(e){return false}if(typeof Symbol.iterator==="symbol")return true;if(typeof Symbol.isConcatSpreadable!=="object")return false;if(typeof Symbol.isRegExp!=="object")return false;if(typeof Symbol.iterator!=="object")return false;if(typeof Symbol.toPrimitive!=="object")return false;if(typeof Symbol.toStringTag!=="object")return false;if(typeof Symbol.unscopables!=="object")return false;return true}},{}],7:[function(require,module,exports){"use strict";var assign=require("es5-ext/object/assign"),normalizeOpts=require("es5-ext/object/normalize-options"),isCallable=require("es5-ext/object/is-callable"),contains=require("es5-ext/string/#/contains"),d;d=module.exports=function(dscr,value){var c,e,w,options,desc;if(arguments.length<2||typeof dscr!=="string"){options=value;value=dscr;dscr=null}else{options=arguments[2]}if(dscr==null){c=w=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e");w=contains.call(dscr,"w")}desc={value:value,configurable:c,enumerable:e,writable:w};return!options?desc:assign(normalizeOpts(options),desc)};d.gs=function(dscr,get,set){var c,e,options,desc;if(typeof dscr!=="string"){options=set;set=get;get=dscr;dscr=null}else{options=arguments[3]}if(get==null){get=undefined}else if(!isCallable(get)){options=get;get=set=undefined}else if(set==null){set=undefined}else if(!isCallable(set)){options=set;set=undefined}if(dscr==null){c=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e")}desc={get:get,set:set,configurable:c,enumerable:e};return!options?desc:assign(normalizeOpts(options),desc)}},{"es5-ext/object/assign":9,"es5-ext/object/is-callable":12,"es5-ext/object/normalize-options":16,"es5-ext/string/#/contains":18}],8:[function(require,module,exports){"use strict";module.exports=new Function("return this")()},{}],9:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.assign:require("./shim")},{"./is-implemented":10,"./shim":11}],10:[function(require,module,exports){"use strict";module.exports=function(){var assign=Object.assign,obj;if(typeof assign!=="function")return false;obj={foo:"raz"};assign(obj,{bar:"dwa"},{trzy:"trzy"});return obj.foo+obj.bar+obj.trzy==="razdwatrzy"}},{}],11:[function(require,module,exports){"use strict";var keys=require("../keys"),value=require("../valid-value"),max=Math.max;module.exports=function(dest,src){var error,i,l=max(arguments.length,2),assign;dest=Object(value(dest));assign=function(key){try{dest[key]=src[key]}catch(e){if(!error)error=e}};for(i=1;i<l;++i){src=arguments[i];keys(src).forEach(assign)}if(error!==undefined)throw error;return dest}},{"../keys":13,"../valid-value":17}],12:[function(require,module,exports){"use strict";module.exports=function(obj){return typeof obj==="function"}},{}],13:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.keys:require("./shim")},{"./is-implemented":14,"./shim":15}],14:[function(require,module,exports){"use strict";module.exports=function(){try{Object.keys("primitive");return true}catch(e){return false}}},{}],15:[function(require,module,exports){"use strict";var keys=Object.keys;module.exports=function(object){return keys(object==null?object:Object(object))}},{}],16:[function(require,module,exports){"use strict";var assign=require("./assign"),forEach=Array.prototype.forEach,create=Object.create,getPrototypeOf=Object.getPrototypeOf,process;process=function(src,obj){var proto=getPrototypeOf(src);return assign(proto?process(proto,obj):obj,src)};module.exports=function(options){var result=create(null);forEach.call(arguments,function(options){if(options==null)return;process(Object(options),result)});return result}},{"./assign":9}],17:[function(require,module,exports){"use strict";module.exports=function(value){if(value==null)throw new TypeError("Cannot use null or undefined");return value}},{}],18:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?String.prototype.contains:require("./shim")},{"./is-implemented":19,"./shim":20}],19:[function(require,module,exports){"use strict";var str="razdwatrzy";module.exports=function(){if(typeof str.contains!=="function")return false;return str.contains("dwa")===true&&str.contains("foo")===false}},{}],20:[function(require,module,exports){"use strict";var indexOf=String.prototype.indexOf;module.exports=function(searchString){return indexOf.call(this,searchString,arguments[1])>-1}},{}],21:[function(require,module,exports){"use strict";var d=require("d"),create=Object.create,defineProperties=Object.defineProperties,generateName,Symbol;generateName=function(){var created=create(null);return function(desc){var postfix=0;while(created[desc+(postfix||"")])++postfix;desc+=postfix||"";created[desc]=true;return"@@"+desc}}();module.exports=Symbol=function(description){var symbol;if(this instanceof Symbol){throw new TypeError("TypeError: Symbol is not a constructor")}symbol=create(Symbol.prototype);description=description===undefined?"":String(description);return defineProperties(symbol,{__description__:d("",description),__name__:d("",generateName(description))})};Object.defineProperties(Symbol,{create:d("",Symbol("create")),hasInstance:d("",Symbol("hasInstance")),isConcatSpreadable:d("",Symbol("isConcatSpreadable")),isRegExp:d("",Symbol("isRegExp")),iterator:d("",Symbol("iterator")),toPrimitive:d("",Symbol("toPrimitive")),toStringTag:d("",Symbol("toStringTag")),unscopables:d("",Symbol("unscopables"))});defineProperties(Symbol.prototype,{properToString:d(function(){return"Symbol ("+this.__description__+")"}),toString:d("",function(){return this.__name__})});Object.defineProperty(Symbol.prototype,Symbol.toPrimitive,d("",function(hint){throw new TypeError("Conversion of symbol objects is not allowed")}));Object.defineProperty(Symbol.prototype,Symbol.toStringTag,d("c","Symbol"))},{d:7}]},{},[1]);</script>
 
     <script>
       function __createIterableObject(a, b, c) {
@@ -587,15 +587,23 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <script data-source="&quot;use strict&quot;;
 
-var _slice = Array.prototype.slice;
+var _argumentsToArray = function (args) {
+  var target = new Array(args.length);
+  for (var i = 0; i < args.length; i++) {
+    target[i] = args[i];
+  }
+
+  return target;
+};
+
 (function () {
   return (function () {
-    var args = _slice.call(arguments);
+    var args = _argumentsToArray(arguments);
 
     return typeof args !== &quot;undefined&quot;;
   }());
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _slice = Array.prototype.slice;\n(function () {\n  return (function () {\n    var args = _slice.call(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _argumentsToArray = function (args) {\n  var target = new Array(args.length);\n  for (var i = 0; i < args.length; i++) {\n    target[i] = args[i];\n  }\n\n  return target;\n};\n\n(function () {\n  return (function () {\n    var args = _argumentsToArray(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -617,73 +625,97 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Mat
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return [1, 2, 3][2] === 3;
+  return [1, 2, 3].concat()[2] === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [1, 2, 3][2] === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [1, 2, 3].concat()[2] === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with strings, in function calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
-  return Math.max.apply(Math, Array.from(&quot;1234&quot;)) === 4;
+  return Math.max.apply(Math, _toArray(&quot;1234&quot;)) === 4;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Math.max.apply(Math, Array.from(\"1234\")) === 4;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return Math.max.apply(Math, _toArray(\"1234\")) === 4;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with strings, in array literals</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
-  return [&quot;a&quot;].concat(Array.from(&quot;bcd&quot;), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(&quot;bcd&quot;), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [\"a\"].concat(Array.from(\"bcd\"), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return [\"a\"].concat(_toArray(\"bcd\"), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  return Math.max.apply(Math, Array.from(iterable)) === 3;
+  return Math.max.apply(Math, _toArray(iterable)) === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, Array.from(iterable)) === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, _toArray(iterable)) === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
-  return [&quot;a&quot;].concat(Array.from(iterable), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(iterable), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(Array.from(iterable), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(_toArray(iterable), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  return Math.max.apply(Math, Array.from(Object.create(iterable))) === 3;
+  return Math.max.apply(Math, _toArray(Object.create(iterable))) === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, Array.from(Object.create(iterable))) === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, _toArray(Object.create(iterable))) === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
-  return [&quot;a&quot;].concat(Array.from(Object.create(iterable)), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(Object.create(iterable)), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(Array.from(Object.create(iterable)), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(_toArray(Object.create(iterable)), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -695,11 +727,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {};
+  var _C = function _C() {};
 
-  return typeof C === &quot;function&quot;;
+  return typeof _C === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  return typeof C === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  return typeof _C === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -707,16 +739,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = fu
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {};
+  var _C = function _C() {};
 
   {
     (function () {
-      var D = function D() {};
+      var _D = function _D() {};
     })();
   }
-  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  {\n    (function () {\n      var D = function D() {};\n    })();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -734,13 +766,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {
+  var _C = function _C() {
     this.x = 1;
   };
 
-  return C.prototype.constructor === C && new C().x === 1;
+  return _C.prototype.constructor === _C && new _C().x === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {\n    this.x = 1;\n  };\n\n  return C.prototype.constructor === C && new C().x === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {\n    this.x = 1;\n  };\n\n  return _C.prototype.constructor === _C && new _C().x === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -753,10 +785,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, null, {
+    _classProps(_C, null, {
       method: {
         writable: true,
         value: function () {
@@ -765,12 +797,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return C;
+    return _C;
   })();
 
-  return typeof C.prototype.method === &quot;function&quot; && new C().method() === 2;
+  return typeof _C.prototype.method === &quot;function&quot; && new _C().method() === 2;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.prototype.method === \"function\" && new C().method() === 2;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.prototype.method === \"function\" && new _C().method() === 2;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -783,10 +815,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, {
+    _classProps(_C, {
       method: {
         writable: true,
         value: function () {
@@ -795,12 +827,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return C;
+    return _C;
   })();
 
-  return typeof C.method === &quot;function&quot; && C.method() === 3;
+  return typeof _C.method === &quot;function&quot; && _C.method() === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.method === \"function\" && C.method() === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.method === \"function\" && _C.method() === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -850,19 +882,19 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var C = (function (Array) {
-    var C = function C() {
+  var _C = (function (Array) {
+    var _C = function _C() {
       Array.apply(this, arguments);
     };
 
-    _extends(C, Array);
+    _extends(_C, Array);
 
-    return C;
+    return _C;
   })(Array);
 
-  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);
+  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var C = (function (Array) {\n    var C = function C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(C, Array);\n\n    return C;\n  })(Array);\n\n  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _C = (function (Array) {\n    var _C = function _C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(_C, Array);\n\n    return _C;\n  })(Array);\n\n  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -886,21 +918,21 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B(a) {
+  var _B = (function (_ref) {
+    var _B = function _B(a) {
       return _ref.call(this, &quot;bar&quot; + a);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    return B;
+    return _B;
   })(function (a) {
     return [&quot;foo&quot; + a];
   });
 
-  return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
+  return new _B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(B, _ref);\n\n    return B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(_B, _ref);\n\n    return _B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new _B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -925,14 +957,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B() {
+  var _B = (function (_ref) {
+    var _B = function _B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    _classProps(B, null, {
+    _classProps(_B, null, {
       qux: {
         writable: true,
         value: function (a) {
@@ -941,7 +973,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return B;
+    return _B;
   })((function () {
     var _class = function () {};
 
@@ -957,9 +989,9 @@ var _extends = function (child, parent) {
     return _class;
   })());
 
-  return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
+  return new _B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new _B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -984,14 +1016,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B() {
+  var _B = (function (_ref) {
+    var _B = function _B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    _classProps(B, null, {
+    _classProps(_B, null, {
       qux: {
         writable: true,
         value: function () {
@@ -1000,7 +1032,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return B;
+    return _B;
   })((function () {
     var _class = function () {};
 
@@ -1017,12 +1049,12 @@ var _extends = function (child, parent) {
   })());
 
   var obj = {
-    qux: B.prototype.qux,
+    qux: _B.prototype.qux,
     corge: &quot;ley&quot;
   };
   return obj.qux() === &quot;barley&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: _B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1144,14 +1176,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var result
 
 (function () {
   var generator = regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: context$2$0.next = 2;
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: _context.next = 2;
           return 5;
-        case 2: context$2$0.next = 4;
+        case 2: _context.next = 4;
           return 6;
         case 4:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   });
@@ -1166,7 +1198,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var result
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: context$2$0.next = 2;\n          return 5;\n        case 2: context$2$0.next = 4;\n          return 6;\n        case 4:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  });\n\n  ;\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: _context.next = 2;\n          return 5;\n        case 2: _context.next = 4;\n          return 6;\n        case 4:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  });\n\n  ;\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1175,11 +1207,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var genera
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield([5, 6], &quot;t4&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield([5, 6], &quot;t4&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1191,7 +1223,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var genera
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield([5, 6], \"t4\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield([5, 6], \"t4\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1200,11 +1232,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(&quot;56&quot;, &quot;t5&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(&quot;56&quot;, &quot;t5&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1216,7 +1248,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(\"56\", \"t5\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === \"5\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === \"6\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(\"56\", \"t5\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === \"5\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === \"6\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1225,11 +1257,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), &quot;t6&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(__createIterableObject(5, 6, 7), &quot;t6&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1243,7 +1275,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t6\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(__createIterableObject(5, 6, 7), \"t6\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1252,11 +1284,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t7&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t7&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1270,7 +1302,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t7\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t7\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1279,17 +1311,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var o = {
-    generator: regeneratorRuntime.mark(function callee$1$0() {
-      return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-        while (true) switch (context$2$0.prev = context$2$0.next) {
-          case 0: context$2$0.next = 2;
+    generator: regeneratorRuntime.mark(function _callee() {
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (true) switch (_context.prev = _context.next) {
+          case 0: _context.next = 2;
             return 5;
-          case 2: context$2$0.next = 4;
+          case 2: _context.next = 4;
             return 6;
           case 4:
-          case &quot;end&quot;: return context$2$0.stop();
+          case &quot;end&quot;: return _context.stop();
         }
-      }, callee$1$0, this);
+      }, _callee, this);
     }) };
   var iterator = o.generator();
   var item = iterator.next();
@@ -1300,7 +1332,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {\n    generator: regeneratorRuntime.mark(function callee$1$0() {\n      return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {\n        while (true) switch (context$2$0.prev = context$2$0.next) {\n          case 0: context$2$0.next = 2;\n            return 5;\n          case 2: context$2$0.next = 4;\n            return 6;\n          case 4:\n          case \"end\": return context$2$0.stop();\n        }\n      }, callee$1$0, this);\n    }) };\n  var iterator = o.generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {\n    generator: regeneratorRuntime.mark(function _callee() {\n      return regeneratorRuntime.wrap(function _callee$(_context) {\n        while (true) switch (_context.prev = _context.next) {\n          case 0: _context.next = 2;\n            return 5;\n          case 2: _context.next = 4;\n            return 6;\n          case 4:\n          case \"end\": return _context.stop();\n        }\n      }, _callee, this);\n    }) };\n  var iterator = o.generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2728,60 +2760,86 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
           <td><span>with arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [5, null, [6]];
 
-  var a = _ref[0];
-  var b = _ref[2][0];
-  var c = _ref[3];
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var _ref3 = _toArray(_ref2[2]);
+
+  var b = _ref3[0];
+  var c = _ref2[3];
   return a === 5 && b === 6 && c === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var a = _ref[0];\n  var b = _ref[2][0];\n  var c = _ref[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var _ref3 = _toArray(_ref2[2]);\n\n  var b = _ref3[0];\n  var c = _ref2[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with strings</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = &quot;bar&quot;;
 
-  var a = _ref[0];
-  var b = _ref[1];
-  var c = _ref[2];
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var b = _ref2[1];
+  var c = _ref2[2];
   return a === &quot;b&quot; && b === &quot;a&quot; && c === &quot;r&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = \"bar\";\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with generic iterables</span></td>
 <script data-source="&quot;use strict&quot;;
 
-(function () {
-  var iterable = __createIterableObject(1, 2, 3);
-  var a = iterable[0];
-  var b = iterable[1];
-  var c = iterable[2];
-  return a === 1 && b === 2 && c === 3;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var a = iterable[0];\n  var b = iterable[1];\n  var c = iterable[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="destructuring">
-          <td><span>with instances of generic iterables</span></td>
-<script data-source="&quot;use strict&quot;;
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
 
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  var _ref = Object.create(iterable);
+  var _ref = _toArray(iterable);
 
   var a = _ref[0];
   var b = _ref[1];
   var c = _ref[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = _toArray(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>with instances of generic iterables</span></td>
+<script data-source="&quot;use strict&quot;;
+
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
+(function () {
+  var iterable = __createIterableObject(1, 2, 3);
+  var _ref = Object.create(iterable);
+
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var b = _ref2[1];
+  var c = _ref2[2];
+  return a === 1 && b === 2 && c === 3;
+});">
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2802,52 +2860,72 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
           <td><span>nested</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [9, { x: 10 }];
 
-  var e = _ref[0];
-  var f = _ref[1].x;
-  var g = _ref[1].g;
+  var _ref2 = _toArray(_ref);
+
+  var e = _ref2[0];
+  var f = _ref2[1].x;
+  var g = _ref2[1].g;
   return e === 9 && f === 10 && g === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var e = _ref[0];\n  var f = _ref[1].x;\n  var g = _ref[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var _ref2 = _toArray(_ref);\n\n  var e = _ref2[0];\n  var f = _ref2[1].x;\n  var g = _ref2[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>parameters</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   return (function (_ref, _ref2) {
     var a = _ref.a;
     var b = _ref.x;
     var e = _ref.y;
-    var c = _ref2[0];
-    var d = _ref2[1];
+    var _ref3 = _toArray(_ref2);
+
+    var c = _ref3[0];
+    var d = _ref3[1];
     return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;
   }({ a: 1, x: 2 }, [3, 4]));
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var c = _ref2[0];\n    var d = _ref2[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var _ref3 = _toArray(_ref2);\n\n    var c = _ref3[0];\n    var d = _ref3[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>rest</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [3, 4, 5];
 
-  var a = _ref[0];
-  var b = _ref.slice(1);
+  var _ref2 = _toArray(_ref);
 
-  var _ref2 = [6];
+  var a = _ref2[0];
+  var b = _toArray(_ref2).slice(1);
 
-  var c = _ref2[0];
-  var d = _ref2.slice(1);
+  var _ref3 = [6];
+
+  var _ref4 = _toArray(_ref3);
+
+  var c = _ref4[0];
+  var d = _toArray(_ref4).slice(1);
 
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var a = _ref[0];\n  var b = _ref.slice(1);\n\n  var _ref2 = [6];\n\n  var c = _ref2[0];\n  var d = _ref2.slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _toArray(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = _toArray(_ref3);\n\n  var c = _ref4[0];\n  var d = _toArray(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3062,26 +3140,26 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var foo = function foo() {};
+  var _foo = function _foo() {};
 
   ;
-  var bar = (function () {
-    var bar = function bar() {};
+  var _bar = (function () {
+    var _bar = function _bar() {};
 
-    _classProps(bar, {
+    _classProps(_bar, {
       name: {
         writable: true,
         value: function () {}
       }
     });
 
-    return bar;
+    return _bar;
   })();
 
   ;
-  return foo.name === &quot;foo&quot; && typeof bar.name === &quot;function&quot;;
+  return _foo.name === &quot;foo&quot; && typeof _bar.name === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var foo = function foo() {};\n\n  ;\n  var bar = (function () {\n    var bar = function bar() {};\n\n    _classProps(bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return bar;\n  })();\n\n  ;\n  return foo.name === \"foo\" && typeof bar.name === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _foo = function _foo() {};\n\n  ;\n  var _bar = (function () {\n    var _bar = function _bar() {};\n\n    _classProps(_bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _bar;\n  })();\n\n  ;\n  return _foo.name === \"foo\" && typeof _bar.name === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3161,23 +3239,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, null, {
+    _classProps(_C, null, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return C;
+    return _C;
   })();
 
   ;
-  return (new C()).foo.name === &quot;foo&quot;;
+  return (new _C()).foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return (new C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return (new _C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3190,23 +3268,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, {
+    _classProps(_C, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return C;
+    return _C;
   })();
 
   ;
-  return C.foo.name === &quot;foo&quot;;
+  return _C.foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return _C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -4018,7 +4096,8 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
   }
   function g() {
     return 1;
-  }{
+  }
+  {
     function g() {
       return 2;
     }
@@ -4027,13 +4106,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
     function h() {
       return 1;
     }
-  }function h() {
+  }
+  function h() {
     return 2;
   }
 
   return f() === 1 && g() === 2 && h() === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }{\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }\n  {\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }\n  function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/6to5-polyfill.html
+++ b/es6/compilers/6to5-polyfill.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../../master.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="../../master.js"></script>
-    <script>(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){if(typeof Symbol==="undefined"){require("es6-symbol/implement")}require("es6-shim");require("./transformation/transformers/generators/runtime")},{"./transformation/transformers/generators/runtime":2,"es6-shim":4,"es6-symbol/implement":5}],2:[function(require,module,exports){(function(global){var iteratorSymbol=typeof Symbol==="function"&&Symbol.iterator||"@@iterator";var runtime=global.regeneratorRuntime=exports;var hasOwn=Object.prototype.hasOwnProperty;var wrap=runtime.wrap=function wrap(innerFn,outerFn,self,tryList){return new Generator(innerFn,outerFn,self||null,tryList||[])};var GenStateSuspendedStart="suspendedStart";var GenStateSuspendedYield="suspendedYield";var GenStateExecuting="executing";var GenStateCompleted="completed";var ContinueSentinel={};var GF=function GeneratorFunction(){};var GFp=function GeneratorFunctionPrototype(){};var Gp=GFp.prototype=Generator.prototype;(GFp.constructor=GF).prototype=Gp.constructor=GFp;var GFName="GeneratorFunction";if(GF.name!==GFName)GF.name=GFName;if(GF.name!==GFName)throw new Error(GFName+" renamed?");runtime.isGeneratorFunction=function(genFun){var ctor=genFun&&genFun.constructor;return ctor?GF.name===ctor.name:false};runtime.mark=function(genFun){genFun.__proto__=GFp;genFun.prototype=Object.create(Gp);return genFun};runtime.async=function(innerFn,outerFn,self,tryList){return new Promise(function(resolve,reject){var generator=wrap(innerFn,outerFn,self,tryList);var callNext=step.bind(generator.next);var callThrow=step.bind(generator["throw"]);function step(arg){var info;var value;try{info=this(arg);value=info.value}catch(error){return reject(error)}if(info.done){resolve(value)}else{Promise.resolve(value).then(callNext,callThrow)}}callNext()})};function Generator(innerFn,outerFn,self,tryList){var generator=outerFn?Object.create(outerFn.prototype):this;var context=new Context(tryList);var state=GenStateSuspendedStart;function invoke(method,arg){if(state===GenStateExecuting){throw new Error("Generator is already running")}if(state===GenStateCompleted){throw new Error("Generator has already finished")}while(true){var delegate=context.delegate;var info;if(delegate){try{info=delegate.iterator[method](arg);method="next";arg=undefined}catch(uncaught){context.delegate=null;method="throw";arg=uncaught;continue}if(info.done){context[delegate.resultName]=info.value;context.next=delegate.nextLoc}else{state=GenStateSuspendedYield;return info}context.delegate=null}if(method==="next"){if(state===GenStateSuspendedStart&&typeof arg!=="undefined"){throw new TypeError("attempt to send "+JSON.stringify(arg)+" to newborn generator")}if(state===GenStateSuspendedYield){context.sent=arg}else{delete context.sent}}else if(method==="throw"){if(state===GenStateSuspendedStart){state=GenStateCompleted;throw arg}if(context.dispatchException(arg)){method="next";arg=undefined}}else if(method==="return"){context.abrupt("return",arg)}state=GenStateExecuting;try{var value=innerFn.call(self,context);state=context.done?GenStateCompleted:GenStateSuspendedYield;info={value:value,done:context.done};if(value===ContinueSentinel){if(context.delegate&&method==="next"){arg=undefined}}else{return info}}catch(thrown){state=GenStateCompleted;if(method==="next"){context.dispatchException(thrown)}else{arg=thrown}}}}generator.next=invoke.bind(generator,"next");generator["throw"]=invoke.bind(generator,"throw");generator["return"]=invoke.bind(generator,"return");return generator}Gp[iteratorSymbol]=function(){return this};Gp.toString=function(){return"[object Generator]"};function pushTryEntry(triple){var entry={tryLoc:triple[0]};if(1 in triple){entry.catchLoc=triple[1]}if(2 in triple){entry.finallyLoc=triple[2]}this.tryEntries.push(entry)}function resetTryEntry(entry,i){var record=entry.completion||{};record.type=i===0?"normal":"return";delete record.arg;entry.completion=record}function Context(tryList){this.tryEntries=[{tryLoc:"root"}];tryList.forEach(pushTryEntry,this);this.reset()}runtime.keys=function(object){var keys=[];for(var key in object){keys.push(key)}keys.reverse();return function next(){while(keys.length){var key=keys.pop();if(key in object){next.value=key;next.done=false;return next}}next.done=true;return next}};function values(iterable){var iterator=iterable;if(iteratorSymbol in iterable){iterator=iterable[iteratorSymbol]()}else if(!isNaN(iterable.length)){var i=-1;iterator=function next(){while(++i<iterable.length){if(i in iterable){next.value=iterable[i];next.done=false;return next}}next.done=true;return next};iterator.next=iterator}return iterator}runtime.values=values;Context.prototype={constructor:Context,reset:function(){this.prev=0;this.next=0;this.sent=undefined;this.done=false;this.delegate=null;this.tryEntries.forEach(resetTryEntry);for(var tempIndex=0,tempName;hasOwn.call(this,tempName="t"+tempIndex)||tempIndex<20;++tempIndex){this[tempName]=null}},stop:function(){this.done=true;var rootEntry=this.tryEntries[0];var rootRecord=rootEntry.completion;if(rootRecord.type==="throw"){throw rootRecord.arg}return this.rval},dispatchException:function(exception){if(this.done){throw exception}var context=this;function handle(loc,caught){record.type="throw";record.arg=exception;context.next=loc;return!!caught}for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];var record=entry.completion;if(entry.tryLoc==="root"){return handle("end")}if(entry.tryLoc<=this.prev){var hasCatch=hasOwn.call(entry,"catchLoc");var hasFinally=hasOwn.call(entry,"finallyLoc");if(hasCatch&&hasFinally){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}else if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else if(hasCatch){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}}else if(hasFinally){if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else{throw new Error("try statement without catch or finally")}}}},_findFinallyEntry:function(finallyLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc<=this.prev&&hasOwn.call(entry,"finallyLoc")&&(entry.finallyLoc===finallyLoc||this.prev<entry.finallyLoc)){return entry}}},abrupt:function(type,arg){var entry=this._findFinallyEntry();var record=entry?entry.completion:{};record.type=type;record.arg=arg;if(entry){this.next=entry.finallyLoc}else{this.complete(record)}return ContinueSentinel},complete:function(record){if(record.type==="throw"){throw record.arg}if(record.type==="break"||record.type==="continue"){this.next=record.arg}else if(record.type==="return"){this.rval=record.arg;this.next="end"}return ContinueSentinel},finish:function(finallyLoc){var entry=this._findFinallyEntry(finallyLoc);return this.complete(entry.completion)},"catch":function(tryLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc===tryLoc){var record=entry.completion;var thrown;if(record.type==="throw"){thrown=record.arg;resetTryEntry(entry,i)}return thrown}}throw new Error("illegal catch attempt")},delegateYield:function(iterable,resultName,nextLoc){this.delegate={iterator:values(iterable),resultName:resultName,nextLoc:nextLoc};return ContinueSentinel}}}).call(this,typeof global!=="undefined"?global:typeof self!=="undefined"?self:typeof window!=="undefined"?window:{})},{}],3:[function(require,module,exports){var process=module.exports={};process.nextTick=function(){var canSetImmediate=typeof window!=="undefined"&&window.setImmediate;var canMutationObserver=typeof window!=="undefined"&&window.MutationObserver;var canPost=typeof window!=="undefined"&&window.postMessage&&window.addEventListener;if(canSetImmediate){return function(f){return window.setImmediate(f)}}var queue=[];if(canMutationObserver){var hiddenDiv=document.createElement("div");var observer=new MutationObserver(function(){var queueList=queue.slice();queue.length=0;queueList.forEach(function(fn){fn()})});observer.observe(hiddenDiv,{attributes:true});return function nextTick(fn){if(!queue.length){hiddenDiv.setAttribute("yes","no")}queue.push(fn)}}if(canPost){window.addEventListener("message",function(ev){var source=ev.source;if((source===window||source===null)&&ev.data==="process-tick"){ev.stopPropagation();if(queue.length>0){var fn=queue.shift();fn()}}},true);return function nextTick(fn){queue.push(fn);window.postMessage("process-tick","*")}}return function nextTick(fn){setTimeout(fn,0)}}();process.title="browser";process.browser=true;process.env={};process.argv=[];function noop(){}process.on=noop;process.addListener=noop;process.once=noop;process.off=noop;process.removeListener=noop;process.removeAllListeners=noop;process.emit=noop;process.binding=function(name){throw new Error("process.binding is not supported")};process.cwd=function(){return"/"};process.chdir=function(dir){throw new Error("process.chdir is not supported")}},{}],4:[function(require,module,exports){(function(process){(function(root,factory){if(typeof define==="function"&&define.amd){define(factory)}else if(typeof exports==="object"){module.exports=factory()}else{root.returnExports=factory()}})(this,function(){"use strict";var isCallableWithoutNew=function(func){try{func()}catch(e){return false}return true};var supportsSubclassing=function(C,f){try{var Sub=function(){C.apply(this,arguments)};if(!Sub.__proto__){return false}Object.setPrototypeOf(Sub,C);Sub.prototype=Object.create(C.prototype,{constructor:{value:C}});return f(Sub)}catch(e){return false}};var arePropertyDescriptorsSupported=function(){try{Object.defineProperty({},"x",{});return true}catch(e){return false}};var startsWithRejectsRegex=function(){var rejectsRegex=false;if(String.prototype.startsWith){try{"/a/".startsWith(/a/)}catch(e){rejectsRegex=true}}return rejectsRegex};var getGlobal=new Function("return this;");var globals=getGlobal();var global_isFinite=globals.isFinite;var supportsDescriptors=!!Object.defineProperty&&arePropertyDescriptorsSupported();var startsWithIsCompliant=startsWithRejectsRegex();var _slice=Array.prototype.slice;var _indexOf=String.prototype.indexOf;var _toString=Object.prototype.toString;var _hasOwnProperty=Object.prototype.hasOwnProperty;var ArrayIterator;var defineProperty=function(object,name,value,force){if(!force&&name in object){return}if(supportsDescriptors){Object.defineProperty(object,name,{configurable:true,enumerable:false,writable:true,value:value})}else{object[name]=value}};var defineProperties=function(object,map){Object.keys(map).forEach(function(name){var method=map[name];defineProperty(object,name,method,false)})};var create=Object.create||function(prototype,properties){function Type(){}Type.prototype=prototype;var object=new Type;if(typeof properties!=="undefined"){defineProperties(object,properties)}return object};var $iterator$=typeof Symbol==="function"&&Symbol.iterator||"_es6shim_iterator_";if(globals.Set&&typeof(new globals.Set)["@@iterator"]==="function"){$iterator$="@@iterator"}var addIterator=function(prototype,impl){if(!impl){impl=function iterator(){return this}}var o={};o[$iterator$]=impl;defineProperties(prototype,o);if(!prototype[$iterator$]&&typeof $iterator$==="symbol"){prototype[$iterator$]=impl}};var isArguments=function isArguments(value){var str=_toString.call(value);var result=str==="[object Arguments]";if(!result){result=str!=="[object Array]"&&value!==null&&typeof value==="object"&&typeof value.length==="number"&&value.length>=0&&_toString.call(value.callee)==="[object Function]"}return result};var emulateES6construct=function(o){if(!ES.TypeIsObject(o)){throw new TypeError("bad object")}if(!o._es6construct){if(o.constructor&&ES.IsCallable(o.constructor["@@create"])){o=o.constructor["@@create"](o)}defineProperties(o,{_es6construct:true})}return o};var ES={CheckObjectCoercible:function(x,optMessage){if(x==null){throw new TypeError(optMessage||"Cannot call method on "+x)}return x},TypeIsObject:function(x){return x!=null&&Object(x)===x},ToObject:function(o,optMessage){return Object(ES.CheckObjectCoercible(o,optMessage))},IsCallable:function(x){return typeof x==="function"&&_toString.call(x)==="[object Function]"},ToInt32:function(x){return x>>0},ToUint32:function(x){return x>>>0},ToInteger:function(value){var number=+value;if(Number.isNaN(number)){return 0}if(number===0||!Number.isFinite(number)){return number}return(number>0?1:-1)*Math.floor(Math.abs(number))},ToLength:function(value){var len=ES.ToInteger(value);if(len<=0){return 0}if(len>Number.MAX_SAFE_INTEGER){return Number.MAX_SAFE_INTEGER}return len},SameValue:function(a,b){if(a===b){if(a===0){return 1/a===1/b}return true}return Number.isNaN(a)&&Number.isNaN(b)},SameValueZero:function(a,b){return a===b||Number.isNaN(a)&&Number.isNaN(b)},IsIterable:function(o){return ES.TypeIsObject(o)&&(typeof o[$iterator$]!=="undefined"||isArguments(o))},GetIterator:function(o){if(isArguments(o)){return new ArrayIterator(o,"value")}var it=o[$iterator$]();if(!ES.TypeIsObject(it)){throw new TypeError("bad iterator")}return it},IteratorNext:function(it){var result=arguments.length>1?it.next(arguments[1]):it.next();if(!ES.TypeIsObject(result)){throw new TypeError("bad iterator")}return result},Construct:function(C,args){var obj;if(ES.IsCallable(C["@@create"])){obj=C["@@create"]()}else{obj=create(C.prototype||null)}defineProperties(obj,{_es6construct:true});var result=C.apply(obj,args);return ES.TypeIsObject(result)?result:obj}};var numberConversion=function(){function roundToEven(n){var w=Math.floor(n),f=n-w;if(f<.5){return w}if(f>.5){return w+1}return w%2?w+1:w}function packIEEE754(v,ebits,fbits){var bias=(1<<ebits-1)-1,s,e,f,ln,i,bits,str,bytes;if(v!==v){e=(1<<ebits)-1;f=Math.pow(2,fbits-1);s=0}else if(v===Infinity||v===-Infinity){e=(1<<ebits)-1;f=0;s=v<0?1:0}else if(v===0){e=0;f=0;s=1/v===-Infinity?1:0}else{s=v<0;v=Math.abs(v);if(v>=Math.pow(2,1-bias)){e=Math.min(Math.floor(Math.log(v)/Math.LN2),1023);f=roundToEven(v/Math.pow(2,e)*Math.pow(2,fbits));if(f/Math.pow(2,fbits)>=2){e=e+1;f=1}if(e>bias){e=(1<<ebits)-1;f=0}else{e=e+bias;f=f-Math.pow(2,fbits)}}else{e=0;f=roundToEven(v/Math.pow(2,1-bias-fbits))}}bits=[];for(i=fbits;i;i-=1){bits.push(f%2?1:0);f=Math.floor(f/2)}for(i=ebits;i;i-=1){bits.push(e%2?1:0);e=Math.floor(e/2)}bits.push(s?1:0);bits.reverse();str=bits.join("");bytes=[];while(str.length){bytes.push(parseInt(str.slice(0,8),2));str=str.slice(8)}return bytes}function unpackIEEE754(bytes,ebits,fbits){var bits=[],i,j,b,str,bias,s,e,f;for(i=bytes.length;i;i-=1){b=bytes[i-1];for(j=8;j;j-=1){bits.push(b%2?1:0);b=b>>1}}bits.reverse();str=bits.join("");bias=(1<<ebits-1)-1;s=parseInt(str.slice(0,1),2)?-1:1;e=parseInt(str.slice(1,1+ebits),2);f=parseInt(str.slice(1+ebits),2);if(e===(1<<ebits)-1){return f!==0?NaN:s*Infinity}else if(e>0){return s*Math.pow(2,e-bias)*(1+f/Math.pow(2,fbits))}else if(f!==0){return s*Math.pow(2,-(bias-1))*(f/Math.pow(2,fbits))}else{return s<0?-0:0}}function unpackFloat64(b){return unpackIEEE754(b,11,52)}function packFloat64(v){return packIEEE754(v,11,52)}function unpackFloat32(b){return unpackIEEE754(b,8,23)}function packFloat32(v){return packIEEE754(v,8,23)}var conversions={toFloat32:function(num){return unpackFloat32(packFloat32(num))}};if(typeof Float32Array!=="undefined"){var float32array=new Float32Array(1);conversions.toFloat32=function(num){float32array[0]=num;return float32array[0]}}return conversions}();defineProperties(String,{fromCodePoint:function(_){var points=_slice.call(arguments,0,arguments.length);var result=[];var next;for(var i=0,length=points.length;i<length;i++){next=Number(points[i]);if(!ES.SameValue(next,ES.ToInteger(next))||next<0||next>1114111){throw new RangeError("Invalid code point "+next)}if(next<65536){result.push(String.fromCharCode(next))}else{next-=65536;result.push(String.fromCharCode((next>>10)+55296));result.push(String.fromCharCode(next%1024+56320))}}return result.join("")},raw:function(callSite){var substitutions=_slice.call(arguments,1,arguments.length);var cooked=ES.ToObject(callSite,"bad callSite");var rawValue=cooked.raw;var raw=ES.ToObject(rawValue,"bad raw value");var len=Object.keys(raw).length;var literalsegments=ES.ToLength(len);if(literalsegments===0){return""}var stringElements=[];var nextIndex=0;var nextKey,next,nextSeg,nextSub;while(nextIndex<literalsegments){nextKey=String(nextIndex);next=raw[nextKey];nextSeg=String(next);stringElements.push(nextSeg);if(nextIndex+1>=literalsegments){break}next=substitutions[nextKey];if(typeof next==="undefined"){break}nextSub=String(next);stringElements.push(nextSub);nextIndex++}return stringElements.join("")}});if(String.fromCodePoint.length!==1){var originalFromCodePoint=String.fromCodePoint;defineProperty(String,"fromCodePoint",function(_){return originalFromCodePoint.apply(this,arguments)},true)}var StringShims={repeat:function(){var repeat=function(s,times){if(times<1){return""}if(times%2){return repeat(s,times-1)+s}var half=repeat(s,times/2);return half+half};return function(times){var thisStr=String(ES.CheckObjectCoercible(this));times=ES.ToInteger(times);if(times<0||times===Infinity){throw new RangeError("Invalid String#repeat value")}return repeat(thisStr,times)}}(),startsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "startsWith" with a regex')}searchStr=String(searchStr);var startArg=arguments.length>1?arguments[1]:void 0;var start=Math.max(ES.ToInteger(startArg),0);return thisStr.slice(start,start+searchStr.length)===searchStr},endsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "endsWith" with a regex')}searchStr=String(searchStr);var thisLen=thisStr.length;var posArg=arguments.length>1?arguments[1]:void 0;var pos=typeof posArg==="undefined"?thisLen:ES.ToInteger(posArg);var end=Math.min(Math.max(pos,0),thisLen);return thisStr.slice(end-searchStr.length,end)===searchStr},contains:function(searchString){var position=arguments.length>1?arguments[1]:void 0;return _indexOf.call(this,searchString,position)!==-1},codePointAt:function(pos){var thisStr=String(ES.CheckObjectCoercible(this));var position=ES.ToInteger(pos);var length=thisStr.length;if(position<0||position>=length){return}var first=thisStr.charCodeAt(position);var isEnd=position+1===length;if(first<55296||first>56319||isEnd){return first}var second=thisStr.charCodeAt(position+1);if(second<56320||second>57343){return first}return(first-55296)*1024+(second-56320)+65536}};defineProperties(String.prototype,StringShims);var hasStringTrimBug="".trim().length!==1;if(hasStringTrimBug){var originalStringTrim=String.prototype.trim;delete String.prototype.trim;var ws=["  \n\f\r   ᠎    ","         　\u2028","\u2029﻿"].join("");var trimRegexp=new RegExp("(^["+ws+"]+)|(["+ws+"]+$)","g");defineProperties(String.prototype,{trim:function(){if(typeof this==="undefined"||this===null){throw new TypeError("can't convert "+this+" to object")}return String(this).replace(trimRegexp,"")}})}var StringIterator=function(s){this._s=String(ES.CheckObjectCoercible(s));this._i=0};StringIterator.prototype.next=function(){var s=this._s,i=this._i;if(typeof s==="undefined"||i>=s.length){this._s=void 0;return{value:void 0,done:true}}var first=s.charCodeAt(i),second,len;if(first<55296||first>56319||i+1==s.length){len=1}else{second=s.charCodeAt(i+1);len=second<56320||second>57343?1:2}this._i=i+len;return{value:s.substr(i,len),done:false}};addIterator(StringIterator.prototype);addIterator(String.prototype,function(){return new StringIterator(this)});if(!startsWithIsCompliant){String.prototype.startsWith=StringShims.startsWith;String.prototype.endsWith=StringShims.endsWith}var ArrayShims={from:function(iterable){var mapFn=arguments.length>1?arguments[1]:void 0;var list=ES.ToObject(iterable,"bad iterable");if(typeof mapFn!=="undefined"&&!ES.IsCallable(mapFn)){throw new TypeError("Array.from: when provided, the second argument must be a function")}var hasThisArg=arguments.length>2;var thisArg=hasThisArg?arguments[2]:void 0;var usingIterator=ES.IsIterable(list);var length;var result,i,value;if(usingIterator){i=0;result=ES.IsCallable(this)?Object(new this):[];var it=usingIterator?ES.GetIterator(list):null;var iterationValue;do{iterationValue=ES.IteratorNext(it);if(!iterationValue.done){value=iterationValue.value;if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}i+=1}}while(!iterationValue.done);length=i}else{length=ES.ToLength(list.length);result=ES.IsCallable(this)?Object(new this(length)):new Array(length);for(i=0;i<length;++i){value=list[i];if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}}}result.length=length;return result},of:function(){return Array.from(arguments)}};defineProperties(Array,ArrayShims);var arrayFromSwallowsNegativeLengths=function(){try{return Array.from({length:-1}).length===0}catch(e){return false}};if(!arrayFromSwallowsNegativeLengths()){defineProperty(Array,"from",ArrayShims.from,true)}ArrayIterator=function(array,kind){this.i=0;this.array=array;this.kind=kind};defineProperties(ArrayIterator.prototype,{next:function(){var i=this.i,array=this.array;if(!(this instanceof ArrayIterator)){throw new TypeError("Not an ArrayIterator")}if(typeof array!=="undefined"){var len=ES.ToLength(array.length);for(;i<len;i++){var kind=this.kind;var retval;if(kind==="key"){retval=i}else if(kind==="value"){retval=array[i]}else if(kind==="entry"){retval=[i,array[i]]}this.i=i+1;return{value:retval,done:false}}}this.array=void 0;return{value:void 0,done:true}}});addIterator(ArrayIterator.prototype);var ArrayPrototypeShims={copyWithin:function(target,start){var end=arguments[2];var o=ES.ToObject(this);var len=ES.ToLength(o.length);target=ES.ToInteger(target);start=ES.ToInteger(start);var to=target<0?Math.max(len+target,0):Math.min(target,len);var from=start<0?Math.max(len+start,0):Math.min(start,len);end=typeof end==="undefined"?len:ES.ToInteger(end);var fin=end<0?Math.max(len+end,0):Math.min(end,len);var count=Math.min(fin-from,len-to);var direction=1;if(from<to&&to<from+count){direction=-1;from+=count-1;to+=count-1}while(count>0){if(_hasOwnProperty.call(o,from)){o[to]=o[from]}else{delete o[from]}from+=direction;to+=direction;count-=1}return o},fill:function(value){var start=arguments.length>1?arguments[1]:void 0;var end=arguments.length>2?arguments[2]:void 0;var O=ES.ToObject(this);var len=ES.ToLength(O.length);start=ES.ToInteger(typeof start==="undefined"?0:start);end=ES.ToInteger(typeof end==="undefined"?len:end);var relativeStart=start<0?Math.max(len+start,0):Math.min(start,len);var relativeEnd=end<0?len+end:end;for(var i=relativeStart;i<len&&i<relativeEnd;++i){O[i]=value}return O},find:function find(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#find: predicate must be a function")}var thisArg=arguments[1];for(var i=0,value;i<length;i++){value=list[i];if(predicate.call(thisArg,value,i,list)){return value}}return},findIndex:function findIndex(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#findIndex: predicate must be a function")}var thisArg=arguments[1];for(var i=0;i<length;i++){if(predicate.call(thisArg,list[i],i,list)){return i}}return-1},keys:function(){return new ArrayIterator(this,"key")},values:function(){return new ArrayIterator(this,"value")},entries:function(){return new ArrayIterator(this,"entry")}};if(Array.prototype.keys&&!ES.IsCallable([1].keys().next)){delete Array.prototype.keys}if(Array.prototype.entries&&!ES.IsCallable([1].entries().next)){delete Array.prototype.entries}defineProperties(Array.prototype,ArrayPrototypeShims);addIterator(Array.prototype,function(){return this.values()});if(Object.getPrototypeOf){addIterator(Object.getPrototypeOf([].values()))}var maxSafeInteger=Math.pow(2,53)-1;defineProperties(Number,{MAX_SAFE_INTEGER:maxSafeInteger,MIN_SAFE_INTEGER:-maxSafeInteger,EPSILON:2.220446049250313e-16,parseInt:globals.parseInt,parseFloat:globals.parseFloat,isFinite:function(value){return typeof value==="number"&&global_isFinite(value)},isInteger:function(value){return Number.isFinite(value)&&ES.ToInteger(value)===value},isSafeInteger:function(value){return Number.isInteger(value)&&Math.abs(value)<=Number.MAX_SAFE_INTEGER},isNaN:function(value){return value!==value}});if(![,1].find(function(item,idx){return idx===0})){defineProperty(Array.prototype,"find",ArrayPrototypeShims.find,true)}if([,1].findIndex(function(item,idx){return idx===0})!==0){defineProperty(Array.prototype,"findIndex",ArrayPrototypeShims.findIndex,true)}if(supportsDescriptors){defineProperties(Object,{getPropertyDescriptor:function(subject,name){var pd=Object.getOwnPropertyDescriptor(subject,name);var proto=Object.getPrototypeOf(subject);while(typeof pd==="undefined"&&proto!==null){pd=Object.getOwnPropertyDescriptor(proto,name);proto=Object.getPrototypeOf(proto)}return pd},getPropertyNames:function(subject){var result=Object.getOwnPropertyNames(subject);var proto=Object.getPrototypeOf(subject);var addProperty=function(property){if(result.indexOf(property)===-1){result.push(property)}};while(proto!==null){Object.getOwnPropertyNames(proto).forEach(addProperty);proto=Object.getPrototypeOf(proto)}return result}});defineProperties(Object,{assign:function(target,source){if(!ES.TypeIsObject(target)){throw new TypeError("target must be an object")}return Array.prototype.reduce.call(arguments,function(target,source){return Object.keys(Object(source)).reduce(function(target,key){target[key]=source[key];return target},target)})},is:function(a,b){return ES.SameValue(a,b)},setPrototypeOf:function(Object,magic){var set;var checkArgs=function(O,proto){if(!ES.TypeIsObject(O)){throw new TypeError("cannot set prototype on a non-object")}if(!(proto===null||ES.TypeIsObject(proto))){throw new TypeError("can only set prototype to an object or null"+proto)}};var setPrototypeOf=function(O,proto){checkArgs(O,proto);set.call(O,proto);return O};try{set=Object.getOwnPropertyDescriptor(Object.prototype,magic).set;set.call({},null)}catch(e){if(Object.prototype!=={}[magic]){return}set=function(proto){this[magic]=proto};setPrototypeOf.polyfill=setPrototypeOf(setPrototypeOf({},null),Object.prototype)instanceof Object}return setPrototypeOf}(Object,"__proto__")})}if(Object.setPrototypeOf&&Object.getPrototypeOf&&Object.getPrototypeOf(Object.setPrototypeOf({},null))!==null&&Object.getPrototypeOf(Object.create(null))===null){(function(){var FAKENULL=Object.create(null);var gpo=Object.getPrototypeOf,spo=Object.setPrototypeOf;Object.getPrototypeOf=function(o){var result=gpo(o);return result===FAKENULL?null:result};Object.setPrototypeOf=function(o,p){if(p===null){p=FAKENULL}return spo(o,p)};Object.setPrototypeOf.polyfill=false})()}try{Object.keys("foo")}catch(e){var originalObjectKeys=Object.keys;Object.keys=function(obj){return originalObjectKeys(ES.ToObject(obj))}}var MathShims={acosh:function(value){value=Number(value);if(Number.isNaN(value)||value<1){return NaN}if(value===1){return 0}if(value===Infinity){return value}return Math.log(value+Math.sqrt(value*value-1))},asinh:function(value){value=Number(value);if(value===0||!global_isFinite(value)){return value}return value<0?-Math.asinh(-value):Math.log(value+Math.sqrt(value*value+1))},atanh:function(value){value=Number(value);if(Number.isNaN(value)||value<-1||value>1){return NaN}if(value===-1){return-Infinity}if(value===1){return Infinity}if(value===0){return value}return.5*Math.log((1+value)/(1-value))},cbrt:function(value){value=Number(value);if(value===0){return value}var negate=value<0,result;if(negate){value=-value}result=Math.pow(value,1/3);return negate?-result:result},clz32:function(value){value=Number(value);var number=ES.ToUint32(value);if(number===0){return 32}return 32-number.toString(2).length},cosh:function(value){value=Number(value);if(value===0){return 1}if(Number.isNaN(value)){return NaN}if(!global_isFinite(value)){return Infinity}if(value<0){value=-value}if(value>21){return Math.exp(value)/2}return(Math.exp(value)+Math.exp(-value))/2},expm1:function(value){value=Number(value);if(value===-Infinity){return-1}if(!global_isFinite(value)||value===0){return value}return Math.exp(value)-1},hypot:function(x,y){var anyNaN=false;var allZero=true;var anyInfinity=false;var numbers=[];Array.prototype.every.call(arguments,function(arg){var num=Number(arg);if(Number.isNaN(num)){anyNaN=true}else if(num===Infinity||num===-Infinity){anyInfinity=true}else if(num!==0){allZero=false}if(anyInfinity){return false}else if(!anyNaN){numbers.push(Math.abs(num))}return true});if(anyInfinity){return Infinity}if(anyNaN){return NaN}if(allZero){return 0}numbers.sort(function(a,b){return b-a});var largest=numbers[0];var divided=numbers.map(function(number){return number/largest});var sum=divided.reduce(function(sum,number){return sum+=number*number},0);return largest*Math.sqrt(sum)},log2:function(value){return Math.log(value)*Math.LOG2E},log10:function(value){return Math.log(value)*Math.LOG10E},log1p:function(value){value=Number(value);if(value<-1||Number.isNaN(value)){return NaN}if(value===0||value===Infinity){return value}if(value===-1){return-Infinity}var result=0;var n=50;if(value<0||value>1){return Math.log(1+value)}for(var i=1;i<n;i++){if(i%2===0){result-=Math.pow(value,i)/i}else{result+=Math.pow(value,i)/i}}return result},sign:function(value){var number=+value;if(number===0){return number}if(Number.isNaN(number)){return number}return number<0?-1:1},sinh:function(value){value=Number(value);if(!global_isFinite(value)||value===0){return value}return(Math.exp(value)-Math.exp(-value))/2},tanh:function(value){value=Number(value);if(Number.isNaN(value)||value===0){return value}if(value===Infinity){return 1}if(value===-Infinity){return-1}return(Math.exp(value)-Math.exp(-value))/(Math.exp(value)+Math.exp(-value))},trunc:function(value){var number=Number(value);return number<0?-Math.floor(-number):Math.floor(number)},imul:function(x,y){x=ES.ToUint32(x);y=ES.ToUint32(y);var ah=x>>>16&65535;var al=x&65535;var bh=y>>>16&65535;var bl=y&65535;return al*bl+(ah*bl+al*bh<<16>>>0)|0},fround:function(x){if(x===0||x===Infinity||x===-Infinity||Number.isNaN(x)){return x}var num=Number(x);return numberConversion.toFloat32(num)}};defineProperties(Math,MathShims);if(Math.imul(4294967295,5)!==-5){Math.imul=MathShims.imul}var PromiseShim=function(){var Promise,Promise$prototype;ES.IsPromise=function(promise){if(!ES.TypeIsObject(promise)){return false}if(!promise._promiseConstructor){return false}if(typeof promise._status==="undefined"){return false}return true};var PromiseCapability=function(C){if(!ES.IsCallable(C)){throw new TypeError("bad promise constructor")}var capability=this;var resolver=function(resolve,reject){capability.resolve=resolve;capability.reject=reject};capability.promise=ES.Construct(C,[resolver]);if(!capability.promise._es6construct){throw new TypeError("bad promise constructor")}if(!(ES.IsCallable(capability.resolve)&&ES.IsCallable(capability.reject))){throw new TypeError("bad promise constructor")}};var setTimeout=globals.setTimeout;var makeZeroTimeout;if(typeof window!=="undefined"&&ES.IsCallable(window.postMessage)){makeZeroTimeout=function(){var timeouts=[];var messageName="zero-timeout-message";var setZeroTimeout=function(fn){timeouts.push(fn);window.postMessage(messageName,"*")};var handleMessage=function(event){if(event.source==window&&event.data==messageName){event.stopPropagation();
+    <script>(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){if(typeof Symbol==="undefined"){require("es6-symbol/implement")}require("es6-shim");require("./transformation/transformers/generators/runtime")},{"./transformation/transformers/generators/runtime":2,"es6-shim":4,"es6-symbol/implement":5}],2:[function(require,module,exports){(function(global){if(typeof global.regeneratorRuntime==="object"){return}var hasOwn=Object.prototype.hasOwnProperty;var iteratorSymbol=typeof Symbol==="function"&&Symbol.iterator||"@@iterator";var runtime=global.regeneratorRuntime=exports;var wrap=runtime.wrap=function wrap(innerFn,outerFn,self,tryList){return new Generator(innerFn,outerFn,self||null,tryList||[])};var GenStateSuspendedStart="suspendedStart";var GenStateSuspendedYield="suspendedYield";var GenStateExecuting="executing";var GenStateCompleted="completed";var ContinueSentinel={};var GF=function GeneratorFunction(){};var GFp=function GeneratorFunctionPrototype(){};var Gp=GFp.prototype=Generator.prototype;(GFp.constructor=GF).prototype=Gp.constructor=GFp;var GFName="GeneratorFunction";if(GF.name!==GFName)GF.name=GFName;if(GF.name!==GFName)throw new Error(GFName+" renamed?");runtime.isGeneratorFunction=function(genFun){var ctor=genFun&&genFun.constructor;return ctor?GF.name===ctor.name:false};runtime.mark=function(genFun){genFun.__proto__=GFp;genFun.prototype=Object.create(Gp);return genFun};runtime.async=function(innerFn,outerFn,self,tryList){return new Promise(function(resolve,reject){var generator=wrap(innerFn,outerFn,self,tryList);var callNext=step.bind(generator.next);var callThrow=step.bind(generator["throw"]);function step(arg){var info;var value;try{info=this(arg);value=info.value}catch(error){return reject(error)}if(info.done){resolve(value)}else{Promise.resolve(value).then(callNext,callThrow)}}callNext()})};function Generator(innerFn,outerFn,self,tryList){var generator=outerFn?Object.create(outerFn.prototype):this;var context=new Context(tryList);var state=GenStateSuspendedStart;function invoke(method,arg){if(state===GenStateExecuting){throw new Error("Generator is already running")}if(state===GenStateCompleted){throw new Error("Generator has already finished")}while(true){var delegate=context.delegate;var info;if(delegate){try{info=delegate.iterator[method](arg);method="next";arg=undefined}catch(uncaught){context.delegate=null;method="throw";arg=uncaught;continue}if(info.done){context[delegate.resultName]=info.value;context.next=delegate.nextLoc}else{state=GenStateSuspendedYield;return info}context.delegate=null}if(method==="next"){if(state===GenStateSuspendedStart&&typeof arg!=="undefined"){throw new TypeError("attempt to send "+JSON.stringify(arg)+" to newborn generator")}if(state===GenStateSuspendedYield){context.sent=arg}else{delete context.sent}}else if(method==="throw"){if(state===GenStateSuspendedStart){state=GenStateCompleted;throw arg}if(context.dispatchException(arg)){method="next";arg=undefined}}else if(method==="return"){context.abrupt("return",arg)}state=GenStateExecuting;try{var value=innerFn.call(self,context);state=context.done?GenStateCompleted:GenStateSuspendedYield;info={value:value,done:context.done};if(value===ContinueSentinel){if(context.delegate&&method==="next"){arg=undefined}}else{return info}}catch(thrown){state=GenStateCompleted;if(method==="next"){context.dispatchException(thrown)}else{arg=thrown}}}}generator.next=invoke.bind(generator,"next");generator["throw"]=invoke.bind(generator,"throw");generator["return"]=invoke.bind(generator,"return");return generator}Gp[iteratorSymbol]=function(){return this};Gp.toString=function(){return"[object Generator]"};function pushTryEntry(triple){var entry={tryLoc:triple[0]};if(1 in triple){entry.catchLoc=triple[1]}if(2 in triple){entry.finallyLoc=triple[2]}this.tryEntries.push(entry)}function resetTryEntry(entry,i){var record=entry.completion||{};record.type=i===0?"normal":"return";delete record.arg;entry.completion=record}function Context(tryList){this.tryEntries=[{tryLoc:"root"}];tryList.forEach(pushTryEntry,this);this.reset()}runtime.keys=function(object){var keys=[];for(var key in object){keys.push(key)}keys.reverse();return function next(){while(keys.length){var key=keys.pop();if(key in object){next.value=key;next.done=false;return next}}next.done=true;return next}};function values(iterable){var iterator=iterable;if(iteratorSymbol in iterable){iterator=iterable[iteratorSymbol]()}else if(!isNaN(iterable.length)){var i=-1;iterator=function next(){while(++i<iterable.length){if(i in iterable){next.value=iterable[i];next.done=false;return next}}next.done=true;return next};iterator.next=iterator}return iterator}runtime.values=values;Context.prototype={constructor:Context,reset:function(){this.prev=0;this.next=0;this.sent=undefined;this.done=false;this.delegate=null;this.tryEntries.forEach(resetTryEntry);for(var tempIndex=0,tempName;hasOwn.call(this,tempName="t"+tempIndex)||tempIndex<20;++tempIndex){this[tempName]=null}},stop:function(){this.done=true;var rootEntry=this.tryEntries[0];var rootRecord=rootEntry.completion;if(rootRecord.type==="throw"){throw rootRecord.arg}return this.rval},dispatchException:function(exception){if(this.done){throw exception}var context=this;function handle(loc,caught){record.type="throw";record.arg=exception;context.next=loc;return!!caught}for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];var record=entry.completion;if(entry.tryLoc==="root"){return handle("end")}if(entry.tryLoc<=this.prev){var hasCatch=hasOwn.call(entry,"catchLoc");var hasFinally=hasOwn.call(entry,"finallyLoc");if(hasCatch&&hasFinally){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}else if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else if(hasCatch){if(this.prev<entry.catchLoc){return handle(entry.catchLoc,true)}}else if(hasFinally){if(this.prev<entry.finallyLoc){return handle(entry.finallyLoc)}}else{throw new Error("try statement without catch or finally")}}}},_findFinallyEntry:function(finallyLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc<=this.prev&&hasOwn.call(entry,"finallyLoc")&&(entry.finallyLoc===finallyLoc||this.prev<entry.finallyLoc)){return entry}}},abrupt:function(type,arg){var entry=this._findFinallyEntry();var record=entry?entry.completion:{};record.type=type;record.arg=arg;if(entry){this.next=entry.finallyLoc}else{this.complete(record)}return ContinueSentinel},complete:function(record){if(record.type==="throw"){throw record.arg}if(record.type==="break"||record.type==="continue"){this.next=record.arg}else if(record.type==="return"){this.rval=record.arg;this.next="end"}return ContinueSentinel},finish:function(finallyLoc){var entry=this._findFinallyEntry(finallyLoc);return this.complete(entry.completion)},"catch":function(tryLoc){for(var i=this.tryEntries.length-1;i>=0;--i){var entry=this.tryEntries[i];if(entry.tryLoc===tryLoc){var record=entry.completion;var thrown;if(record.type==="throw"){thrown=record.arg;resetTryEntry(entry,i)}return thrown}}throw new Error("illegal catch attempt")},delegateYield:function(iterable,resultName,nextLoc){this.delegate={iterator:values(iterable),resultName:resultName,nextLoc:nextLoc};return ContinueSentinel}}}).call(this,typeof global!=="undefined"?global:typeof self!=="undefined"?self:typeof window!=="undefined"?window:{})},{}],3:[function(require,module,exports){var process=module.exports={};process.nextTick=function(){var canSetImmediate=typeof window!=="undefined"&&window.setImmediate;var canMutationObserver=typeof window!=="undefined"&&window.MutationObserver;var canPost=typeof window!=="undefined"&&window.postMessage&&window.addEventListener;if(canSetImmediate){return function(f){return window.setImmediate(f)}}var queue=[];if(canMutationObserver){var hiddenDiv=document.createElement("div");var observer=new MutationObserver(function(){var queueList=queue.slice();queue.length=0;queueList.forEach(function(fn){fn()})});observer.observe(hiddenDiv,{attributes:true});return function nextTick(fn){if(!queue.length){hiddenDiv.setAttribute("yes","no")}queue.push(fn)}}if(canPost){window.addEventListener("message",function(ev){var source=ev.source;if((source===window||source===null)&&ev.data==="process-tick"){ev.stopPropagation();if(queue.length>0){var fn=queue.shift();fn()}}},true);return function nextTick(fn){queue.push(fn);window.postMessage("process-tick","*")}}return function nextTick(fn){setTimeout(fn,0)}}();process.title="browser";process.browser=true;process.env={};process.argv=[];function noop(){}process.on=noop;process.addListener=noop;process.once=noop;process.off=noop;process.removeListener=noop;process.removeAllListeners=noop;process.emit=noop;process.binding=function(name){throw new Error("process.binding is not supported")};process.cwd=function(){return"/"};process.chdir=function(dir){throw new Error("process.chdir is not supported")}},{}],4:[function(require,module,exports){(function(process){(function(root,factory){if(typeof define==="function"&&define.amd){define(factory)}else if(typeof exports==="object"){module.exports=factory()}else{root.returnExports=factory()}})(this,function(){"use strict";var isCallableWithoutNew=function(func){try{func()}catch(e){return false}return true};var supportsSubclassing=function(C,f){try{var Sub=function(){C.apply(this,arguments)};if(!Sub.__proto__){return false}Object.setPrototypeOf(Sub,C);Sub.prototype=Object.create(C.prototype,{constructor:{value:C}});return f(Sub)}catch(e){return false}};var arePropertyDescriptorsSupported=function(){try{Object.defineProperty({},"x",{});return true}catch(e){return false}};var startsWithRejectsRegex=function(){var rejectsRegex=false;if(String.prototype.startsWith){try{"/a/".startsWith(/a/)}catch(e){rejectsRegex=true}}return rejectsRegex};var getGlobal=new Function("return this;");var globals=getGlobal();var global_isFinite=globals.isFinite;var supportsDescriptors=!!Object.defineProperty&&arePropertyDescriptorsSupported();var startsWithIsCompliant=startsWithRejectsRegex();var _slice=Array.prototype.slice;var _indexOf=String.prototype.indexOf;var _toString=Object.prototype.toString;var _hasOwnProperty=Object.prototype.hasOwnProperty;var ArrayIterator;var defineProperty=function(object,name,value,force){if(!force&&name in object){return}if(supportsDescriptors){Object.defineProperty(object,name,{configurable:true,enumerable:false,writable:true,value:value})}else{object[name]=value}};var defineProperties=function(object,map){Object.keys(map).forEach(function(name){var method=map[name];defineProperty(object,name,method,false)})};var create=Object.create||function(prototype,properties){function Type(){}Type.prototype=prototype;var object=new Type;if(typeof properties!=="undefined"){defineProperties(object,properties)}return object};var $iterator$=typeof Symbol==="function"&&Symbol.iterator||"_es6shim_iterator_";if(globals.Set&&typeof(new globals.Set)["@@iterator"]==="function"){$iterator$="@@iterator"}var addIterator=function(prototype,impl){if(!impl){impl=function iterator(){return this}}var o={};o[$iterator$]=impl;defineProperties(prototype,o);if(!prototype[$iterator$]&&typeof $iterator$==="symbol"){prototype[$iterator$]=impl}};var isArguments=function isArguments(value){var str=_toString.call(value);var result=str==="[object Arguments]";if(!result){result=str!=="[object Array]"&&value!==null&&typeof value==="object"&&typeof value.length==="number"&&value.length>=0&&_toString.call(value.callee)==="[object Function]"}return result};var emulateES6construct=function(o){if(!ES.TypeIsObject(o)){throw new TypeError("bad object")}if(!o._es6construct){if(o.constructor&&ES.IsCallable(o.constructor["@@create"])){o=o.constructor["@@create"](o)}defineProperties(o,{_es6construct:true})}return o};var ES={CheckObjectCoercible:function(x,optMessage){if(x==null){throw new TypeError(optMessage||"Cannot call method on "+x)}return x},TypeIsObject:function(x){return x!=null&&Object(x)===x},ToObject:function(o,optMessage){return Object(ES.CheckObjectCoercible(o,optMessage))},IsCallable:function(x){return typeof x==="function"&&_toString.call(x)==="[object Function]"},ToInt32:function(x){return x>>0},ToUint32:function(x){return x>>>0},ToInteger:function(value){var number=+value;if(Number.isNaN(number)){return 0}if(number===0||!Number.isFinite(number)){return number}return(number>0?1:-1)*Math.floor(Math.abs(number))},ToLength:function(value){var len=ES.ToInteger(value);if(len<=0){return 0}if(len>Number.MAX_SAFE_INTEGER){return Number.MAX_SAFE_INTEGER}return len},SameValue:function(a,b){if(a===b){if(a===0){return 1/a===1/b}return true}return Number.isNaN(a)&&Number.isNaN(b)},SameValueZero:function(a,b){return a===b||Number.isNaN(a)&&Number.isNaN(b)},IsIterable:function(o){return ES.TypeIsObject(o)&&(typeof o[$iterator$]!=="undefined"||isArguments(o))},GetIterator:function(o){if(isArguments(o)){return new ArrayIterator(o,"value")}var it=o[$iterator$]();if(!ES.TypeIsObject(it)){throw new TypeError("bad iterator")}return it},IteratorNext:function(it){var result=arguments.length>1?it.next(arguments[1]):it.next();if(!ES.TypeIsObject(result)){throw new TypeError("bad iterator")}return result},Construct:function(C,args){var obj;if(ES.IsCallable(C["@@create"])){obj=C["@@create"]()}else{obj=create(C.prototype||null)}defineProperties(obj,{_es6construct:true});var result=C.apply(obj,args);return ES.TypeIsObject(result)?result:obj}};var numberConversion=function(){function roundToEven(n){var w=Math.floor(n),f=n-w;if(f<.5){return w}if(f>.5){return w+1}return w%2?w+1:w}function packIEEE754(v,ebits,fbits){var bias=(1<<ebits-1)-1,s,e,f,ln,i,bits,str,bytes;if(v!==v){e=(1<<ebits)-1;f=Math.pow(2,fbits-1);s=0}else if(v===Infinity||v===-Infinity){e=(1<<ebits)-1;f=0;s=v<0?1:0}else if(v===0){e=0;f=0;s=1/v===-Infinity?1:0}else{s=v<0;v=Math.abs(v);if(v>=Math.pow(2,1-bias)){e=Math.min(Math.floor(Math.log(v)/Math.LN2),1023);f=roundToEven(v/Math.pow(2,e)*Math.pow(2,fbits));if(f/Math.pow(2,fbits)>=2){e=e+1;f=1}if(e>bias){e=(1<<ebits)-1;f=0}else{e=e+bias;f=f-Math.pow(2,fbits)}}else{e=0;f=roundToEven(v/Math.pow(2,1-bias-fbits))}}bits=[];for(i=fbits;i;i-=1){bits.push(f%2?1:0);f=Math.floor(f/2)}for(i=ebits;i;i-=1){bits.push(e%2?1:0);e=Math.floor(e/2)}bits.push(s?1:0);bits.reverse();str=bits.join("");bytes=[];while(str.length){bytes.push(parseInt(str.slice(0,8),2));str=str.slice(8)}return bytes}function unpackIEEE754(bytes,ebits,fbits){var bits=[],i,j,b,str,bias,s,e,f;for(i=bytes.length;i;i-=1){b=bytes[i-1];for(j=8;j;j-=1){bits.push(b%2?1:0);b=b>>1}}bits.reverse();str=bits.join("");bias=(1<<ebits-1)-1;s=parseInt(str.slice(0,1),2)?-1:1;e=parseInt(str.slice(1,1+ebits),2);f=parseInt(str.slice(1+ebits),2);if(e===(1<<ebits)-1){return f!==0?NaN:s*Infinity}else if(e>0){return s*Math.pow(2,e-bias)*(1+f/Math.pow(2,fbits))}else if(f!==0){return s*Math.pow(2,-(bias-1))*(f/Math.pow(2,fbits))}else{return s<0?-0:0}}function unpackFloat64(b){return unpackIEEE754(b,11,52)}function packFloat64(v){return packIEEE754(v,11,52)}function unpackFloat32(b){return unpackIEEE754(b,8,23)}function packFloat32(v){return packIEEE754(v,8,23)}var conversions={toFloat32:function(num){return unpackFloat32(packFloat32(num))}};if(typeof Float32Array!=="undefined"){var float32array=new Float32Array(1);conversions.toFloat32=function(num){float32array[0]=num;return float32array[0]}}return conversions}();defineProperties(String,{fromCodePoint:function(_){var points=_slice.call(arguments,0,arguments.length);var result=[];var next;for(var i=0,length=points.length;i<length;i++){next=Number(points[i]);if(!ES.SameValue(next,ES.ToInteger(next))||next<0||next>1114111){throw new RangeError("Invalid code point "+next)}if(next<65536){result.push(String.fromCharCode(next))}else{next-=65536;result.push(String.fromCharCode((next>>10)+55296));result.push(String.fromCharCode(next%1024+56320))}}return result.join("")},raw:function(callSite){var substitutions=_slice.call(arguments,1,arguments.length);var cooked=ES.ToObject(callSite,"bad callSite");var rawValue=cooked.raw;var raw=ES.ToObject(rawValue,"bad raw value");var len=Object.keys(raw).length;var literalsegments=ES.ToLength(len);if(literalsegments===0){return""}var stringElements=[];var nextIndex=0;var nextKey,next,nextSeg,nextSub;while(nextIndex<literalsegments){nextKey=String(nextIndex);next=raw[nextKey];nextSeg=String(next);stringElements.push(nextSeg);if(nextIndex+1>=literalsegments){break}next=substitutions[nextKey];if(typeof next==="undefined"){break}nextSub=String(next);stringElements.push(nextSub);nextIndex++}return stringElements.join("")}});if(String.fromCodePoint.length!==1){var originalFromCodePoint=String.fromCodePoint;defineProperty(String,"fromCodePoint",function(_){return originalFromCodePoint.apply(this,arguments)},true)}var StringShims={repeat:function(){var repeat=function(s,times){if(times<1){return""}if(times%2){return repeat(s,times-1)+s}var half=repeat(s,times/2);return half+half};return function(times){var thisStr=String(ES.CheckObjectCoercible(this));times=ES.ToInteger(times);if(times<0||times===Infinity){throw new RangeError("Invalid String#repeat value")}return repeat(thisStr,times)}}(),startsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "startsWith" with a regex')}searchStr=String(searchStr);var startArg=arguments.length>1?arguments[1]:void 0;var start=Math.max(ES.ToInteger(startArg),0);return thisStr.slice(start,start+searchStr.length)===searchStr},endsWith:function(searchStr){var thisStr=String(ES.CheckObjectCoercible(this));if(_toString.call(searchStr)==="[object RegExp]"){throw new TypeError('Cannot call method "endsWith" with a regex')}searchStr=String(searchStr);var thisLen=thisStr.length;var posArg=arguments.length>1?arguments[1]:void 0;var pos=typeof posArg==="undefined"?thisLen:ES.ToInteger(posArg);var end=Math.min(Math.max(pos,0),thisLen);return thisStr.slice(end-searchStr.length,end)===searchStr},contains:function(searchString){var position=arguments.length>1?arguments[1]:void 0;return _indexOf.call(this,searchString,position)!==-1},codePointAt:function(pos){var thisStr=String(ES.CheckObjectCoercible(this));var position=ES.ToInteger(pos);var length=thisStr.length;if(position<0||position>=length){return}var first=thisStr.charCodeAt(position);var isEnd=position+1===length;if(first<55296||first>56319||isEnd){return first}var second=thisStr.charCodeAt(position+1);if(second<56320||second>57343){return first}return(first-55296)*1024+(second-56320)+65536}};defineProperties(String.prototype,StringShims);var hasStringTrimBug="".trim().length!==1;if(hasStringTrimBug){var originalStringTrim=String.prototype.trim;delete String.prototype.trim;var ws=["  \n\f\r   ᠎    ","         　\u2028","\u2029﻿"].join("");var trimRegexp=new RegExp("(^["+ws+"]+)|(["+ws+"]+$)","g");defineProperties(String.prototype,{trim:function(){if(typeof this==="undefined"||this===null){throw new TypeError("can't convert "+this+" to object")}return String(this).replace(trimRegexp,"")}})}var StringIterator=function(s){this._s=String(ES.CheckObjectCoercible(s));this._i=0};StringIterator.prototype.next=function(){var s=this._s,i=this._i;if(typeof s==="undefined"||i>=s.length){this._s=void 0;return{value:void 0,done:true}}var first=s.charCodeAt(i),second,len;if(first<55296||first>56319||i+1==s.length){len=1}else{second=s.charCodeAt(i+1);len=second<56320||second>57343?1:2}this._i=i+len;return{value:s.substr(i,len),done:false}};addIterator(StringIterator.prototype);addIterator(String.prototype,function(){return new StringIterator(this)});if(!startsWithIsCompliant){String.prototype.startsWith=StringShims.startsWith;String.prototype.endsWith=StringShims.endsWith}var ArrayShims={from:function(iterable){var mapFn=arguments.length>1?arguments[1]:void 0;var list=ES.ToObject(iterable,"bad iterable");if(typeof mapFn!=="undefined"&&!ES.IsCallable(mapFn)){throw new TypeError("Array.from: when provided, the second argument must be a function")}var hasThisArg=arguments.length>2;var thisArg=hasThisArg?arguments[2]:void 0;var usingIterator=ES.IsIterable(list);var length;var result,i,value;if(usingIterator){i=0;result=ES.IsCallable(this)?Object(new this):[];var it=usingIterator?ES.GetIterator(list):null;var iterationValue;do{iterationValue=ES.IteratorNext(it);if(!iterationValue.done){value=iterationValue.value;if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}i+=1}}while(!iterationValue.done);length=i}else{length=ES.ToLength(list.length);result=ES.IsCallable(this)?Object(new this(length)):new Array(length);for(i=0;i<length;++i){value=list[i];if(mapFn){result[i]=hasThisArg?mapFn.call(thisArg,value,i):mapFn(value,i)}else{result[i]=value}}}result.length=length;return result},of:function(){return Array.from(arguments)}};defineProperties(Array,ArrayShims);var arrayFromSwallowsNegativeLengths=function(){try{return Array.from({length:-1}).length===0}catch(e){return false}};if(!arrayFromSwallowsNegativeLengths()){defineProperty(Array,"from",ArrayShims.from,true)}ArrayIterator=function(array,kind){this.i=0;this.array=array;this.kind=kind};defineProperties(ArrayIterator.prototype,{next:function(){var i=this.i,array=this.array;if(!(this instanceof ArrayIterator)){throw new TypeError("Not an ArrayIterator")}if(typeof array!=="undefined"){var len=ES.ToLength(array.length);for(;i<len;i++){var kind=this.kind;var retval;if(kind==="key"){retval=i}else if(kind==="value"){retval=array[i]}else if(kind==="entry"){retval=[i,array[i]]}this.i=i+1;return{value:retval,done:false}}}this.array=void 0;return{value:void 0,done:true}}});addIterator(ArrayIterator.prototype);var ArrayPrototypeShims={copyWithin:function(target,start){var end=arguments[2];var o=ES.ToObject(this);var len=ES.ToLength(o.length);target=ES.ToInteger(target);start=ES.ToInteger(start);var to=target<0?Math.max(len+target,0):Math.min(target,len);var from=start<0?Math.max(len+start,0):Math.min(start,len);end=typeof end==="undefined"?len:ES.ToInteger(end);var fin=end<0?Math.max(len+end,0):Math.min(end,len);var count=Math.min(fin-from,len-to);var direction=1;if(from<to&&to<from+count){direction=-1;from+=count-1;to+=count-1}while(count>0){if(_hasOwnProperty.call(o,from)){o[to]=o[from]}else{delete o[from]}from+=direction;to+=direction;count-=1}return o},fill:function(value){var start=arguments.length>1?arguments[1]:void 0;var end=arguments.length>2?arguments[2]:void 0;var O=ES.ToObject(this);var len=ES.ToLength(O.length);start=ES.ToInteger(typeof start==="undefined"?0:start);end=ES.ToInteger(typeof end==="undefined"?len:end);var relativeStart=start<0?Math.max(len+start,0):Math.min(start,len);var relativeEnd=end<0?len+end:end;for(var i=relativeStart;i<len&&i<relativeEnd;++i){O[i]=value}return O},find:function find(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#find: predicate must be a function")}var thisArg=arguments[1];for(var i=0,value;i<length;i++){value=list[i];if(predicate.call(thisArg,value,i,list)){return value}}return},findIndex:function findIndex(predicate){var list=ES.ToObject(this);var length=ES.ToLength(list.length);if(!ES.IsCallable(predicate)){throw new TypeError("Array#findIndex: predicate must be a function")}var thisArg=arguments[1];for(var i=0;i<length;i++){if(predicate.call(thisArg,list[i],i,list)){return i}}return-1},keys:function(){return new ArrayIterator(this,"key")},values:function(){return new ArrayIterator(this,"value")},entries:function(){return new ArrayIterator(this,"entry")}};if(Array.prototype.keys&&!ES.IsCallable([1].keys().next)){delete Array.prototype.keys}if(Array.prototype.entries&&!ES.IsCallable([1].entries().next)){delete Array.prototype.entries}defineProperties(Array.prototype,ArrayPrototypeShims);addIterator(Array.prototype,function(){return this.values()});if(Object.getPrototypeOf){addIterator(Object.getPrototypeOf([].values()))}var maxSafeInteger=Math.pow(2,53)-1;defineProperties(Number,{MAX_SAFE_INTEGER:maxSafeInteger,MIN_SAFE_INTEGER:-maxSafeInteger,EPSILON:2.220446049250313e-16,parseInt:globals.parseInt,parseFloat:globals.parseFloat,isFinite:function(value){return typeof value==="number"&&global_isFinite(value)},isInteger:function(value){return Number.isFinite(value)&&ES.ToInteger(value)===value},isSafeInteger:function(value){return Number.isInteger(value)&&Math.abs(value)<=Number.MAX_SAFE_INTEGER},isNaN:function(value){return value!==value}});if(![,1].find(function(item,idx){return idx===0})){defineProperty(Array.prototype,"find",ArrayPrototypeShims.find,true)}if([,1].findIndex(function(item,idx){return idx===0})!==0){defineProperty(Array.prototype,"findIndex",ArrayPrototypeShims.findIndex,true)}if(supportsDescriptors){defineProperties(Object,{getPropertyDescriptor:function(subject,name){var pd=Object.getOwnPropertyDescriptor(subject,name);var proto=Object.getPrototypeOf(subject);while(typeof pd==="undefined"&&proto!==null){pd=Object.getOwnPropertyDescriptor(proto,name);proto=Object.getPrototypeOf(proto)}return pd},getPropertyNames:function(subject){var result=Object.getOwnPropertyNames(subject);var proto=Object.getPrototypeOf(subject);var addProperty=function(property){if(result.indexOf(property)===-1){result.push(property)}};while(proto!==null){Object.getOwnPropertyNames(proto).forEach(addProperty);proto=Object.getPrototypeOf(proto)}return result}});defineProperties(Object,{assign:function(target,source){if(!ES.TypeIsObject(target)){throw new TypeError("target must be an object")}return Array.prototype.reduce.call(arguments,function(target,source){return Object.keys(Object(source)).reduce(function(target,key){target[key]=source[key];return target},target)})},is:function(a,b){return ES.SameValue(a,b)},setPrototypeOf:function(Object,magic){var set;var checkArgs=function(O,proto){if(!ES.TypeIsObject(O)){throw new TypeError("cannot set prototype on a non-object")}if(!(proto===null||ES.TypeIsObject(proto))){throw new TypeError("can only set prototype to an object or null"+proto)}};var setPrototypeOf=function(O,proto){checkArgs(O,proto);set.call(O,proto);return O};try{set=Object.getOwnPropertyDescriptor(Object.prototype,magic).set;set.call({},null)}catch(e){if(Object.prototype!=={}[magic]){return}set=function(proto){this[magic]=proto};setPrototypeOf.polyfill=setPrototypeOf(setPrototypeOf({},null),Object.prototype)instanceof Object}return setPrototypeOf}(Object,"__proto__")})}if(Object.setPrototypeOf&&Object.getPrototypeOf&&Object.getPrototypeOf(Object.setPrototypeOf({},null))!==null&&Object.getPrototypeOf(Object.create(null))===null){(function(){var FAKENULL=Object.create(null);var gpo=Object.getPrototypeOf,spo=Object.setPrototypeOf;Object.getPrototypeOf=function(o){var result=gpo(o);return result===FAKENULL?null:result};Object.setPrototypeOf=function(o,p){if(p===null){p=FAKENULL}return spo(o,p)};Object.setPrototypeOf.polyfill=false})()}try{Object.keys("foo")}catch(e){var originalObjectKeys=Object.keys;Object.keys=function(obj){return originalObjectKeys(ES.ToObject(obj))}}var MathShims={acosh:function(value){value=Number(value);if(Number.isNaN(value)||value<1){return NaN}if(value===1){return 0}if(value===Infinity){return value}return Math.log(value+Math.sqrt(value*value-1))},asinh:function(value){value=Number(value);if(value===0||!global_isFinite(value)){return value}return value<0?-Math.asinh(-value):Math.log(value+Math.sqrt(value*value+1))},atanh:function(value){value=Number(value);if(Number.isNaN(value)||value<-1||value>1){return NaN}if(value===-1){return-Infinity}if(value===1){return Infinity}if(value===0){return value}return.5*Math.log((1+value)/(1-value))},cbrt:function(value){value=Number(value);if(value===0){return value}var negate=value<0,result;if(negate){value=-value}result=Math.pow(value,1/3);return negate?-result:result},clz32:function(value){value=Number(value);var number=ES.ToUint32(value);if(number===0){return 32}return 32-number.toString(2).length},cosh:function(value){value=Number(value);if(value===0){return 1}if(Number.isNaN(value)){return NaN}if(!global_isFinite(value)){return Infinity}if(value<0){value=-value}if(value>21){return Math.exp(value)/2}return(Math.exp(value)+Math.exp(-value))/2},expm1:function(value){value=Number(value);if(value===-Infinity){return-1}if(!global_isFinite(value)||value===0){return value}return Math.exp(value)-1},hypot:function(x,y){var anyNaN=false;var allZero=true;var anyInfinity=false;var numbers=[];Array.prototype.every.call(arguments,function(arg){var num=Number(arg);if(Number.isNaN(num)){anyNaN=true}else if(num===Infinity||num===-Infinity){anyInfinity=true}else if(num!==0){allZero=false}if(anyInfinity){return false}else if(!anyNaN){numbers.push(Math.abs(num))}return true});if(anyInfinity){return Infinity}if(anyNaN){return NaN}if(allZero){return 0}numbers.sort(function(a,b){return b-a});var largest=numbers[0];var divided=numbers.map(function(number){return number/largest});var sum=divided.reduce(function(sum,number){return sum+=number*number},0);return largest*Math.sqrt(sum)},log2:function(value){return Math.log(value)*Math.LOG2E},log10:function(value){return Math.log(value)*Math.LOG10E},log1p:function(value){value=Number(value);if(value<-1||Number.isNaN(value)){return NaN}if(value===0||value===Infinity){return value}if(value===-1){return-Infinity}var result=0;var n=50;if(value<0||value>1){return Math.log(1+value)}for(var i=1;i<n;i++){if(i%2===0){result-=Math.pow(value,i)/i}else{result+=Math.pow(value,i)/i}}return result},sign:function(value){var number=+value;if(number===0){return number}if(Number.isNaN(number)){return number}return number<0?-1:1},sinh:function(value){value=Number(value);if(!global_isFinite(value)||value===0){return value}return(Math.exp(value)-Math.exp(-value))/2},tanh:function(value){value=Number(value);if(Number.isNaN(value)||value===0){return value}if(value===Infinity){return 1}if(value===-Infinity){return-1}return(Math.exp(value)-Math.exp(-value))/(Math.exp(value)+Math.exp(-value))},trunc:function(value){var number=Number(value);return number<0?-Math.floor(-number):Math.floor(number)},imul:function(x,y){x=ES.ToUint32(x);y=ES.ToUint32(y);var ah=x>>>16&65535;var al=x&65535;var bh=y>>>16&65535;var bl=y&65535;return al*bl+(ah*bl+al*bh<<16>>>0)|0},fround:function(x){if(x===0||x===Infinity||x===-Infinity||Number.isNaN(x)){return x}var num=Number(x);return numberConversion.toFloat32(num)}};defineProperties(Math,MathShims);if(Math.imul(4294967295,5)!==-5){Math.imul=MathShims.imul}var PromiseShim=function(){var Promise,Promise$prototype;ES.IsPromise=function(promise){if(!ES.TypeIsObject(promise)){return false}if(!promise._promiseConstructor){return false}if(typeof promise._status==="undefined"){return false}return true};var PromiseCapability=function(C){if(!ES.IsCallable(C)){throw new TypeError("bad promise constructor")}var capability=this;var resolver=function(resolve,reject){capability.resolve=resolve;capability.reject=reject};capability.promise=ES.Construct(C,[resolver]);if(!capability.promise._es6construct){throw new TypeError("bad promise constructor")}if(!(ES.IsCallable(capability.resolve)&&ES.IsCallable(capability.reject))){throw new TypeError("bad promise constructor")}};var setTimeout=globals.setTimeout;var makeZeroTimeout;if(typeof window!=="undefined"&&ES.IsCallable(window.postMessage)){makeZeroTimeout=function(){var timeouts=[];var messageName="zero-timeout-message";var setZeroTimeout=function(fn){timeouts.push(fn);window.postMessage(messageName,"*")};var handleMessage=function(event){if(event.source==window&&event.data==messageName){event.stopPropagation();
 if(timeouts.length===0){return}var fn=timeouts.shift();fn()}};window.addEventListener("message",handleMessage,true);return setZeroTimeout}}var makePromiseAsap=function(){var P=globals.Promise;return P&&P.resolve&&function(task){return P.resolve().then(task)}};var enqueue=ES.IsCallable(globals.setImmediate)?globals.setImmediate.bind(globals):typeof process==="object"&&process.nextTick?process.nextTick:makePromiseAsap()||(ES.IsCallable(makeZeroTimeout)?makeZeroTimeout():function(task){setTimeout(task,0)});var triggerPromiseReactions=function(reactions,x){reactions.forEach(function(reaction){enqueue(function(){var handler=reaction.handler;var capability=reaction.capability;var resolve=capability.resolve;var reject=capability.reject;try{var result=handler(x);if(result===capability.promise){throw new TypeError("self resolution")}var updateResult=updatePromiseFromPotentialThenable(result,capability);if(!updateResult){resolve(result)}}catch(e){reject(e)}})})};var updatePromiseFromPotentialThenable=function(x,capability){if(!ES.TypeIsObject(x)){return false}var resolve=capability.resolve;var reject=capability.reject;try{var then=x.then;if(!ES.IsCallable(then)){return false}then.call(x,resolve,reject)}catch(e){reject(e)}return true};var promiseResolutionHandler=function(promise,onFulfilled,onRejected){return function(x){if(x===promise){return onRejected(new TypeError("self resolution"))}var C=promise._promiseConstructor;var capability=new PromiseCapability(C);var updateResult=updatePromiseFromPotentialThenable(x,capability);if(updateResult){return capability.promise.then(onFulfilled,onRejected)}else{return onFulfilled(x)}}};Promise=function(resolver){var promise=this;promise=emulateES6construct(promise);if(!promise._promiseConstructor){throw new TypeError("bad promise")}if(typeof promise._status!=="undefined"){throw new TypeError("promise already initialized")}if(!ES.IsCallable(resolver)){throw new TypeError("not a valid resolver")}promise._status="unresolved";promise._resolveReactions=[];promise._rejectReactions=[];var resolve=function(resolution){if(promise._status!=="unresolved"){return}var reactions=promise._resolveReactions;promise._result=resolution;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-resolution";triggerPromiseReactions(reactions,resolution)};var reject=function(reason){if(promise._status!=="unresolved"){return}var reactions=promise._rejectReactions;promise._result=reason;promise._resolveReactions=void 0;promise._rejectReactions=void 0;promise._status="has-rejection";triggerPromiseReactions(reactions,reason)};try{resolver(resolve,reject)}catch(e){reject(e)}return promise};Promise$prototype=Promise.prototype;defineProperties(Promise,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Promise$prototype;obj=obj||create(prototype);defineProperties(obj,{_status:void 0,_result:void 0,_resolveReactions:void 0,_rejectReactions:void 0,_promiseConstructor:void 0});obj._promiseConstructor=constructor;return obj}});var _promiseAllResolver=function(index,values,capability,remaining){var done=false;return function(x){if(done){return}done=true;values[index]=x;if(--remaining.count===0){var resolve=capability.resolve;resolve(values)}}};Promise.all=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);var values=[],remaining={count:1};for(var index=0;;index++){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);var resolveElement=_promiseAllResolver(index,values,capability,remaining);remaining.count++;nextPromise.then(resolveElement,capability.reject)}if(--remaining.count===0){resolve(values)}}catch(e){reject(e)}return capability.promise};Promise.race=function(iterable){var C=this;var capability=new PromiseCapability(C);var resolve=capability.resolve;var reject=capability.reject;try{if(!ES.IsIterable(iterable)){throw new TypeError("bad iterable")}var it=ES.GetIterator(iterable);while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextPromise=C.resolve(next.value);nextPromise.then(resolve,reject)}}catch(e){reject(e)}return capability.promise};Promise.reject=function(reason){var C=this;var capability=new PromiseCapability(C);var reject=capability.reject;reject(reason);return capability.promise};Promise.resolve=function(v){var C=this;if(ES.IsPromise(v)){var constructor=v._promiseConstructor;if(constructor===C){return v}}var capability=new PromiseCapability(C);var resolve=capability.resolve;resolve(v);return capability.promise};Promise.prototype["catch"]=function(onRejected){return this.then(void 0,onRejected)};Promise.prototype.then=function(onFulfilled,onRejected){var promise=this;if(!ES.IsPromise(promise)){throw new TypeError("not a promise")}var C=this.constructor;var capability=new PromiseCapability(C);if(!ES.IsCallable(onRejected)){onRejected=function(e){throw e}}if(!ES.IsCallable(onFulfilled)){onFulfilled=function(x){return x}}var resolutionHandler=promiseResolutionHandler(promise,onFulfilled,onRejected);var resolveReaction={capability:capability,handler:resolutionHandler};var rejectReaction={capability:capability,handler:onRejected};switch(promise._status){case"unresolved":promise._resolveReactions.push(resolveReaction);promise._rejectReactions.push(rejectReaction);break;case"has-resolution":triggerPromiseReactions([resolveReaction],promise._result);break;case"has-rejection":triggerPromiseReactions([rejectReaction],promise._result);break;default:throw new TypeError("unexpected")}return capability.promise};return Promise}();defineProperties(globals,{Promise:PromiseShim});var promiseSupportsSubclassing=supportsSubclassing(globals.Promise,function(S){return S.resolve(42)instanceof S});var promiseIgnoresNonFunctionThenCallbacks=function(){try{globals.Promise.reject(42).then(null,5).then(null,function(){});return true}catch(ex){return false}}();var promiseRequiresObjectContext=function(){try{Promise.call(3,function(){})}catch(e){return true}return false}();if(!promiseSupportsSubclassing||!promiseIgnoresNonFunctionThenCallbacks||!promiseRequiresObjectContext){globals.Promise=PromiseShim}var testOrder=function(a){var b=Object.keys(a.reduce(function(o,k){o[k]=true;return o},{}));return a.join(":")===b.join(":")};var preservesInsertionOrder=testOrder(["z","a","bb"]);var preservesNumericInsertionOrder=testOrder(["z",1,"a","3",2]);if(supportsDescriptors){var fastkey=function fastkey(key){if(!preservesInsertionOrder){return null}var type=typeof key;if(type==="string"){return"$"+key}else if(type==="number"){if(!preservesNumericInsertionOrder){return"n"+key}return key}return null};var emptyObject=function emptyObject(){return Object.create?Object.create(null):{}};var collectionShims={Map:function(){var empty={};function MapEntry(key,value){this.key=key;this.value=value;this.next=null;this.prev=null}MapEntry.prototype.isRemoved=function(){return this.key===empty};function MapIterator(map,kind){this.head=map._head;this.i=this.head;this.kind=kind}MapIterator.prototype={next:function(){var i=this.i,kind=this.kind,head=this.head,result;if(typeof this.i==="undefined"){return{value:void 0,done:true}}while(i.isRemoved()&&i!==head){i=i.prev}while(i.next!==head){i=i.next;if(!i.isRemoved()){if(kind==="key"){result=i.key}else if(kind==="value"){result=i.value}else{result=[i.key,i.value]}this.i=i;return{value:result,done:false}}}this.i=void 0;return{value:void 0,done:true}}};addIterator(MapIterator.prototype);function Map(iterable){var map=this;map=emulateES6construct(map);if(!map._es6map){throw new TypeError("bad map")}var head=new MapEntry(null,null);head.next=head.prev=head;defineProperties(map,{_head:head,_storage:emptyObject(),_size:0});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=map.set;if(!ES.IsCallable(adder)){throw new TypeError("bad map")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;if(!ES.TypeIsObject(nextItem)){throw new TypeError("expected iterable of pairs")}adder.call(map,nextItem[0],nextItem[1])}}return map}var Map$prototype=Map.prototype;defineProperties(Map,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Map$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6map:true});return obj}});Object.defineProperty(Map.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._size==="undefined"){throw new TypeError("size method called on incompatible Map")}return this._size}});defineProperties(Map.prototype,{get:function(key){var fkey=fastkey(key);if(fkey!==null){var entry=this._storage[fkey];if(entry){return entry.value}else{return}}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return i.value}}return},has:function(key){var fkey=fastkey(key);if(fkey!==null){return typeof this._storage[fkey]!=="undefined"}var head=this._head,i=head;while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){return true}}return false},set:function(key,value){var head=this._head,i=head,entry;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]!=="undefined"){this._storage[fkey].value=value;return}else{entry=this._storage[fkey]=new MapEntry(key,value);i=head.prev}}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.value=value;return}}entry=entry||new MapEntry(key,value);if(ES.SameValue(-0,key)){entry.key=+0}entry.next=this._head;entry.prev=this._head.prev;entry.prev.next=entry;entry.next.prev=entry;this._size+=1;return this},"delete":function(key){var head=this._head,i=head;var fkey=fastkey(key);if(fkey!==null){if(typeof this._storage[fkey]==="undefined"){return false}i=this._storage[fkey].prev;delete this._storage[fkey]}while((i=i.next)!==head){if(ES.SameValueZero(i.key,key)){i.key=i.value=empty;i.prev.next=i.next;i.next.prev=i.prev;this._size-=1;return true}}return false},clear:function(){this._size=0;this._storage=emptyObject();var head=this._head,i=head,p=i.next;while((i=p)!==head){i.key=i.value=empty;p=i.next;i.next=i.prev=head}head.next=head.prev=head},keys:function(){return new MapIterator(this,"key")},values:function(){return new MapIterator(this,"value")},entries:function(){return new MapIterator(this,"key+value")},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var it=this.entries();for(var entry=it.next();!entry.done;entry=it.next()){callback.call(context,entry.value[1],entry.value[0],this)}}});addIterator(Map.prototype,function(){return this.entries()});return Map}(),Set:function(){var SetShim=function Set(iterable){var set=this;set=emulateES6construct(set);if(!set._es6set){throw new TypeError("bad set")}defineProperties(set,{"[[SetData]]":null,_storage:emptyObject()});if(typeof iterable!=="undefined"&&iterable!==null){var it=ES.GetIterator(iterable);var adder=set.add;if(!ES.IsCallable(adder)){throw new TypeError("bad set")}while(true){var next=ES.IteratorNext(it);if(next.done){break}var nextItem=next.value;adder.call(set,nextItem)}}return set};var Set$prototype=SetShim.prototype;defineProperties(SetShim,{"@@create":function(obj){var constructor=this;var prototype=constructor.prototype||Set$prototype;obj=obj||create(prototype);defineProperties(obj,{_es6set:true});return obj}});var ensureMap=function ensureMap(set){if(!set["[[SetData]]"]){var m=set["[[SetData]]"]=new collectionShims.Map;Object.keys(set._storage).forEach(function(k){if(k.charCodeAt(0)===36){k=k.slice(1)}else if(k.charAt(0)==="n"){k=+k.slice(1)}else{k=+k}m.set(k,k)});set._storage=null}};Object.defineProperty(SetShim.prototype,"size",{configurable:true,enumerable:false,get:function(){if(typeof this._storage==="undefined"){throw new TypeError("size method called on incompatible Set")}ensureMap(this);return this["[[SetData]]"].size}});defineProperties(SetShim.prototype,{has:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){return!!this._storage[fkey]}ensureMap(this);return this["[[SetData]]"].has(key)},add:function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){this._storage[fkey]=true;return}ensureMap(this);this["[[SetData]]"].set(key,key);return this},"delete":function(key){var fkey;if(this._storage&&(fkey=fastkey(key))!==null){var hasFKey=_hasOwnProperty.call(this._storage,fkey);return delete this._storage[fkey]&&hasFKey}ensureMap(this);return this["[[SetData]]"]["delete"](key)},clear:function(){if(this._storage){this._storage=emptyObject();return}return this["[[SetData]]"].clear()},keys:function(){ensureMap(this);return this["[[SetData]]"].keys()},values:function(){ensureMap(this);return this["[[SetData]]"].values()},entries:function(){ensureMap(this);return this["[[SetData]]"].entries()},forEach:function(callback){var context=arguments.length>1?arguments[1]:null;var entireSet=this;ensureMap(this);this["[[SetData]]"].forEach(function(value,key){callback.call(context,key,key,entireSet)})}});addIterator(SetShim.prototype,function(){return this.values()});return SetShim}()};defineProperties(globals,collectionShims);if(globals.Map||globals.Set){if(typeof globals.Map.prototype.clear!=="function"||(new globals.Set).size!==0||(new globals.Map).size!==0||typeof globals.Map.prototype.keys!=="function"||typeof globals.Set.prototype.keys!=="function"||typeof globals.Map.prototype.forEach!=="function"||typeof globals.Set.prototype.forEach!=="function"||isCallableWithoutNew(globals.Map)||isCallableWithoutNew(globals.Set)||!supportsSubclassing(globals.Map,function(M){var m=new M([]);m.set(42,42);return m instanceof M})){globals.Map=collectionShims.Map;globals.Set=collectionShims.Set}}addIterator(Object.getPrototypeOf((new globals.Map).keys()));addIterator(Object.getPrototypeOf((new globals.Set).keys()))}return globals})}).call(this,require("_process"))},{_process:3}],5:[function(require,module,exports){"use strict";if(!require("./is-implemented")()){Object.defineProperty(require("es5-ext/global"),"Symbol",{value:require("./polyfill"),configurable:true,enumerable:false,writable:true})}},{"./is-implemented":6,"./polyfill":21,"es5-ext/global":8}],6:[function(require,module,exports){"use strict";module.exports=function(){var symbol;if(typeof Symbol!=="function")return false;symbol=Symbol("test symbol");try{String(symbol)}catch(e){return false}if(typeof Symbol.iterator==="symbol")return true;if(typeof Symbol.isConcatSpreadable!=="object")return false;if(typeof Symbol.isRegExp!=="object")return false;if(typeof Symbol.iterator!=="object")return false;if(typeof Symbol.toPrimitive!=="object")return false;if(typeof Symbol.toStringTag!=="object")return false;if(typeof Symbol.unscopables!=="object")return false;return true}},{}],7:[function(require,module,exports){"use strict";var assign=require("es5-ext/object/assign"),normalizeOpts=require("es5-ext/object/normalize-options"),isCallable=require("es5-ext/object/is-callable"),contains=require("es5-ext/string/#/contains"),d;d=module.exports=function(dscr,value){var c,e,w,options,desc;if(arguments.length<2||typeof dscr!=="string"){options=value;value=dscr;dscr=null}else{options=arguments[2]}if(dscr==null){c=w=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e");w=contains.call(dscr,"w")}desc={value:value,configurable:c,enumerable:e,writable:w};return!options?desc:assign(normalizeOpts(options),desc)};d.gs=function(dscr,get,set){var c,e,options,desc;if(typeof dscr!=="string"){options=set;set=get;get=dscr;dscr=null}else{options=arguments[3]}if(get==null){get=undefined}else if(!isCallable(get)){options=get;get=set=undefined}else if(set==null){set=undefined}else if(!isCallable(set)){options=set;set=undefined}if(dscr==null){c=true;e=false}else{c=contains.call(dscr,"c");e=contains.call(dscr,"e")}desc={get:get,set:set,configurable:c,enumerable:e};return!options?desc:assign(normalizeOpts(options),desc)}},{"es5-ext/object/assign":9,"es5-ext/object/is-callable":12,"es5-ext/object/normalize-options":16,"es5-ext/string/#/contains":18}],8:[function(require,module,exports){"use strict";module.exports=new Function("return this")()},{}],9:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.assign:require("./shim")},{"./is-implemented":10,"./shim":11}],10:[function(require,module,exports){"use strict";module.exports=function(){var assign=Object.assign,obj;if(typeof assign!=="function")return false;obj={foo:"raz"};assign(obj,{bar:"dwa"},{trzy:"trzy"});return obj.foo+obj.bar+obj.trzy==="razdwatrzy"}},{}],11:[function(require,module,exports){"use strict";var keys=require("../keys"),value=require("../valid-value"),max=Math.max;module.exports=function(dest,src){var error,i,l=max(arguments.length,2),assign;dest=Object(value(dest));assign=function(key){try{dest[key]=src[key]}catch(e){if(!error)error=e}};for(i=1;i<l;++i){src=arguments[i];keys(src).forEach(assign)}if(error!==undefined)throw error;return dest}},{"../keys":13,"../valid-value":17}],12:[function(require,module,exports){"use strict";module.exports=function(obj){return typeof obj==="function"}},{}],13:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?Object.keys:require("./shim")},{"./is-implemented":14,"./shim":15}],14:[function(require,module,exports){"use strict";module.exports=function(){try{Object.keys("primitive");return true}catch(e){return false}}},{}],15:[function(require,module,exports){"use strict";var keys=Object.keys;module.exports=function(object){return keys(object==null?object:Object(object))}},{}],16:[function(require,module,exports){"use strict";var assign=require("./assign"),forEach=Array.prototype.forEach,create=Object.create,getPrototypeOf=Object.getPrototypeOf,process;process=function(src,obj){var proto=getPrototypeOf(src);return assign(proto?process(proto,obj):obj,src)};module.exports=function(options){var result=create(null);forEach.call(arguments,function(options){if(options==null)return;process(Object(options),result)});return result}},{"./assign":9}],17:[function(require,module,exports){"use strict";module.exports=function(value){if(value==null)throw new TypeError("Cannot use null or undefined");return value}},{}],18:[function(require,module,exports){"use strict";module.exports=require("./is-implemented")()?String.prototype.contains:require("./shim")},{"./is-implemented":19,"./shim":20}],19:[function(require,module,exports){"use strict";var str="razdwatrzy";module.exports=function(){if(typeof str.contains!=="function")return false;return str.contains("dwa")===true&&str.contains("foo")===false}},{}],20:[function(require,module,exports){"use strict";var indexOf=String.prototype.indexOf;module.exports=function(searchString){return indexOf.call(this,searchString,arguments[1])>-1}},{}],21:[function(require,module,exports){"use strict";var d=require("d"),create=Object.create,defineProperties=Object.defineProperties,generateName,Symbol;generateName=function(){var created=create(null);return function(desc){var postfix=0;while(created[desc+(postfix||"")])++postfix;desc+=postfix||"";created[desc]=true;return"@@"+desc}}();module.exports=Symbol=function(description){var symbol;if(this instanceof Symbol){throw new TypeError("TypeError: Symbol is not a constructor")}symbol=create(Symbol.prototype);description=description===undefined?"":String(description);return defineProperties(symbol,{__description__:d("",description),__name__:d("",generateName(description))})};Object.defineProperties(Symbol,{create:d("",Symbol("create")),hasInstance:d("",Symbol("hasInstance")),isConcatSpreadable:d("",Symbol("isConcatSpreadable")),isRegExp:d("",Symbol("isRegExp")),iterator:d("",Symbol("iterator")),toPrimitive:d("",Symbol("toPrimitive")),toStringTag:d("",Symbol("toStringTag")),unscopables:d("",Symbol("unscopables"))});defineProperties(Symbol.prototype,{properToString:d(function(){return"Symbol ("+this.__description__+")"}),toString:d("",function(){return this.__name__})});Object.defineProperty(Symbol.prototype,Symbol.toPrimitive,d("",function(hint){throw new TypeError("Conversion of symbol objects is not allowed")}));Object.defineProperty(Symbol.prototype,Symbol.toStringTag,d("c","Symbol"))},{d:7}]},{},[1]);</script>
 
     <script>
@@ -564,6 +564,24 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
 
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return (function (a) {
+    if (a === undefined) a = function () {
+      return typeof b === &quot;undefined&quot;;
+    };
+    return (function () {
+      var b = 1;
+      return a();
+    })();
+  }());
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (a) {\n    if (a === undefined) a = function () {\n      return typeof b === \"undefined\";\n    };\n    return (function () {\n      var b = 1;\n      return a();\n    })();\n  }());\n});")()}catch(e){return false;}}());
+</script>
+
         </tr>
         <tr>
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
@@ -677,11 +695,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {};
+  var C = function C() {};
 
-  return typeof _C === &quot;function&quot;;
+  return typeof C === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  return typeof _C === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  return typeof C === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -689,16 +707,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = f
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {};
+  var C = function C() {};
 
   {
     (function () {
-      var _D = function _D() {};
+      var D = function D() {};
     })();
   }
-  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  {\n    (function () {\n      var D = function D() {};\n    })();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -716,13 +734,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {
+  var C = function C() {
     this.x = 1;
   };
 
-  return _C.prototype.constructor === _C && new _C().x === 1;
+  return C.prototype.constructor === C && new C().x === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {\n    this.x = 1;\n  };\n\n  return _C.prototype.constructor === _C && new _C().x === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {\n    this.x = 1;\n  };\n\n  return C.prototype.constructor === C && new C().x === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -735,10 +753,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, null, {
+    _classProps(C, null, {
       method: {
         writable: true,
         value: function () {
@@ -747,12 +765,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return _C;
+    return C;
   })();
 
-  return typeof _C.prototype.method === &quot;function&quot; && new _C().method() === 2;
+  return typeof C.prototype.method === &quot;function&quot; && new C().method() === 2;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.prototype.method === \"function\" && new _C().method() === 2;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.prototype.method === \"function\" && new C().method() === 2;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -765,10 +783,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, {
+    _classProps(C, {
       method: {
         writable: true,
         value: function () {
@@ -777,12 +795,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return _C;
+    return C;
   })();
 
-  return typeof _C.method === &quot;function&quot; && _C.method() === 3;
+  return typeof C.method === &quot;function&quot; && C.method() === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.method === \"function\" && _C.method() === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.method === \"function\" && C.method() === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -832,19 +850,19 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _C = (function (Array) {
-    var _C = function _C() {
+  var C = (function (Array) {
+    var C = function C() {
       Array.apply(this, arguments);
     };
 
-    _extends(_C, Array);
+    _extends(C, Array);
 
-    return _C;
+    return C;
   })(Array);
 
-  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);
+  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _C = (function (Array) {\n    var _C = function _C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(_C, Array);\n\n    return _C;\n  })(Array);\n\n  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var C = (function (Array) {\n    var C = function C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(C, Array);\n\n    return C;\n  })(Array);\n\n  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -868,21 +886,21 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B(a) {
+  var B = (function (_ref) {
+    var B = function B(a) {
       return _ref.call(this, &quot;bar&quot; + a);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    return _B;
+    return B;
   })(function (a) {
     return [&quot;foo&quot; + a];
   });
 
-  return new _B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
+  return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(_B, _ref);\n\n    return _B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new _B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(B, _ref);\n\n    return B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -907,14 +925,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B() {
+  var B = (function (_ref) {
+    var B = function B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    _classProps(_B, null, {
+    _classProps(B, null, {
       qux: {
         writable: true,
         value: function (a) {
@@ -923,7 +941,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return _B;
+    return B;
   })((function () {
     var _class = function () {};
 
@@ -939,9 +957,9 @@ var _extends = function (child, parent) {
     return _class;
   })());
 
-  return new _B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
+  return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new _B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -966,14 +984,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B() {
+  var B = (function (_ref) {
+    var B = function B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    _classProps(_B, null, {
+    _classProps(B, null, {
       qux: {
         writable: true,
         value: function () {
@@ -982,7 +1000,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return _B;
+    return B;
   })((function () {
     var _class = function () {};
 
@@ -999,12 +1017,12 @@ var _extends = function (child, parent) {
   })());
 
   var obj = {
-    qux: _B.prototype.qux,
+    qux: B.prototype.qux,
     corge: &quot;ley&quot;
   };
   return obj.qux() === &quot;barley&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: _B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1209,18 +1227,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   var iterator = (regeneratorRuntime.mark(function generator() {
     return regeneratorRuntime.wrap(function generator$(context$2$0) {
       while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield((regeneratorRuntime.mark(function callee$2$0() {
-            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-              while (true) switch (context$3$0.prev = context$3$0.next) {
-                case 0: context$3$0.next = 2;
-                  return 5;
-                case 2: context$3$0.next = 4;
-                  return 6;
-                case 4:
-                case &quot;end&quot;: return context$3$0.stop();
-              }
-            }, callee$2$0, this);
-          })()), &quot;t6&quot;, 1);
+        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), &quot;t6&quot;, 1);
         case 1:
         case &quot;end&quot;: return context$2$0.stop();
       }
@@ -1231,10 +1238,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield((regeneratorRuntime.mark(function callee$2$0() {\n            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n              while (true) switch (context$3$0.prev = context$3$0.next) {\n                case 0: context$3$0.next = 2;\n                  return 5;\n                case 2: context$3$0.next = 4;\n                  return 6;\n                case 4:\n                case \"end\": return context$3$0.stop();\n              }\n            }, callee$2$0, this);\n          })()), \"t6\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t6\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1245,18 +1254,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   var iterator = (regeneratorRuntime.mark(function generator() {
     return regeneratorRuntime.wrap(function generator$(context$2$0) {
       while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {
-            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-              while (true) switch (context$3$0.prev = context$3$0.next) {
-                case 0: context$3$0.next = 2;
-                  return 5;
-                case 2: context$3$0.next = 4;
-                  return 6;
-                case 4:
-                case &quot;end&quot;: return context$3$0.stop();
-              }
-            }, callee$2$0, this);
-          })()), &quot;t7&quot;, 1);
+        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t7&quot;, 1);
         case 1:
         case &quot;end&quot;: return context$2$0.stop();
       }
@@ -1267,10 +1265,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {\n            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n              while (true) switch (context$3$0.prev = context$3$0.next) {\n                case 0: context$3$0.next = 2;\n                  return 5;\n                case 2: context$3$0.next = 4;\n                  return 6;\n                case 4:\n                case \"end\": return context$3$0.stop();\n              }\n            }, callee$2$0, this);\n          })()), \"t7\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t7\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -2361,11 +2361,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxie
   Object.defineProperty(new Proxy(proxied, {
     defineProperty: function (t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+      return true;
     }
-  }), &quot;foo&quot;, { value: 5 });
+  }), &quot;foo&quot;, { value: 5, configurable: true });
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }), \"foo\", { value: 5 });\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }), \"foo\", { value: 5, configurable: true });\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -2730,16 +2731,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 (function () {
   var _ref = [5, null, [6]];
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var _ref3 = Array.from(_ref2[2]);
-
-  var b = _ref3[0];
-  var c = _ref2[3];
+  var a = _ref[0];
+  var b = _ref[2][0];
+  var c = _ref[3];
   return a === 5 && b === 6 && c === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var _ref3 = Array.from(_ref2[2]);\n\n  var b = _ref3[0];\n  var c = _ref2[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var a = _ref[0];\n  var b = _ref[2][0];\n  var c = _ref[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2749,14 +2746,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 (function () {
   var _ref = &quot;bar&quot;;
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var b = _ref2[1];
-  var c = _ref2[2];
+  var a = _ref[0];
+  var b = _ref[1];
+  var c = _ref[2];
   return a === &quot;b&quot; && b === &quot;a&quot; && c === &quot;r&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2765,14 +2760,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  var _ref = Array.from(iterable);
-
-  var a = _ref[0];
-  var b = _ref[1];
-  var c = _ref[2];
+  var a = iterable[0];
+  var b = iterable[1];
+  var c = iterable[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Array.from(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var a = iterable[0];\n  var b = iterable[1];\n  var c = iterable[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2783,14 +2776,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
   var iterable = __createIterableObject(1, 2, 3);
   var _ref = Object.create(iterable);
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var b = _ref2[1];
-  var c = _ref2[2];
+  var a = _ref[0];
+  var b = _ref[1];
+  var c = _ref[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2814,14 +2805,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 (function () {
   var _ref = [9, { x: 10 }];
 
-  var _ref2 = Array.from(_ref);
-
-  var e = _ref2[0];
-  var f = _ref2[1].x;
-  var g = _ref2[1].g;
+  var e = _ref[0];
+  var f = _ref[1].x;
+  var g = _ref[1].g;
   return e === 9 && f === 10 && g === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var _ref2 = Array.from(_ref);\n\n  var e = _ref2[0];\n  var f = _ref2[1].x;\n  var g = _ref2[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var e = _ref[0];\n  var f = _ref[1].x;\n  var g = _ref[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2833,14 +2822,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
     var a = _ref.a;
     var b = _ref.x;
     var e = _ref.y;
-    var _ref3 = Array.from(_ref2);
-
-    var c = _ref3[0];
-    var d = _ref3[1];
+    var c = _ref2[0];
+    var d = _ref2[1];
     return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;
   }({ a: 1, x: 2 }, [3, 4]));
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var _ref3 = Array.from(_ref2);\n\n    var c = _ref3[0];\n    var d = _ref3[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var c = _ref2[0];\n    var d = _ref2[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2850,21 +2837,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
 (function () {
   var _ref = [3, 4, 5];
 
-  var _ref2 = Array.from(_ref);
+  var a = _ref[0];
+  var b = _ref.slice(1);
 
-  var a = _ref2[0];
-  var b = Array.from(_ref2).slice(1);
+  var _ref2 = [6];
 
-  var _ref3 = [6];
-
-  var _ref4 = Array.from(_ref3);
-
-  var c = _ref4[0];
-  var d = Array.from(_ref4).slice(1);
+  var c = _ref2[0];
+  var d = _ref2.slice(1);
 
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = Array.from(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = Array.from(_ref3);\n\n  var c = _ref4[0];\n  var d = Array.from(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var a = _ref[0];\n  var b = _ref.slice(1);\n\n  var _ref2 = [6];\n\n  var c = _ref2[0];\n  var d = _ref2.slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2884,10 +2867,10 @@ test(function(){try{return Function("/* Error during compilation: unknown: Unexp
   1  | (function(){
 > 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
      |                    ^
-  3  |   return a === 1 && b === 2 && c === 3 && d === 4 && 
+  3  |   return a === 1 && b === 2 && c === 3 && d === 4 &&
   4  |     e === 5 && f === undefined;
   5  | }({b:2, c:undefined, x:4}));*/">
-test(function(){try{return Function("/* Error during compilation: unknown: Unexpected token (2:20)\n  1  | (function(){\n> 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n     |                    ^\n  3  |   return a === 1 && b === 2 && c === 3 && d === 4 && \n  4  |     e === 5 && f === undefined;\n  5  | }({b:2, c:undefined, x:4}));*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: unknown: Unexpected token (2:20)\n  1  | (function(){\n> 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n     |                    ^\n  3  |   return a === 1 && b === 2 && c === 3 && d === 4 &&\n  4  |     e === 5 && f === undefined;\n  5  | }({b:2, c:undefined, x:4}));*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3014,9 +2997,9 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 (function () {
   var o = { foo: function () {}, bar: function baz() {} };
   o.qux = function () {};
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3028,16 +3011,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { 
     Object.defineProperties(_o, {
       foo: {
         get: function () {},
-        set: function () {}
+        set: function (x) {}
       }
     });
 
     return _o;
   })({});
   var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
-  return descriptor.get.name === &quot;get foo&quot; && descriptor.get.name === &quot;set foo&quot;;
+  return descriptor.get.name === &quot;get foo&quot; && descriptor.set.name === &quot;set foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = (function (_o) {\n    Object.defineProperties(_o, {\n      foo: {\n        get: function () {},\n        set: function () {}\n      }\n    });\n\n    return _o;\n  })({});\n  var descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\n  return descriptor.get.name === \"get foo\" && descriptor.get.name === \"set foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = (function (_o) {\n    Object.defineProperties(_o, {\n      foo: {\n        get: function () {},\n        set: function (x) {}\n      }\n    });\n\n    return _o;\n  })({});\n  var descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\n  return descriptor.get.name === \"get foo\" && descriptor.set.name === \"set foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3056,16 +3039,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { 
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var o = {};
-  var sym = Symbol(&quot;foo&quot;);
+  var sym1 = Symbol(&quot;foo&quot;);
   var sym2 = Symbol();
-
-  o[sym] = function () {};
-  o[sym2] = function () {};
+  var o = (function (_o) {
+    _o[sym1] = function () {};
+    _o[sym2] = function () {};
+    return _o;
+  })({});
 
   return o[sym].name === &quot;[foo]&quot; && o[sym2].name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {};\n  var sym = Symbol(\"foo\");\n  var sym2 = Symbol();\n\n  o[sym] = function () {};\n  o[sym2] = function () {};\n\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = (function (_o) {\n    _o[sym1] = function () {};\n    _o[sym2] = function () {};\n    return _o;\n  })({});\n\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3078,26 +3062,26 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _foo = function _foo() {};
+  var foo = function foo() {};
 
   ;
-  var _bar = (function () {
-    var _bar = function _bar() {};
+  var bar = (function () {
+    var bar = function bar() {};
 
-    _classProps(_bar, {
+    _classProps(bar, {
       name: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _bar;
+    return bar;
   })();
 
   ;
-  return _foo.name === &quot;foo&quot; && typeof _bar.name === &quot;function&quot;;
+  return foo.name === &quot;foo&quot; && typeof bar.name === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _foo = function _foo() {};\n\n  ;\n  var _bar = (function () {\n    var _bar = function _bar() {};\n\n    _classProps(_bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _bar;\n  })();\n\n  ;\n  return _foo.name === \"foo\" && typeof _bar.name === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var foo = function foo() {};\n\n  ;\n  var bar = (function () {\n    var bar = function bar() {};\n\n    _classProps(bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return bar;\n  })();\n\n  ;\n  return foo.name === \"foo\" && typeof bar.name === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3162,9 +3146,9 @@ test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (
 (function () {
   var o = { foo: function () {}, bar: function baz() {} };
   o.qux = function () {};
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3177,23 +3161,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, null, {
+    _classProps(C, null, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _C;
+    return C;
   })();
 
   ;
-  return (new _C()).foo.name === &quot;foo&quot;;
+  return (new C()).foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return (new _C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return (new C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3206,23 +3190,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, {
+    _classProps(C, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _C;
+    return C;
   })();
 
   ;
-  return _C.foo.name === &quot;foo&quot;;
+  return C.foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return _C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3230,10 +3214,10 @@ test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var descriptor = Object.getOwnPropertyDescriptor(function () {}, &quot;name&quot;);
+  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, &quot;name&quot;);
   return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var descriptor = Object.getOwnPropertyDescriptor(function () {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3498,13 +3482,15 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var symbol
   var passed = false;
   var obj = { foo: true };
   var C = function () {};
-  C[Symbol.hasInstance] = function (inst) {
-    passed = inst.foo;return false;
-  };
+  Object.defineProperty(C, Symbol.hasInstance, {
+    value: function (inst) {
+      passed = inst.foo;return false;
+    }
+  });
   obj instanceof C;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var passed = false;\n  var obj = { foo: true };\n  var C = function () {};\n  C[Symbol.hasInstance] = function (inst) {\n    passed = inst.foo;return false;\n  };\n  obj instanceof C;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var passed = false;\n  var obj = { foo: true };\n  var C = function () {};\n  Object.defineProperty(C, Symbol.hasInstance, {\n    value: function (inst) {\n      passed = inst.foo;return false;\n    }\n  });\n  obj instanceof C;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -4019,6 +4005,38 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  // Note: only available outside of strict mode.
+  {
+    function f() {
+      return 1;
+    }
+  }
+  function g() {
+    return 1;
+  }{
+    function g() {
+      return 2;
+    }
+  }
+  {
+    function h() {
+      return 1;
+    }
+  }function h() {
+    return 2;
+  }
+
+  return f() === 1 && g() === 2 && h() === 1;
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }{\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -4080,37 +4098,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  if (!({ __
   return !({ __proto__: function () {} } instanceof Function);
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  if (!({ __proto__: [] } instanceof Array)) {\n    return false;\n  }\n  return !({ __proto__: function () {} } instanceof Function);\n});")()}catch(e){return false;}}());
-</script>
-
-        </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  // Note: only available outside of strict mode.
-  var passed = f() === 2 && g() === 4;
-  if (true) {
-    function f() {
-      return 1;
-    }
-  } else {
-    function f() {
-      return 2;
-    }
-  }
-  if (false) {
-    function g() {
-      return 3;
-    }
-  } else {
-    function g() {
-      return 4;
-    }
-  }
-  return passed;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  var passed = f() === 2 && g() === 4;\n  if (true) {\n    function f() {\n      return 1;\n    }\n  } else {\n    function f() {\n      return 2;\n    }\n  }\n  if (false) {\n    function g() {\n      return 3;\n    }\n  } else {\n    function g() {\n      return 4;\n    }\n  }\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4190,9 +4177,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/compilers/6to5.html
+++ b/es6/compilers/6to5.html
@@ -585,15 +585,23 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <script data-source="&quot;use strict&quot;;
 
-var _slice = Array.prototype.slice;
+var _argumentsToArray = function (args) {
+  var target = new Array(args.length);
+  for (var i = 0; i < args.length; i++) {
+    target[i] = args[i];
+  }
+
+  return target;
+};
+
 (function () {
   return (function () {
-    var args = _slice.call(arguments);
+    var args = _argumentsToArray(arguments);
 
     return typeof args !== &quot;undefined&quot;;
   }());
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _slice = Array.prototype.slice;\n(function () {\n  return (function () {\n    var args = _slice.call(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _argumentsToArray = function (args) {\n  var target = new Array(args.length);\n  for (var i = 0; i < args.length; i++) {\n    target[i] = args[i];\n  }\n\n  return target;\n};\n\n(function () {\n  return (function () {\n    var args = _argumentsToArray(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -615,73 +623,97 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Mat
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return [1, 2, 3][2] === 3;
+  return [1, 2, 3].concat()[2] === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [1, 2, 3][2] === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [1, 2, 3].concat()[2] === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with strings, in function calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
-  return Math.max.apply(Math, Array.from(&quot;1234&quot;)) === 4;
+  return Math.max.apply(Math, _toArray(&quot;1234&quot;)) === 4;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Math.max.apply(Math, Array.from(\"1234\")) === 4;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return Math.max.apply(Math, _toArray(\"1234\")) === 4;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with strings, in array literals</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
-  return [&quot;a&quot;].concat(Array.from(&quot;bcd&quot;), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(&quot;bcd&quot;), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return [\"a\"].concat(Array.from(\"bcd\"), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return [\"a\"].concat(_toArray(\"bcd\"), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  return Math.max.apply(Math, Array.from(iterable)) === 3;
+  return Math.max.apply(Math, _toArray(iterable)) === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, Array.from(iterable)) === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, _toArray(iterable)) === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
-  return [&quot;a&quot;].concat(Array.from(iterable), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(iterable), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(Array.from(iterable), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(_toArray(iterable), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in calls</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  return Math.max.apply(Math, Array.from(Object.create(iterable))) === 3;
+  return Math.max.apply(Math, _toArray(Object.create(iterable))) === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, Array.from(Object.create(iterable))) === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  return Math.max.apply(Math, _toArray(Object.create(iterable))) === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
-  return [&quot;a&quot;].concat(Array.from(Object.create(iterable)), [&quot;e&quot;])[3] === &quot;d&quot;;
+  return [&quot;a&quot;].concat(_toArray(Object.create(iterable)), [&quot;e&quot;])[3] === &quot;d&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(Array.from(Object.create(iterable)), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(\"b\", \"c\", \"d\");\n  return [\"a\"].concat(_toArray(Object.create(iterable)), [\"e\"])[3] === \"d\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -693,11 +725,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {};
+  var _C = function _C() {};
 
-  return typeof C === &quot;function&quot;;
+  return typeof _C === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  return typeof C === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  return typeof _C === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -705,16 +737,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = fu
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {};
+  var _C = function _C() {};
 
   {
     (function () {
-      var D = function D() {};
+      var _D = function _D() {};
     })();
   }
-  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  {\n    (function () {\n      var D = function D() {};\n    })();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -732,13 +764,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var C = function C() {
+  var _C = function _C() {
     this.x = 1;
   };
 
-  return C.prototype.constructor === C && new C().x === 1;
+  return _C.prototype.constructor === _C && new _C().x === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {\n    this.x = 1;\n  };\n\n  return C.prototype.constructor === C && new C().x === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {\n    this.x = 1;\n  };\n\n  return _C.prototype.constructor === _C && new _C().x === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -751,10 +783,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, null, {
+    _classProps(_C, null, {
       method: {
         writable: true,
         value: function () {
@@ -763,12 +795,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return C;
+    return _C;
   })();
 
-  return typeof C.prototype.method === &quot;function&quot; && new C().method() === 2;
+  return typeof _C.prototype.method === &quot;function&quot; && new _C().method() === 2;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.prototype.method === \"function\" && new C().method() === 2;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.prototype.method === \"function\" && new _C().method() === 2;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -781,10 +813,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, {
+    _classProps(_C, {
       method: {
         writable: true,
         value: function () {
@@ -793,12 +825,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return C;
+    return _C;
   })();
 
-  return typeof C.method === &quot;function&quot; && C.method() === 3;
+  return typeof _C.method === &quot;function&quot; && _C.method() === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.method === \"function\" && C.method() === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.method === \"function\" && _C.method() === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -848,19 +880,19 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var C = (function (Array) {
-    var C = function C() {
+  var _C = (function (Array) {
+    var _C = function _C() {
       Array.apply(this, arguments);
     };
 
-    _extends(C, Array);
+    _extends(_C, Array);
 
-    return C;
+    return _C;
   })(Array);
 
-  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);
+  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var C = (function (Array) {\n    var C = function C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(C, Array);\n\n    return C;\n  })(Array);\n\n  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _C = (function (Array) {\n    var _C = function _C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(_C, Array);\n\n    return _C;\n  })(Array);\n\n  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -884,21 +916,21 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B(a) {
+  var _B = (function (_ref) {
+    var _B = function _B(a) {
       return _ref.call(this, &quot;bar&quot; + a);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    return B;
+    return _B;
   })(function (a) {
     return [&quot;foo&quot; + a];
   });
 
-  return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
+  return new _B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(B, _ref);\n\n    return B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(_B, _ref);\n\n    return _B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new _B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -923,14 +955,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B() {
+  var _B = (function (_ref) {
+    var _B = function _B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    _classProps(B, null, {
+    _classProps(_B, null, {
       qux: {
         writable: true,
         value: function (a) {
@@ -939,7 +971,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return B;
+    return _B;
   })((function () {
     var _class = function () {};
 
@@ -955,9 +987,9 @@ var _extends = function (child, parent) {
     return _class;
   })());
 
-  return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
+  return new _B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new _B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -982,14 +1014,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var B = (function (_ref) {
-    var B = function B() {
+  var _B = (function (_ref) {
+    var _B = function _B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(B, _ref);
+    _extends(_B, _ref);
 
-    _classProps(B, null, {
+    _classProps(_B, null, {
       qux: {
         writable: true,
         value: function () {
@@ -998,7 +1030,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return B;
+    return _B;
   })((function () {
     var _class = function () {};
 
@@ -1015,12 +1047,12 @@ var _extends = function (child, parent) {
   })());
 
   var obj = {
-    qux: B.prototype.qux,
+    qux: _B.prototype.qux,
     corge: &quot;ley&quot;
   };
   return obj.qux() === &quot;barley&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: _B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1142,14 +1174,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var result
 
 (function () {
   var generator = regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: context$2$0.next = 2;
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: _context.next = 2;
           return 5;
-        case 2: context$2$0.next = 4;
+        case 2: _context.next = 4;
           return 6;
         case 4:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   });
@@ -1164,7 +1196,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var result
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: context$2$0.next = 2;\n          return 5;\n        case 2: context$2$0.next = 4;\n          return 6;\n        case 4:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  });\n\n  ;\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: _context.next = 2;\n          return 5;\n        case 2: _context.next = 4;\n          return 6;\n        case 4:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  });\n\n  ;\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1173,11 +1205,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var genera
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield([5, 6], &quot;t0&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield([5, 6], &quot;t0&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1189,7 +1221,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var genera
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield([5, 6], \"t0\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield([5, 6], \"t0\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1198,11 +1230,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(&quot;56&quot;, &quot;t1&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(&quot;56&quot;, &quot;t1&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1214,7 +1246,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(\"56\", \"t1\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === \"5\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === \"6\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(\"56\", \"t1\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === \"5\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === \"6\" && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1223,11 +1255,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), &quot;t2&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(__createIterableObject(5, 6, 7), &quot;t2&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1241,7 +1273,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1250,11 +1282,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var iterator = (regeneratorRuntime.mark(function generator() {
-    return regeneratorRuntime.wrap(function generator$(context$2$0) {
-      while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t3&quot;, 1);
+    return regeneratorRuntime.wrap(function generator$(_context) {
+      while (true) switch (_context.prev = _context.next) {
+        case 0: return _context.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t3&quot;, 1);
         case 1:
-        case &quot;end&quot;: return context$2$0.stop();
+        case &quot;end&quot;: return _context.stop();
       }
     }, generator, this);
   })());
@@ -1268,7 +1300,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(_context) {\n      while (true) switch (_context.prev = _context.next) {\n        case 0: return _context.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n        case 1:\n        case \"end\": return _context.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1277,17 +1309,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
 
 (function () {
   var o = {
-    generator: regeneratorRuntime.mark(function callee$1$0() {
-      return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-        while (true) switch (context$2$0.prev = context$2$0.next) {
-          case 0: context$2$0.next = 2;
+    generator: regeneratorRuntime.mark(function _callee() {
+      return regeneratorRuntime.wrap(function _callee$(_context) {
+        while (true) switch (_context.prev = _context.next) {
+          case 0: _context.next = 2;
             return 5;
-          case 2: context$2$0.next = 4;
+          case 2: _context.next = 4;
             return 6;
           case 4:
-          case &quot;end&quot;: return context$2$0.stop();
+          case &quot;end&quot;: return _context.stop();
         }
-      }, callee$1$0, this);
+      }, _callee, this);
     }) };
   var iterator = o.generator();
   var item = iterator.next();
@@ -1298,7 +1330,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {\n    generator: regeneratorRuntime.mark(function callee$1$0() {\n      return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {\n        while (true) switch (context$2$0.prev = context$2$0.next) {\n          case 0: context$2$0.next = 2;\n            return 5;\n          case 2: context$2$0.next = 4;\n            return 6;\n          case 4:\n          case \"end\": return context$2$0.stop();\n        }\n      }, callee$1$0, this);\n    }) };\n  var iterator = o.generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {\n    generator: regeneratorRuntime.mark(function _callee() {\n      return regeneratorRuntime.wrap(function _callee$(_context) {\n        while (true) switch (_context.prev = _context.next) {\n          case 0: _context.next = 2;\n            return 5;\n          case 2: _context.next = 4;\n            return 6;\n          case 4:\n          case \"end\": return _context.stop();\n        }\n      }, _callee, this);\n    }) };\n  var iterator = o.generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2726,60 +2758,86 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
           <td><span>with arrays</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [5, null, [6]];
 
-  var a = _ref[0];
-  var b = _ref[2][0];
-  var c = _ref[3];
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var _ref3 = _toArray(_ref2[2]);
+
+  var b = _ref3[0];
+  var c = _ref2[3];
   return a === 5 && b === 6 && c === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var a = _ref[0];\n  var b = _ref[2][0];\n  var c = _ref[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var _ref3 = _toArray(_ref2[2]);\n\n  var b = _ref3[0];\n  var c = _ref2[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with strings</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = &quot;bar&quot;;
 
-  var a = _ref[0];
-  var b = _ref[1];
-  var c = _ref[2];
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var b = _ref2[1];
+  var c = _ref2[2];
   return a === &quot;b&quot; && b === &quot;a&quot; && c === &quot;r&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = \"bar\";\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with generic iterables</span></td>
 <script data-source="&quot;use strict&quot;;
 
-(function () {
-  var iterable = __createIterableObject(1, 2, 3);
-  var a = iterable[0];
-  var b = iterable[1];
-  var c = iterable[2];
-  return a === 1 && b === 2 && c === 3;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var a = iterable[0];\n  var b = iterable[1];\n  var c = iterable[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="destructuring">
-          <td><span>with instances of generic iterables</span></td>
-<script data-source="&quot;use strict&quot;;
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
 
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  var _ref = Object.create(iterable);
+  var _ref = _toArray(iterable);
 
   var a = _ref[0];
   var b = _ref[1];
   var c = _ref[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = _toArray(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>with instances of generic iterables</span></td>
+<script data-source="&quot;use strict&quot;;
+
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
+(function () {
+  var iterable = __createIterableObject(1, 2, 3);
+  var _ref = Object.create(iterable);
+
+  var _ref2 = _toArray(_ref);
+
+  var a = _ref2[0];
+  var b = _ref2[1];
+  var c = _ref2[2];
+  return a === 1 && b === 2 && c === 3;
+});">
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2800,52 +2858,72 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
           <td><span>nested</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [9, { x: 10 }];
 
-  var e = _ref[0];
-  var f = _ref[1].x;
-  var g = _ref[1].g;
+  var _ref2 = _toArray(_ref);
+
+  var e = _ref2[0];
+  var f = _ref2[1].x;
+  var g = _ref2[1].g;
   return e === 9 && f === 10 && g === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var e = _ref[0];\n  var f = _ref[1].x;\n  var g = _ref[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var _ref2 = _toArray(_ref);\n\n  var e = _ref2[0];\n  var f = _ref2[1].x;\n  var g = _ref2[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>parameters</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   return (function (_ref, _ref2) {
     var a = _ref.a;
     var b = _ref.x;
     var e = _ref.y;
-    var c = _ref2[0];
-    var d = _ref2[1];
+    var _ref3 = _toArray(_ref2);
+
+    var c = _ref3[0];
+    var d = _ref3[1];
     return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;
   }({ a: 1, x: 2 }, [3, 4]));
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var c = _ref2[0];\n    var d = _ref2[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var _ref3 = _toArray(_ref2);\n\n    var c = _ref3[0];\n    var d = _ref3[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>rest</span></td>
 <script data-source="&quot;use strict&quot;;
 
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
 (function () {
   var _ref = [3, 4, 5];
 
-  var a = _ref[0];
-  var b = _ref.slice(1);
+  var _ref2 = _toArray(_ref);
 
-  var _ref2 = [6];
+  var a = _ref2[0];
+  var b = _toArray(_ref2).slice(1);
 
-  var c = _ref2[0];
-  var d = _ref2.slice(1);
+  var _ref3 = [6];
+
+  var _ref4 = _toArray(_ref3);
+
+  var c = _ref4[0];
+  var d = _toArray(_ref4).slice(1);
 
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var a = _ref[0];\n  var b = _ref.slice(1);\n\n  var _ref2 = [6];\n\n  var c = _ref2[0];\n  var d = _ref2.slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _toArray(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = _toArray(_ref3);\n\n  var c = _ref4[0];\n  var d = _toArray(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3060,26 +3138,26 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var foo = function foo() {};
+  var _foo = function _foo() {};
 
   ;
-  var bar = (function () {
-    var bar = function bar() {};
+  var _bar = (function () {
+    var _bar = function _bar() {};
 
-    _classProps(bar, {
+    _classProps(_bar, {
       name: {
         writable: true,
         value: function () {}
       }
     });
 
-    return bar;
+    return _bar;
   })();
 
   ;
-  return foo.name === &quot;foo&quot; && typeof bar.name === &quot;function&quot;;
+  return _foo.name === &quot;foo&quot; && typeof _bar.name === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var foo = function foo() {};\n\n  ;\n  var bar = (function () {\n    var bar = function bar() {};\n\n    _classProps(bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return bar;\n  })();\n\n  ;\n  return foo.name === \"foo\" && typeof bar.name === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _foo = function _foo() {};\n\n  ;\n  var _bar = (function () {\n    var _bar = function _bar() {};\n\n    _classProps(_bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _bar;\n  })();\n\n  ;\n  return _foo.name === \"foo\" && typeof _bar.name === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3159,23 +3237,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, null, {
+    _classProps(_C, null, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return C;
+    return _C;
   })();
 
   ;
-  return (new C()).foo.name === &quot;foo&quot;;
+  return (new _C()).foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return (new C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return (new _C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3188,23 +3266,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var C = (function () {
-    var C = function C() {};
+  var _C = (function () {
+    var _C = function _C() {};
 
-    _classProps(C, {
+    _classProps(_C, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return C;
+    return _C;
   })();
 
   ;
-  return C.foo.name === &quot;foo&quot;;
+  return _C.foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return _C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -4016,7 +4094,8 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
   }
   function g() {
     return 1;
-  }{
+  }
+  {
     function g() {
       return 2;
     }
@@ -4025,13 +4104,14 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
     function h() {
       return 1;
     }
-  }function h() {
+  }
+  function h() {
     return 2;
   }
 
   return f() === 1 && g() === 2 && h() === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }{\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }\n  {\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }\n  function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/6to5.html
+++ b/es6/compilers/6to5.html
@@ -562,6 +562,24 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
 
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return (function (a) {
+    if (a === undefined) a = function () {
+      return typeof b === &quot;undefined&quot;;
+    };
+    return (function () {
+      var b = 1;
+      return a();
+    })();
+  }());
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (a) {\n    if (a === undefined) a = function () {\n      return typeof b === \"undefined\";\n    };\n    return (function () {\n      var b = 1;\n      return a();\n    })();\n  }());\n});")()}catch(e){return false;}}());
+</script>
+
         </tr>
         <tr>
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
@@ -675,11 +693,11 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {};
+  var C = function C() {};
 
-  return typeof _C === &quot;function&quot;;
+  return typeof C === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  return typeof _C === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  return typeof C === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -687,16 +705,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = f
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {};
+  var C = function C() {};
 
   {
     (function () {
-      var _D = function _D() {};
+      var D = function D() {};
     })();
   }
-  return typeof _C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
+  return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {};\n\n  {\n    (function () {\n      var _D = function _D() {};\n    })();\n  }\n  return typeof _C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {};\n\n  {\n    (function () {\n      var D = function D() {};\n    })();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -714,13 +732,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var _C = function _C() {
+  var C = function C() {
     this.x = 1;
   };
 
-  return _C.prototype.constructor === _C && new _C().x === 1;
+  return C.prototype.constructor === C && new C().x === 1;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _C = function _C() {\n    this.x = 1;\n  };\n\n  return _C.prototype.constructor === _C && new _C().x === 1;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var C = function C() {\n    this.x = 1;\n  };\n\n  return C.prototype.constructor === C && new C().x === 1;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -733,10 +751,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, null, {
+    _classProps(C, null, {
       method: {
         writable: true,
         value: function () {
@@ -745,12 +763,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return _C;
+    return C;
   })();
 
-  return typeof _C.prototype.method === &quot;function&quot; && new _C().method() === 2;
+  return typeof C.prototype.method === &quot;function&quot; && new C().method() === 2;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.prototype.method === \"function\" && new _C().method() === 2;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      method: {\n        writable: true,\n        value: function () {\n          return 2;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.prototype.method === \"function\" && new C().method() === 2;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -763,10 +781,10 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, {
+    _classProps(C, {
       method: {
         writable: true,
         value: function () {
@@ -775,12 +793,12 @@ var _classProps = function (child, staticProps, instanceProps) {
       }
     });
 
-    return _C;
+    return C;
   })();
 
-  return typeof _C.method === &quot;function&quot; && _C.method() === 3;
+  return typeof C.method === &quot;function&quot; && C.method() === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return _C;\n  })();\n\n  return typeof _C.method === \"function\" && _C.method() === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      method: {\n        writable: true,\n        value: function () {\n          return 3;\n        }\n      }\n    });\n\n    return C;\n  })();\n\n  return typeof C.method === \"function\" && C.method() === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -830,19 +848,19 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _C = (function (Array) {
-    var _C = function _C() {
+  var C = (function (Array) {
+    var C = function C() {
       Array.apply(this, arguments);
     };
 
-    _extends(_C, Array);
+    _extends(C, Array);
 
-    return _C;
+    return C;
   })(Array);
 
-  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);
+  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _C = (function (Array) {\n    var _C = function _C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(_C, Array);\n\n    return _C;\n  })(Array);\n\n  return Array.isPrototypeOf(_C) && Array.prototype.isPrototypeOf(_C.prototype);\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var C = (function (Array) {\n    var C = function C() {\n      Array.apply(this, arguments);\n    };\n\n    _extends(C, Array);\n\n    return C;\n  })(Array);\n\n  return Array.isPrototypeOf(C) && Array.prototype.isPrototypeOf(C.prototype);\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -866,21 +884,21 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B(a) {
+  var B = (function (_ref) {
+    var B = function B(a) {
       return _ref.call(this, &quot;bar&quot; + a);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    return _B;
+    return B;
   })(function (a) {
     return [&quot;foo&quot; + a];
   });
 
-  return new _B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
+  return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(_B, _ref);\n\n    return _B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new _B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B(a) {\n      return _ref.call(this, \"bar\" + a);\n    };\n\n    _extends(B, _ref);\n\n    return B;\n  })(function (a) {\n    return [\"foo\" + a];\n  });\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -905,14 +923,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B() {
+  var B = (function (_ref) {
+    var B = function B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    _classProps(_B, null, {
+    _classProps(B, null, {
       qux: {
         writable: true,
         value: function (a) {
@@ -921,7 +939,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return _B;
+    return B;
   })((function () {
     var _class = function () {};
 
@@ -937,9 +955,9 @@ var _extends = function (child, parent) {
     return _class;
   })());
 
-  return new _B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
+  return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new _B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return _ref.prototype.qux.call(this, \"bar\" + a);\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function (a) {\n          return \"foo\" + a;\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -964,14 +982,14 @@ var _extends = function (child, parent) {
 };
 
 (function () {
-  var _B = (function (_ref) {
-    var _B = function _B() {
+  var B = (function (_ref) {
+    var B = function B() {
       _ref.apply(this, arguments);
     };
 
-    _extends(_B, _ref);
+    _extends(B, _ref);
 
-    _classProps(_B, null, {
+    _classProps(B, null, {
       qux: {
         writable: true,
         value: function () {
@@ -980,7 +998,7 @@ var _extends = function (child, parent) {
       }
     });
 
-    return _B;
+    return B;
   })((function () {
     var _class = function () {};
 
@@ -997,12 +1015,12 @@ var _extends = function (child, parent) {
   })());
 
   var obj = {
-    qux: _B.prototype.qux,
+    qux: B.prototype.qux,
     corge: &quot;ley&quot;
   };
   return obj.qux() === &quot;barley&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var _B = (function (_ref) {\n    var _B = function _B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(_B, _ref);\n\n    _classProps(_B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return _B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: _B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\nvar _extends = function (child, parent) {\n  child.prototype = Object.create(parent.prototype, {\n    constructor: {\n      value: child,\n      enumerable: false,\n      writable: true,\n      configurable: true\n    }\n  });\n  child.__proto__ = parent;\n};\n\n(function () {\n  var B = (function (_ref) {\n    var B = function B() {\n      _ref.apply(this, arguments);\n    };\n\n    _extends(B, _ref);\n\n    _classProps(B, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return _ref.prototype.qux.call(this) + this.corge;\n        }\n      }\n    });\n\n    return B;\n  })((function () {\n    var _class = function () {};\n\n    _classProps(_class, null, {\n      qux: {\n        writable: true,\n        value: function () {\n          return \"bar\";\n        }\n      }\n    });\n\n    return _class;\n  })());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1207,18 +1225,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   var iterator = (regeneratorRuntime.mark(function generator() {
     return regeneratorRuntime.wrap(function generator$(context$2$0) {
       while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield((regeneratorRuntime.mark(function callee$2$0() {
-            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-              while (true) switch (context$3$0.prev = context$3$0.next) {
-                case 0: context$3$0.next = 2;
-                  return 5;
-                case 2: context$3$0.next = 4;
-                  return 6;
-                case 4:
-                case &quot;end&quot;: return context$3$0.stop();
-              }
-            }, callee$2$0, this);
-          })()), &quot;t2&quot;, 1);
+        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), &quot;t2&quot;, 1);
         case 1:
         case &quot;end&quot;: return context$2$0.stop();
       }
@@ -1229,10 +1236,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield((regeneratorRuntime.mark(function callee$2$0() {\n            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n              while (true) switch (context$3$0.prev = context$3$0.next) {\n                case 0: context$3$0.next = 2;\n                  return 5;\n                case 2: context$3$0.next = 4;\n                  return 6;\n                case 4:\n                case \"end\": return context$3$0.stop();\n              }\n            }, callee$2$0, this);\n          })()), \"t2\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1243,18 +1252,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   var iterator = (regeneratorRuntime.mark(function generator() {
     return regeneratorRuntime.wrap(function generator$(context$2$0) {
       while (true) switch (context$2$0.prev = context$2$0.next) {
-        case 0: return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {
-            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-              while (true) switch (context$3$0.prev = context$3$0.next) {
-                case 0: context$3$0.next = 2;
-                  return 5;
-                case 2: context$3$0.next = 4;
-                  return 6;
-                case 4:
-                case &quot;end&quot;: return context$3$0.stop();
-              }
-            }, callee$2$0, this);
-          })()), &quot;t3&quot;, 1);
+        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t3&quot;, 1);
         case 1:
         case &quot;end&quot;: return context$2$0.stop();
       }
@@ -1265,10 +1263,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterat
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {\n            return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n              while (true) switch (context$3$0.prev = context$3$0.next) {\n                case 0: context$3$0.next = 2;\n                  return 5;\n                case 2: context$3$0.next = 4;\n                  return 6;\n                case 4:\n                case \"end\": return context$3$0.stop();\n              }\n            }, callee$2$0, this);\n          })()), \"t3\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterator = (regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (true) switch (context$2$0.prev = context$2$0.next) {\n        case 0: return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n        case 1:\n        case \"end\": return context$2$0.stop();\n      }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -2359,11 +2359,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxie
   Object.defineProperty(new Proxy(proxied, {
     defineProperty: function (t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+      return true;
     }
-  }), &quot;foo&quot;, { value: 5 });
+  }), &quot;foo&quot;, { value: 5, configurable: true });
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }), \"foo\", { value: 5 });\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }), \"foo\", { value: 5, configurable: true });\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -2728,16 +2729,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  \"use stri
 (function () {
   var _ref = [5, null, [6]];
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var _ref3 = Array.from(_ref2[2]);
-
-  var b = _ref3[0];
-  var c = _ref2[3];
+  var a = _ref[0];
+  var b = _ref[2][0];
+  var c = _ref[3];
   return a === 5 && b === 6 && c === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var _ref3 = Array.from(_ref2[2]);\n\n  var b = _ref3[0];\n  var c = _ref2[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [5, null, [6]];\n\n  var a = _ref[0];\n  var b = _ref[2][0];\n  var c = _ref[3];\n  return a === 5 && b === 6 && c === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2747,14 +2744,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 (function () {
   var _ref = &quot;bar&quot;;
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var b = _ref2[1];
-  var c = _ref2[2];
+  var a = _ref[0];
+  var b = _ref[1];
+  var c = _ref[2];
   return a === &quot;b&quot; && b === &quot;a&quot; && c === &quot;r&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = \"bar\";\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === \"b\" && b === \"a\" && c === \"r\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2763,14 +2758,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 
 (function () {
   var iterable = __createIterableObject(1, 2, 3);
-  var _ref = Array.from(iterable);
-
-  var a = _ref[0];
-  var b = _ref[1];
-  var c = _ref[2];
+  var a = iterable[0];
+  var b = iterable[1];
+  var c = iterable[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Array.from(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var a = iterable[0];\n  var b = iterable[1];\n  var c = iterable[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2781,14 +2774,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterab
   var iterable = __createIterableObject(1, 2, 3);
   var _ref = Object.create(iterable);
 
-  var _ref2 = Array.from(_ref);
-
-  var a = _ref2[0];
-  var b = _ref2[1];
-  var c = _ref2[2];
+  var a = _ref[0];
+  var b = _ref[1];
+  var c = _ref[2];
   return a === 1 && b === 2 && c === 3;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = _ref2[1];\n  var c = _ref2[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var iterable = __createIterableObject(1, 2, 3);\n  var _ref = Object.create(iterable);\n\n  var a = _ref[0];\n  var b = _ref[1];\n  var c = _ref[2];\n  return a === 1 && b === 2 && c === 3;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2812,14 +2803,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
 (function () {
   var _ref = [9, { x: 10 }];
 
-  var _ref2 = Array.from(_ref);
-
-  var e = _ref2[0];
-  var f = _ref2[1].x;
-  var g = _ref2[1].g;
+  var e = _ref[0];
+  var f = _ref[1].x;
+  var g = _ref[1].g;
   return e === 9 && f === 10 && g === undefined;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var _ref2 = Array.from(_ref);\n\n  var e = _ref2[0];\n  var f = _ref2[1].x;\n  var g = _ref2[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [9, { x: 10 }];\n\n  var e = _ref[0];\n  var f = _ref[1].x;\n  var g = _ref[1].g;\n  return e === 9 && f === 10 && g === undefined;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2831,14 +2820,12 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref =
     var a = _ref.a;
     var b = _ref.x;
     var e = _ref.y;
-    var _ref3 = Array.from(_ref2);
-
-    var c = _ref3[0];
-    var d = _ref3[1];
+    var c = _ref2[0];
+    var d = _ref2[1];
     return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;
   }({ a: 1, x: 2 }, [3, 4]));
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var _ref3 = Array.from(_ref2);\n\n    var c = _ref3[0];\n    var d = _ref3[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (function (_ref, _ref2) {\n    var a = _ref.a;\n    var b = _ref.x;\n    var e = _ref.y;\n    var c = _ref2[0];\n    var d = _ref2[1];\n    return a === 1 && b === 2 && c === 3 && d === 4 && e === undefined;\n  }({ a: 1, x: 2 }, [3, 4]));\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2848,21 +2835,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
 (function () {
   var _ref = [3, 4, 5];
 
-  var _ref2 = Array.from(_ref);
+  var a = _ref[0];
+  var b = _ref.slice(1);
 
-  var a = _ref2[0];
-  var b = Array.from(_ref2).slice(1);
+  var _ref2 = [6];
 
-  var _ref3 = [6];
-
-  var _ref4 = Array.from(_ref3);
-
-  var c = _ref4[0];
-  var d = Array.from(_ref4).slice(1);
+  var c = _ref2[0];
+  var d = _ref2.slice(1);
 
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = Array.from(_ref);\n\n  var a = _ref2[0];\n  var b = Array.from(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = Array.from(_ref3);\n\n  var c = _ref4[0];\n  var d = Array.from(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var a = _ref[0];\n  var b = _ref.slice(1);\n\n  var _ref2 = [6];\n\n  var c = _ref2[0];\n  var d = _ref2.slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2882,10 +2865,10 @@ test(function(){try{return Function("/* Error during compilation: unknown: Unexp
   1  | (function(){
 > 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
      |                    ^
-  3  |   return a === 1 && b === 2 && c === 3 && d === 4 && 
+  3  |   return a === 1 && b === 2 && c === 3 && d === 4 &&
   4  |     e === 5 && f === undefined;
   5  | }({b:2, c:undefined, x:4}));*/">
-test(function(){try{return Function("/* Error during compilation: unknown: Unexpected token (2:20)\n  1  | (function(){\n> 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n     |                    ^\n  3  |   return a === 1 && b === 2 && c === 3 && d === 4 && \n  4  |     e === 5 && f === undefined;\n  5  | }({b:2, c:undefined, x:4}));*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: unknown: Unexpected token (2:20)\n  1  | (function(){\n> 2  | return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n     |                    ^\n  3  |   return a === 1 && b === 2 && c === 3 && d === 4 &&\n  4  |     e === 5 && f === undefined;\n  5  | }({b:2, c:undefined, x:4}));*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3012,9 +2995,9 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var foo = 
 (function () {
   var o = { foo: function () {}, bar: function baz() {} };
   o.qux = function () {};
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3026,16 +3009,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { 
     Object.defineProperties(_o, {
       foo: {
         get: function () {},
-        set: function () {}
+        set: function (x) {}
       }
     });
 
     return _o;
   })({});
   var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
-  return descriptor.get.name === &quot;get foo&quot; && descriptor.get.name === &quot;set foo&quot;;
+  return descriptor.get.name === &quot;get foo&quot; && descriptor.set.name === &quot;set foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = (function (_o) {\n    Object.defineProperties(_o, {\n      foo: {\n        get: function () {},\n        set: function () {}\n      }\n    });\n\n    return _o;\n  })({});\n  var descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\n  return descriptor.get.name === \"get foo\" && descriptor.get.name === \"set foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = (function (_o) {\n    Object.defineProperties(_o, {\n      foo: {\n        get: function () {},\n        set: function (x) {}\n      }\n    });\n\n    return _o;\n  })({});\n  var descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\n  return descriptor.get.name === \"get foo\" && descriptor.set.name === \"set foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3054,16 +3037,17 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { 
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var o = {};
-  var sym = Symbol(&quot;foo&quot;);
+  var sym1 = Symbol(&quot;foo&quot;);
   var sym2 = Symbol();
-
-  o[sym] = function () {};
-  o[sym2] = function () {};
+  var o = (function (_o) {
+    _o[sym1] = function () {};
+    _o[sym2] = function () {};
+    return _o;
+  })({});
 
   return o[sym].name === &quot;[foo]&quot; && o[sym2].name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = {};\n  var sym = Symbol(\"foo\");\n  var sym2 = Symbol();\n\n  o[sym] = function () {};\n  o[sym2] = function () {};\n\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = (function (_o) {\n    _o[sym1] = function () {};\n    _o[sym2] = function () {};\n    return _o;\n  })({});\n\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3076,26 +3060,26 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _foo = function _foo() {};
+  var foo = function foo() {};
 
   ;
-  var _bar = (function () {
-    var _bar = function _bar() {};
+  var bar = (function () {
+    var bar = function bar() {};
 
-    _classProps(_bar, {
+    _classProps(bar, {
       name: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _bar;
+    return bar;
   })();
 
   ;
-  return _foo.name === &quot;foo&quot; && typeof _bar.name === &quot;function&quot;;
+  return foo.name === &quot;foo&quot; && typeof bar.name === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _foo = function _foo() {};\n\n  ;\n  var _bar = (function () {\n    var _bar = function _bar() {};\n\n    _classProps(_bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _bar;\n  })();\n\n  ;\n  return _foo.name === \"foo\" && typeof _bar.name === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var foo = function foo() {};\n\n  ;\n  var bar = (function () {\n    var bar = function bar() {};\n\n    _classProps(bar, {\n      name: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return bar;\n  })();\n\n  ;\n  return foo.name === \"foo\" && typeof bar.name === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3160,9 +3144,9 @@ test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (
 (function () {
   var o = { foo: function () {}, bar: function baz() {} };
   o.qux = function () {};
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var o = { foo: function () {}, bar: function baz() {} };\n  o.qux = function () {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3175,23 +3159,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, null, {
+    _classProps(C, null, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _C;
+    return C;
   })();
 
   ;
-  return (new _C()).foo.name === &quot;foo&quot;;
+  return (new C()).foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return (new _C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, null, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return (new C()).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3204,23 +3188,23 @@ var _classProps = function (child, staticProps, instanceProps) {
 };
 
 (function () {
-  var _C = (function () {
-    var _C = function _C() {};
+  var C = (function () {
+    var C = function C() {};
 
-    _classProps(_C, {
+    _classProps(C, {
       foo: {
         writable: true,
         value: function () {}
       }
     });
 
-    return _C;
+    return C;
   })();
 
   ;
-  return _C.foo.name === &quot;foo&quot;;
+  return C.foo.name === &quot;foo&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var _C = (function () {\n    var _C = function _C() {};\n\n    _classProps(_C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return _C;\n  })();\n\n  ;\n  return _C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (child, staticProps, instanceProps) {\n  if (staticProps) Object.defineProperties(child, staticProps);\n  if (instanceProps) Object.defineProperties(child.prototype, instanceProps);\n};\n\n(function () {\n  var C = (function () {\n    var C = function C() {};\n\n    _classProps(C, {\n      foo: {\n        writable: true,\n        value: function () {}\n      }\n    });\n\n    return C;\n  })();\n\n  ;\n  return C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3228,10 +3212,10 @@ test(function(){try{return eval("\"use strict\";\n\nvar _classProps = function (
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  var descriptor = Object.getOwnPropertyDescriptor(function () {}, &quot;name&quot;);
+  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, &quot;name&quot;);
   return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var descriptor = Object.getOwnPropertyDescriptor(function () {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3496,13 +3480,15 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var symbol
   var passed = false;
   var obj = { foo: true };
   var C = function () {};
-  C[Symbol.hasInstance] = function (inst) {
-    passed = inst.foo;return false;
-  };
+  Object.defineProperty(C, Symbol.hasInstance, {
+    value: function (inst) {
+      passed = inst.foo;return false;
+    }
+  });
   obj instanceof C;
   return passed;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var passed = false;\n  var obj = { foo: true };\n  var C = function () {};\n  C[Symbol.hasInstance] = function (inst) {\n    passed = inst.foo;return false;\n  };\n  obj instanceof C;\n  return passed;\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var passed = false;\n  var obj = { foo: true };\n  var C = function () {};\n  Object.defineProperty(C, Symbol.hasInstance, {\n    value: function (inst) {\n      passed = inst.foo;return false;\n    }\n  });\n  obj instanceof C;\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -4017,6 +4003,38 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  // Note: only available outside of strict mode.
+  {
+    function f() {
+      return 1;
+    }
+  }
+  function g() {
+    return 1;
+  }{
+    function g() {
+      return 2;
+    }
+  }
+  {
+    function h() {
+      return 1;
+    }
+  }function h() {
+    return 2;
+  }
+
+  return f() === 1 && g() === 2 && h() === 1;
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  {\n    function f() {\n      return 1;\n    }\n  }\n  function g() {\n    return 1;\n  }{\n    function g() {\n      return 2;\n    }\n  }\n  {\n    function h() {\n      return 1;\n    }\n  }function h() {\n    return 2;\n  }\n\n  return f() === 1 && g() === 2 && h() === 1;\n});")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -4078,37 +4096,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  if (!({ __
   return !({ __proto__: function () {} } instanceof Function);
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  if (!({ __proto__: [] } instanceof Array)) {\n    return false;\n  }\n  return !({ __proto__: function () {} } instanceof Function);\n});")()}catch(e){return false;}}());
-</script>
-
-        </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  // Note: only available outside of strict mode.
-  var passed = f() === 2 && g() === 4;
-  if (true) {
-    function f() {
-      return 1;
-    }
-  } else {
-    function f() {
-      return 2;
-    }
-  }
-  if (false) {
-    function g() {
-      return 3;
-    }
-  } else {
-    function g() {
-      return 4;
-    }
-  }
-  return passed;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  // Note: only available outside of strict mode.\n  var passed = f() === 2 && g() === 4;\n  if (true) {\n    function f() {\n      return 1;\n    }\n  } else {\n    function f() {\n      return 2;\n    }\n  }\n  if (false) {\n    function g() {\n      return 3;\n    }\n  } else {\n    function g() {\n      return 4;\n    }\n  }\n  return passed;\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4188,9 +4175,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/compilers/es6-transpiler.html
+++ b/es6/compilers/es6-transpiler.html
@@ -146,9 +146,9 @@ test(function(){try{return Function("/* Error during compilation: This test's co
           <td><span>no "prototype" property</span></td>
 <script data-source="(function(){
 var a = function()  {return 5};
-return !a.hasOwnProperty(&quot;prototype&quot;); 
+return !a.hasOwnProperty(&quot;prototype&quot;);
       })">
-test(function(){try{return eval("(function(){\nvar a = function()  {return 5};\nreturn !a.hasOwnProperty(\"prototype\"); \n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar a = function()  {return 5};\nreturn !a.hasOwnProperty(\"prototype\");\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -331,6 +331,19 @@ test(function(){try{return eval("(function(){\nreturn (function (a) {var b = arg
           <td><span>temporal dead zone</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="(function(){
+return (function(){var a = arguments[0];if(a === void 0)a = function(){
+  return typeof b === 'undefined';
+};
+  var b = 1;
+  return a();
+}());
+      })">
+test(function(){try{return eval("(function(){\nreturn (function(){var a = arguments[0];if(a === void 0)a = function(){\n  return typeof b === 'undefined';\n};\n  var b = 1;\n  return a();\n}());\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -610,7 +623,7 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
         <tr class="subtest" data-parent="generators">
           <td><span>basic functionality</span></td>
 <script data-source="(function(){
-function* generator(){
+function * generator(){
   yield 5; yield 6;
 };
 var iterator = generator();
@@ -622,13 +635,13 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nfunction* generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, arrays</span></td>
 <script data-source="(function(){
-var iterator = (function* generator() {
+var iterator = (function * generator() {
   yield * [5, 6];
 }());
 var item = iterator.next();
@@ -639,13 +652,13 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar iterator = (function* generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, strings</span></td>
 <script data-source="(function(){
-var iterator = (function* generator() {
+var iterator = (function * generator() {
   yield * &quot;56&quot;;
 }());
 var item = iterator.next();
@@ -656,45 +669,19 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar iterator = (function* generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, generic iterables</span></td>
-<script data-source="(function(){
-var iterator = (function* generator() {
-  yield * (function* () {
-    yield 5; yield 6;
-  }());
-}());
-var item = iterator.next();
-var passed = item.value === 5 && item.done === false;
-item = iterator.next();
-passed    &= item.value === 6 && item.done === false;
-item = iterator.next();
-passed    &= item.value === undefined && item.done === true;
-return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (function* generator() {\n  yield * (function* () {\n    yield 5; yield 6;\n  }());\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, instances of iterables</span></td>
-<script data-source="(function(){
-var iterator = (function* generator() {
-  yield * Object.create(function* () {
-    yield 5; yield 6;
-  }());
-}());
-var item = iterator.next();
-var passed = item.value === 5 && item.done === false;
-item = iterator.next();
-passed    &= item.value === 6 && item.done === false;
-item = iterator.next();
-passed    &= item.value === undefined && item.done === true;
-return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (function* generator() {\n  yield * Object.create(function* () {\n    yield 5; yield 6;\n  }());\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -920,10 +907,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint8(0, 0x100); 
+view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100); \nreturn view.getUint8(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -931,10 +918,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setInt16(0, 0x8000); 
+view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000); \nreturn view.getInt16(0) === -0x8000;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -942,10 +929,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint16(0, 0x10000); 
+view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000); \nreturn view.getUint16(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -953,10 +940,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setInt32(0, 0x80000000); 
+view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000); \nreturn view.getInt32(0) === -0x80000000;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -964,10 +951,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint32(0, 0x100000000); 
+view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000); \nreturn view.getUint32(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -975,10 +962,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setFloat32(0, 0.1); 
+view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1); \nreturn view.getFloat32(0) === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -986,10 +973,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setFloat64(0, 0.1); 
+view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1); \nreturn view.getFloat64(0) === 0.1;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1795,14 +1782,15 @@ Object.defineProperty(
   new Proxy(proxied, {
     defineProperty: function (t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+      return true;
     }
   }),
   &quot;foo&quot;,
-  { value: 5 }
+  { value: 5, configurable: true }
 );
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }),\n  \"foo\",\n  { value: 5 }\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -1918,7 +1906,7 @@ test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = f
 var proxied = function(){};
 var passed = false;
 var host = {
-  method: new Proxy(proxied, { 
+  method: new Proxy(proxied, {
     apply: function (t, thisArg, args) {
       passed = t === proxied && thisArg === host && args + &quot;&quot; === &quot;foo,bar&quot;;
     }
@@ -1927,7 +1915,7 @@ var host = {
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, { \n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -2150,11 +2138,11 @@ test(function(){try{return eval("(function(){\nvar a = ((a = (c = {b:2, c:undefi
           <td><span>defaults in parameters</span></td>
 <script data-source="(function(){
 return (function(f) {var a = ((a = f.a) === void 0 ? 1 : a), b = ((b = f.b) === void 0 ? 0 : b), c = ((c = f.c) === void 0 ? 3 : c), d = ((d = f.x) === void 0 ? 0 : d), e = ((e = f.y) === void 0 ? 5 : e), f = f.z;
-  return a === 1 && b === 2 && c === 3 && d === 4 && 
+  return a === 1 && b === 2 && c === 3 && d === 4 &&
     e === 5 && f === undefined;
 }({b:2, c:undefined, x:4}));
       })">
-test(function(){try{return eval("(function(){\nreturn (function(f) {var a = ((a = f.a) === void 0 ? 1 : a), b = ((b = f.b) === void 0 ? 0 : b), c = ((c = f.c) === void 0 ? 3 : c), d = ((d = f.x) === void 0 ? 0 : d), e = ((e = f.y) === void 0 ? 5 : e), f = f.z;\n  return a === 1 && b === 2 && c === 3 && d === 4 && \n    e === 5 && f === undefined;\n}({b:2, c:undefined, x:4}));\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nreturn (function(f) {var a = ((a = f.a) === void 0 ? 1 : a), b = ((b = f.b) === void 0 ? 0 : b), c = ((c = f.c) === void 0 ? 3 : c), d = ((d = f.x) === void 0 ? 0 : d), e = ((e = f.y) === void 0 ? 5 : e), f = f.z;\n  return a === 1 && b === 2 && c === 3 && d === 4 &&\n    e === 5 && f === undefined;\n}({b:2, c:undefined, x:4}));\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2262,16 +2250,20 @@ var o = { foo: function(){}, bar: function baz(){}};
 o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>accessor properties</span></td>
-<script data-source="/* Error during compilation: Line 2: Unexpected token )
-filename: undefined*/">
-test(function(){try{return Function("/* Error during compilation: Line 2: Unexpected token )\nfilename: undefined*/")()}catch(e){return false;}}());
+<script data-source="(function(){
+var o = { get foo(){}, set foo(x){} };
+var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
+return descriptor.get.name === &quot;get foo&quot; &&
+       descriptor.set.name === &quot;set foo&quot;;
+      })">
+test(function(){try{return eval("(function(){\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -2329,9 +2321,9 @@ var o = { foo: ((function(){&quot;use strict&quot;;function constructor$0() {}DP
 o.qux = ((function(){&quot;use strict&quot;;function constructor$1() {}DP$0(constructor$1,&quot;prototype&quot;,{&quot;configurable&quot;:false,&quot;enumerable&quot;:false,&quot;writable&quot;:false});;return constructor$1;})());
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       })">
-test(function(){try{return eval("(function(){var PRS$0 = (function(o,t){o[\"__proto__\"]={\"a\":t};return o[\"a\"]===t})({},{});var DP$0 = Object.defineProperty;var GOPD$0 = Object.getOwnPropertyDescriptor;var MIXIN$0 = function(t,s){for(var p in s){if(s.hasOwnProperty(p)){DP$0(t,p,GOPD$0(s,p));}}return t};\nvar o = { foo: ((function(){\"use strict\";function constructor$0() {}DP$0(constructor$0,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return constructor$0;})()), bar: ((function(){\"use strict\";function baz() {}DP$0(baz,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return baz;})())};\no.qux = ((function(){\"use strict\";function constructor$1() {}DP$0(constructor$1,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return constructor$1;})());\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){var PRS$0 = (function(o,t){o[\"__proto__\"]={\"a\":t};return o[\"a\"]===t})({},{});var DP$0 = Object.defineProperty;var GOPD$0 = Object.getOwnPropertyDescriptor;var MIXIN$0 = function(t,s){for(var p in s){if(s.hasOwnProperty(p)){DP$0(t,p,GOPD$0(s,p));}}return t};\nvar o = { foo: ((function(){\"use strict\";function constructor$0() {}DP$0(constructor$0,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return constructor$0;})()), bar: ((function(){\"use strict\";function baz() {}DP$0(baz,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return baz;})())};\no.qux = ((function(){\"use strict\";function constructor$1() {}DP$0(constructor$1,\"prototype\",{\"configurable\":false,\"enumerable\":false,\"writable\":false});;return constructor$1;})());\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -2355,12 +2347,12 @@ test(function(){try{return eval("(function(){\nvar C = (function(){\"use strict\
         <tr class="subtest" data-parent="function_name_property">
           <td><span>isn't writable, is configurable</span></td>
 <script data-source="(function(){
-var descriptor = Object.getOwnPropertyDescriptor(function(){},&quot;name&quot;);
+var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;);
 return descriptor.enumerable   === false &&
        descriptor.writable     === false &&
        descriptor.configurable === true;
       })">
-test(function(){try{return eval("(function(){\nvar descriptor = Object.getOwnPropertyDescriptor(function(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2891,6 +2883,13 @@ test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"fun
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -2945,13 +2944,6 @@ test(function(){try{return eval("(function(){var PRLS$0 = (function(o){return o[
 </script>
 
         </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
-</script>
-
-        </tr>
         <tr class="supertest">
           <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
 
@@ -2979,14 +2971,14 @@ test(function(){try{return eval("(function(){\nvar o = {};\no.__proto__ = Array.
 <script data-source="(function(){
 var desc = Object.getOwnPropertyDescriptor(Object.prototype,&quot;__proto__&quot;);
 var A = function(){};
-    
+
 return (desc
   && &quot;get&quot; in desc
   && &quot;set&quot; in desc
   && desc.configurable
   && !desc.enumerable);
       })">
-test(function(){try{return eval("(function(){\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n    \nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3023,9 +3015,6 @@ test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.co
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/compilers/esnext.html
+++ b/es6/compilers/esnext.html
@@ -4331,12 +4331,14 @@ test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"fun
 <script data-source="(function(){
 // Note: only available outside of strict mode.
 { function f() { return 1; } }
-  function g() { return 1; } { function g() { return 2; } }
-{ function h() { return 1; } } function h() { return 2; }
+  function g() { return 1; }
+{ function g() { return 2; } }
+{ function h() { return 1; } }
+  function h() { return 2; }
 
 return f() === 1 && g() === 2 && h() === 1;
   })">
-test(function(){try{return eval("(function(){\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; } { function g() { return 2; } }\n{ function h() { return 1; } } function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  })")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/esnext.html
+++ b/es6/compilers/esnext.html
@@ -166,9 +166,9 @@ test(function(){try{return Function("/* Error during compilation: This test's co
 var a = function() {
       return 5;
 };
-return !a.hasOwnProperty(&quot;prototype&quot;); 
+return !a.hasOwnProperty(&quot;prototype&quot;);
       })">
-test(function(){try{return eval("(function(){\nvar a = function() {\n      return 5;\n};\nreturn !a.hasOwnProperty(\"prototype\"); \n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar a = function() {\n      return 5;\n};\nreturn !a.hasOwnProperty(\"prototype\");\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -410,6 +410,21 @@ test(function(){try{return eval("(function(){\nreturn (function(a) {\n      var 
           <td><span>temporal dead zone</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="(function(){
+return (function() {
+  var a = (arguments[0] !== void 0 ? arguments[0] : function(){
+    return typeof b === 'undefined';
+  });
+
+  var b = 1;
+  return a();
+}());
+      })">
+test(function(){try{return eval("(function(){\nreturn (function() {\n  var a = (arguments[0] !== void 0 ? arguments[0] : function(){\n    return typeof b === 'undefined';\n  });\n\n  var b = 1;\n  return a();\n}());\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1258,21 +1273,7 @@ var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
     case 0:
-      return context$2$0.delegateYield(regeneratorRuntime.mark(function callee$2$0() {
-        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-          while (1) switch (context$3$0.prev = context$3$0.next) {
-          case 0:
-            context$3$0.next = 2;
-            return 5;
-          case 2:
-            context$3$0.next = 4;
-            return 6;
-          case 4:
-          case &quot;end&quot;:
-            return context$3$0.stop();
-          }
-        }, callee$2$0, this);
-      })(), &quot;t2&quot;, 1);
+      return context$2$0.delegateYield(__createIterableObject(5, 6, 7), &quot;t2&quot;, 1);
     case 1:
     case &quot;end&quot;:
       return context$2$0.stop();
@@ -1284,10 +1285,12 @@ var passed = item.value === 5 && item.done === false;
 item = iterator.next();
 passed    &= item.value === 6 && item.done === false;
 item = iterator.next();
+passed    &= item.value === 7 && item.done === false;
+item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(regeneratorRuntime.mark(function callee$2$0() {\n        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n          while (1) switch (context$3$0.prev = context$3$0.next) {\n          case 0:\n            context$3$0.next = 2;\n            return 5;\n          case 2:\n            context$3$0.next = 4;\n            return 6;\n          case 4:\n          case \"end\":\n            return context$3$0.stop();\n          }\n        }, callee$2$0, this);\n      })(), \"t2\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1297,21 +1300,7 @@ var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
     case 0:
-      return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {
-        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-          while (1) switch (context$3$0.prev = context$3$0.next) {
-          case 0:
-            context$3$0.next = 2;
-            return 5;
-          case 2:
-            context$3$0.next = 4;
-            return 6;
-          case 4:
-          case &quot;end&quot;:
-            return context$3$0.stop();
-          }
-        }, callee$2$0, this);
-      })()), &quot;t3&quot;, 1);
+      return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), &quot;t3&quot;, 1);
     case 1:
     case &quot;end&quot;:
       return context$2$0.stop();
@@ -1323,10 +1312,12 @@ var passed = item.value === 5 && item.done === false;
 item = iterator.next();
 passed    &= item.value === 6 && item.done === false;
 item = iterator.next();
+passed    &= item.value === 7 && item.done === false;
+item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(Object.create(regeneratorRuntime.mark(function callee$2$0() {\n        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {\n          while (1) switch (context$3$0.prev = context$3$0.next) {\n          case 0:\n            context$3$0.next = 2;\n            return 5;\n          case 2:\n            context$3$0.next = 4;\n            return 6;\n          case 4:\n          case \"end\":\n            return context$3$0.stop();\n          }\n        }, callee$2$0, this);\n      })()), \"t3\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -1541,10 +1532,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint8(0, 0x100); 
+view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100); \nreturn view.getUint8(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1552,10 +1543,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setInt16(0, 0x8000); 
+view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000); \nreturn view.getInt16(0) === -0x8000;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1563,10 +1554,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint16(0, 0x10000); 
+view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000); \nreturn view.getUint16(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1574,10 +1565,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setInt32(0, 0x80000000); 
+view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000); \nreturn view.getInt32(0) === -0x80000000;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1585,10 +1576,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setUint32(0, 0x100000000); 
+view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000); \nreturn view.getUint32(0) === 0;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1596,10 +1587,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setFloat32(0, 0.1); 
+view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1); \nreturn view.getFloat32(0) === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -1607,10 +1598,10 @@ test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);
 <script data-source="(function(){
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
-view.setFloat64(0, 0.1); 
+view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
       })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1); \nreturn view.getFloat64(0) === 0.1;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
@@ -2416,14 +2407,15 @@ Object.defineProperty(
   new Proxy(proxied, {
     defineProperty: function (t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+      return true;
     }
   }),
   &quot;foo&quot;,
-  { value: 5 }
+  { value: 5, configurable: true }
 );
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }),\n  \"foo\",\n  { value: 5 }\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -2539,7 +2531,7 @@ test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = f
 var proxied = function(){};
 var passed = false;
 var host = {
-  method: new Proxy(proxied, { 
+  method: new Proxy(proxied, {
     apply: function (t, thisArg, args) {
       passed = t === proxied && thisArg === host && args + &quot;&quot; === &quot;foo,bar&quot;;
     }
@@ -2548,7 +2540,7 @@ var host = {
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, { \n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -3446,15 +3438,20 @@ var o = { foo: function(){}, bar: function baz(){}};
 o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>accessor properties</span></td>
-<script data-source="/* Error during compilation: Line 2: Unexpected token )*/">
-test(function(){try{return Function("/* Error during compilation: Line 2: Unexpected token )*/")()}catch(e){return false;}}());
+<script data-source="(function(){
+var o = { get foo(){}, set foo(x){} };
+var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
+return descriptor.get.name === &quot;get foo&quot; &&
+       descriptor.set.name === &quot;set foo&quot;;
+      })">
+test(function(){try{return eval("(function(){\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3468,18 +3465,27 @@ test(function(){try{return eval("(function(){\nvar o = { foo: function foo() {} 
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>symbol-keyed methods</span></td>
-<script data-source="(function(){
-var o = {};
-var sym = Symbol(&quot;foo&quot;);
-var sym2 = Symbol();
+<script data-source="var $__Object$defineProperty = Object.defineProperty;
+(function(){
+  var $__0;
+  var sym1 = Symbol(&quot;foo&quot;);
+  var sym2 = Symbol();
+  var o = ($__0 = {}, $__Object$defineProperty($__0, sym1, {
+    value: function(){},
+    enumerable: true,
+    configurable: true,
+    writable: true
+  }), $__Object$defineProperty($__0, sym2, {
+    value: function(){},
+    enumerable: true,
+    configurable: true,
+    writable: true
+  }), $__0);
 
-o[sym] = function(){};
-o[sym2] = function(){};
-
-return o[sym].name === &quot;[foo]&quot; &&
-       o[sym2].name === &quot;&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar o = {};\nvar sym = Symbol(\"foo\");\nvar sym2 = Symbol();\n\no[sym] = function(){};\no[sym2] = function(){};\n\nreturn o[sym].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      })")()}catch(e){return false;}}());
+  return o[sym].name === &quot;[foo]&quot; &&
+         o[sym2].name === &quot;&quot;;
+});">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n(function(){\n  var $__0;\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = ($__0 = {}, $__Object$defineProperty($__0, sym1, {\n    value: function(){},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__Object$defineProperty($__0, sym2, {\n    value: function(){},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__0);\n\n  return o[sym].name === \"[foo]\" &&\n         o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3594,9 +3600,9 @@ o.qux = function() {
 }();
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}(), bar: function() {\n \"use strict\";\n function baz() {}\n return baz;\n}()};\no.qux = function() {\n \"use strict\";\n function $__1() {}\n return $__1;\n}();\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar o = { foo: function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}(), bar: function() {\n \"use strict\";\n function baz() {}\n return baz;\n}()};\no.qux = function() {\n \"use strict\";\n function $__1() {}\n return $__1;\n}();\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -3650,12 +3656,12 @@ test(function(){try{return eval("var $__Object$defineProperties = Object.defineP
         <tr class="subtest" data-parent="function_name_property">
           <td><span>isn't writable, is configurable</span></td>
 <script data-source="(function(){
-var descriptor = Object.getOwnPropertyDescriptor(function(){},&quot;name&quot;);
+var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;);
 return descriptor.enumerable   === false &&
        descriptor.writable     === false &&
        descriptor.configurable === true;
       })">
-test(function(){try{return eval("(function(){\nvar descriptor = Object.getOwnPropertyDescriptor(function(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3891,11 +3897,13 @@ test(function(){try{return eval("(function(){\nvar symbol = Symbol.for('foo');\n
 var passed = false;
 var obj = { foo: true };
 var C = function(){};
-C[Symbol.hasInstance] = function(inst) { passed = inst.foo; return false; };
+Object.defineProperty(C, Symbol.hasInstance, {
+  value: function(inst) { passed = inst.foo; return false; }
+});
 obj instanceof C;
 return passed;
       })">
-test(function(){try{return eval("(function(){\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nC[Symbol.hasInstance] = function(inst) { passed = inst.foo; return false; };\nobj instanceof C;\nreturn passed;\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -4318,6 +4326,20 @@ test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"fun
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="(function(){
+// Note: only available outside of strict mode.
+{ function f() { return 1; } }
+  function g() { return 1; } { function g() { return 2; } }
+{ function h() { return 1; } } function h() { return 2; }
+
+return f() === 1 && g() === 2 && h() === 1;
+  })">
+test(function(){try{return eval("(function(){\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; } { function g() { return 2; } }\n{ function h() { return 1; } } function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  })")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -4379,19 +4401,6 @@ test(function(){try{return eval("(function(){\nif (!({ __proto__ : [] } instance
 </script>
 
         </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="(function(){
-// Note: only available outside of strict mode.
-var passed = f() === 2 && g() === 4;
-if (true) { function f(){ return 1; } } else { function f(){ return 2; } }
-if (false){ function g(){ return 3; } } else { function g(){ return 4; } }
-return passed;
-  })">
-test(function(){try{return eval("(function(){\n// Note: only available outside of strict mode.\nvar passed = f() === 2 && g() === 4;\nif (true) { function f(){ return 1; } } else { function f(){ return 2; } }\nif (false){ function g(){ return 3; } } else { function g(){ return 4; } }\nreturn passed;\n  })")()}catch(e){return false;}}());
-</script>
-
-        </tr>
         <tr class="supertest">
           <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
 
@@ -4419,14 +4428,14 @@ test(function(){try{return eval("(function(){\nvar o = {};\no.__proto__ = Array.
 <script data-source="(function(){
 var desc = Object.getOwnPropertyDescriptor(Object.prototype,&quot;__proto__&quot;);
 var A = function(){};
-    
+
 return (desc
   && &quot;get&quot; in desc
   && &quot;set&quot; in desc
   && desc.configurable
   && !desc.enumerable);
       })">
-test(function(){try{return eval("(function(){\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n    \nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4463,9 +4472,6 @@ test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.co
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/compilers/traceur.html
+++ b/es6/compilers/traceur.html
@@ -3116,6 +3116,22 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return (funct
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
 
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  return (function() {
+    var a = arguments[0] !== (void 0) ? arguments[0] : function() {
+      return typeof b === 'undefined';
+    };
+    var b = 1;
+    return a();
+  }());
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return (function() {\n    var a = arguments[0] !== (void 0) ? arguments[0] : function() {\n      return typeof b === 'undefined';\n    };\n    var b = 1;\n    return a();\n  }());\n});\n")()}catch(e){return false;}}());
+</script>
+
         </tr>
         <tr>
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
@@ -3672,53 +3688,31 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator 
 <script data-source="&quot;use strict&quot;;
 (function() {
   var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {
-    var $__1,
-        $__2;
+    var $__0,
+        $__1;
     return $traceurRuntime.createGeneratorInstance(function($ctx) {
       while (true)
         switch ($ctx.state) {
           case 0:
-            $__1 = ($traceurRuntime.initGeneratorFunction(function $__0() {
-              return $traceurRuntime.createGeneratorInstance(function($ctx) {
-                while (true)
-                  switch ($ctx.state) {
-                    case 0:
-                      $ctx.state = 2;
-                      return 5;
-                    case 2:
-                      $ctx.maybeThrow();
-                      $ctx.state = 4;
-                      break;
-                    case 4:
-                      $ctx.state = 6;
-                      return 6;
-                    case 6:
-                      $ctx.maybeThrow();
-                      $ctx.state = -2;
-                      break;
-                    default:
-                      return $ctx.end();
-                  }
-              }, $__0, this);
-            })())[Symbol.iterator]();
+            $__0 = __createIterableObject(5, 6, 7)[Symbol.iterator]();
             $ctx.sent = void 0;
             $ctx.action = 'next';
             $ctx.state = 12;
             break;
           case 12:
-            $__2 = $__1[$ctx.action]($ctx.sentIgnoreThrow);
+            $__1 = $__0[$ctx.action]($ctx.sentIgnoreThrow);
             $ctx.state = 9;
             break;
           case 9:
-            $ctx.state = ($__2.done) ? 3 : 2;
+            $ctx.state = ($__1.done) ? 3 : 2;
             break;
           case 3:
-            $ctx.sent = $__2.value;
+            $ctx.sent = $__1.value;
             $ctx.state = -2;
             break;
           case 2:
             $ctx.state = 12;
-            return $__2.value;
+            return $__1.value;
           default:
             return $ctx.end();
         }
@@ -3729,11 +3723,13 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator 
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {\n    var $__1,\n        $__2;\n    return $traceurRuntime.createGeneratorInstance(function($ctx) {\n      while (true)\n        switch ($ctx.state) {\n          case 0:\n            $__1 = ($traceurRuntime.initGeneratorFunction(function $__0() {\n              return $traceurRuntime.createGeneratorInstance(function($ctx) {\n                while (true)\n                  switch ($ctx.state) {\n                    case 0:\n                      $ctx.state = 2;\n                      return 5;\n                    case 2:\n                      $ctx.maybeThrow();\n                      $ctx.state = 4;\n                      break;\n                    case 4:\n                      $ctx.state = 6;\n                      return 6;\n                    case 6:\n                      $ctx.maybeThrow();\n                      $ctx.state = -2;\n                      break;\n                    default:\n                      return $ctx.end();\n                  }\n              }, $__0, this);\n            })())[Symbol.iterator]();\n            $ctx.sent = void 0;\n            $ctx.action = 'next';\n            $ctx.state = 12;\n            break;\n          case 12:\n            $__2 = $__1[$ctx.action]($ctx.sentIgnoreThrow);\n            $ctx.state = 9;\n            break;\n          case 9:\n            $ctx.state = ($__2.done) ? 3 : 2;\n            break;\n          case 3:\n            $ctx.sent = $__2.value;\n            $ctx.state = -2;\n            break;\n          case 2:\n            $ctx.state = 12;\n            return $__2.value;\n          default:\n            return $ctx.end();\n        }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {\n    var $__0,\n        $__1;\n    return $traceurRuntime.createGeneratorInstance(function($ctx) {\n      while (true)\n        switch ($ctx.state) {\n          case 0:\n            $__0 = __createIterableObject(5, 6, 7)[Symbol.iterator]();\n            $ctx.sent = void 0;\n            $ctx.action = 'next';\n            $ctx.state = 12;\n            break;\n          case 12:\n            $__1 = $__0[$ctx.action]($ctx.sentIgnoreThrow);\n            $ctx.state = 9;\n            break;\n          case 9:\n            $ctx.state = ($__1.done) ? 3 : 2;\n            break;\n          case 3:\n            $ctx.sent = $__1.value;\n            $ctx.state = -2;\n            break;\n          case 2:\n            $ctx.state = 12;\n            return $__1.value;\n          default:\n            return $ctx.end();\n        }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -3741,53 +3737,31 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator 
 <script data-source="&quot;use strict&quot;;
 (function() {
   var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {
-    var $__1,
-        $__2;
+    var $__0,
+        $__1;
     return $traceurRuntime.createGeneratorInstance(function($ctx) {
       while (true)
         switch ($ctx.state) {
           case 0:
-            $__1 = Object.create($traceurRuntime.initGeneratorFunction(function $__0() {
-              return $traceurRuntime.createGeneratorInstance(function($ctx) {
-                while (true)
-                  switch ($ctx.state) {
-                    case 0:
-                      $ctx.state = 2;
-                      return 5;
-                    case 2:
-                      $ctx.maybeThrow();
-                      $ctx.state = 4;
-                      break;
-                    case 4:
-                      $ctx.state = 6;
-                      return 6;
-                    case 6:
-                      $ctx.maybeThrow();
-                      $ctx.state = -2;
-                      break;
-                    default:
-                      return $ctx.end();
-                  }
-              }, $__0, this);
-            })())[Symbol.iterator]();
+            $__0 = Object.create(__createIterableObject(5, 6, 7))[Symbol.iterator]();
             $ctx.sent = void 0;
             $ctx.action = 'next';
             $ctx.state = 12;
             break;
           case 12:
-            $__2 = $__1[$ctx.action]($ctx.sentIgnoreThrow);
+            $__1 = $__0[$ctx.action]($ctx.sentIgnoreThrow);
             $ctx.state = 9;
             break;
           case 9:
-            $ctx.state = ($__2.done) ? 3 : 2;
+            $ctx.state = ($__1.done) ? 3 : 2;
             break;
           case 3:
-            $ctx.sent = $__2.value;
+            $ctx.sent = $__1.value;
             $ctx.state = -2;
             break;
           case 2:
             $ctx.state = 12;
-            return $__2.value;
+            return $__1.value;
           default:
             return $ctx.end();
         }
@@ -3798,11 +3772,13 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator 
   item = iterator.next();
   passed &= item.value === 6 && item.done === false;
   item = iterator.next();
+  passed &= item.value === 7 && item.done === false;
+  item = iterator.next();
   passed &= item.value === undefined && item.done === true;
   return passed;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {\n    var $__1,\n        $__2;\n    return $traceurRuntime.createGeneratorInstance(function($ctx) {\n      while (true)\n        switch ($ctx.state) {\n          case 0:\n            $__1 = Object.create($traceurRuntime.initGeneratorFunction(function $__0() {\n              return $traceurRuntime.createGeneratorInstance(function($ctx) {\n                while (true)\n                  switch ($ctx.state) {\n                    case 0:\n                      $ctx.state = 2;\n                      return 5;\n                    case 2:\n                      $ctx.maybeThrow();\n                      $ctx.state = 4;\n                      break;\n                    case 4:\n                      $ctx.state = 6;\n                      return 6;\n                    case 6:\n                      $ctx.maybeThrow();\n                      $ctx.state = -2;\n                      break;\n                    default:\n                      return $ctx.end();\n                  }\n              }, $__0, this);\n            })())[Symbol.iterator]();\n            $ctx.sent = void 0;\n            $ctx.action = 'next';\n            $ctx.state = 12;\n            break;\n          case 12:\n            $__2 = $__1[$ctx.action]($ctx.sentIgnoreThrow);\n            $ctx.state = 9;\n            break;\n          case 9:\n            $ctx.state = ($__2.done) ? 3 : 2;\n            break;\n          case 3:\n            $ctx.sent = $__2.value;\n            $ctx.state = -2;\n            break;\n          case 2:\n            $ctx.state = 12;\n            return $__2.value;\n          default:\n            return $ctx.end();\n        }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var iterator = ($traceurRuntime.initGeneratorFunction(function generator() {\n    var $__0,\n        $__1;\n    return $traceurRuntime.createGeneratorInstance(function($ctx) {\n      while (true)\n        switch ($ctx.state) {\n          case 0:\n            $__0 = Object.create(__createIterableObject(5, 6, 7))[Symbol.iterator]();\n            $ctx.sent = void 0;\n            $ctx.action = 'next';\n            $ctx.state = 12;\n            break;\n          case 12:\n            $__1 = $__0[$ctx.action]($ctx.sentIgnoreThrow);\n            $ctx.state = 9;\n            break;\n          case 9:\n            $ctx.state = ($__1.done) ? 3 : 2;\n            break;\n          case 3:\n            $ctx.sent = $__1.value;\n            $ctx.state = -2;\n            break;\n          case 2:\n            $ctx.state = 12;\n            return $__1.value;\n          default:\n            return $ctx.end();\n        }\n    }, generator, this);\n  })());\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === 7 && item.done === false;\n  item = iterator.next();\n  passed &= item.value === undefined && item.done === true;\n  return passed;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -4883,11 +4859,15 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var proxied =
   var passed = false;
   Object.defineProperty(new Proxy(proxied, {defineProperty: function(t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
-    }}), &quot;foo&quot;, {value: 5});
+      return true;
+    }}), &quot;foo&quot;, {
+    value: 5,
+    configurable: true
+  });
   return passed;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {defineProperty: function(t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }}), \"foo\", {value: 5});\n  return passed;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var proxied = {};\n  var passed = false;\n  Object.defineProperty(new Proxy(proxied, {defineProperty: function(t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }}), \"foo\", {\n    value: 5,\n    configurable: true\n  });\n  return passed;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
@@ -5539,16 +5519,25 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var foo = fun
     bar: function baz() {}
   };
   o.qux = function() {};
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {\n    foo: function() {},\n    bar: function baz() {}\n  };\n  o.qux = function() {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {\n    foo: function() {},\n    bar: function baz() {}\n  };\n  o.qux = function() {};\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>accessor properties</span></td>
-<script data-source="/* Error during compilation: undefined*/">
-test(function(){try{return Function("/* Error during compilation: undefined*/")()}catch(e){return false;}}());
+<script data-source="&quot;use strict&quot;;
+(function() {
+  var o = {
+    get foo() {},
+    set foo(x) {}
+  };
+  var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
+  return descriptor.get.name === &quot;get foo&quot; && descriptor.set.name === &quot;set foo&quot;;
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {\n    get foo() {},\n    set foo(x) {}\n  };\n  var descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\n  return descriptor.get.name === \"get foo\" && descriptor.set.name === \"set foo\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -5566,15 +5555,24 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {foo:
           <td><span>symbol-keyed methods</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  var o = {};
-  var sym = Symbol(&quot;foo&quot;);
+  var $__0;
+  var sym1 = Symbol(&quot;foo&quot;);
   var sym2 = Symbol();
-  o[sym] = function() {};
-  o[sym2] = function() {};
+  var o = ($__0 = {}, Object.defineProperty($__0, sym1, {
+    value: function() {},
+    configurable: true,
+    enumerable: true,
+    writable: true
+  }), Object.defineProperty($__0, sym2, {
+    value: function() {},
+    configurable: true,
+    enumerable: true,
+    writable: true
+  }), $__0);
   return o[sym].name === &quot;[foo]&quot; && o[sym2].name === &quot;&quot;;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {};\n  var sym = Symbol(\"foo\");\n  var sym2 = Symbol();\n  o[sym] = function() {};\n  o[sym2] = function() {};\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var $__0;\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = ($__0 = {}, Object.defineProperty($__0, sym1, {\n    value: function() {},\n    configurable: true,\n    enumerable: true,\n    writable: true\n  }), Object.defineProperty($__0, sym2, {\n    value: function() {},\n    configurable: true,\n    enumerable: true,\n    writable: true\n  }), $__0);\n  return o[sym].name === \"[foo]\" && o[sym2].name === \"\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -5637,10 +5635,10 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var foo = (($
     }())
   };
   o.qux = (($traceurRuntime.createClass)(function() {}, {}, {}));
-  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;qux&quot;;
+  return o.foo.name === &quot;foo&quot; && o.bar.name === &quot;baz&quot; && o.qux.name === &quot;&quot;;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {\n    foo: (($traceurRuntime.createClass)(function() {}, {}, {})),\n    bar: (function() {\n      var baz = function baz() {};\n      return ($traceurRuntime.createClass)(baz, {}, {});\n    }())\n  };\n  o.qux = (($traceurRuntime.createClass)(function() {}, {}, {}));\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"qux\";\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var o = {\n    foo: (($traceurRuntime.createClass)(function() {}, {}, {})),\n    bar: (function() {\n      var baz = function baz() {};\n      return ($traceurRuntime.createClass)(baz, {}, {});\n    }())\n  };\n  o.qux = (($traceurRuntime.createClass)(function() {}, {}, {}));\n  return o.foo.name === \"foo\" && o.bar.name === \"baz\" && o.qux.name === \"\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -5673,11 +5671,11 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var C = funct
           <td><span>isn't writable, is configurable</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  var descriptor = Object.getOwnPropertyDescriptor(function() {}, &quot;name&quot;);
+  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, &quot;name&quot;);
   return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var descriptor = Object.getOwnPropertyDescriptor(function() {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var descriptor = Object.getOwnPropertyDescriptor(function f() {}, \"name\");\n  return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -5932,15 +5930,15 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var symbol = 
   var passed = false;
   var obj = {foo: true};
   var C = function() {};
-  C[Symbol.hasInstance] = function(inst) {
-    passed = inst.foo;
-    return false;
-  };
+  Object.defineProperty(C, Symbol.hasInstance, {value: function(inst) {
+      passed = inst.foo;
+      return false;
+    }});
   obj instanceof C;
   return passed;
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var passed = false;\n  var obj = {foo: true};\n  var C = function() {};\n  C[Symbol.hasInstance] = function(inst) {\n    passed = inst.foo;\n    return false;\n  };\n  obj instanceof C;\n  return passed;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var passed = false;\n  var obj = {foo: true};\n  var C = function() {};\n  Object.defineProperty(C, Symbol.hasInstance, {value: function(inst) {\n      passed = inst.foo;\n      return false;\n    }});\n  obj instanceof C;\n  return passed;\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -6453,6 +6451,38 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  {
+    var f = function() {
+      return 1;
+    };
+  }
+  function g() {
+    return 1;
+  }
+  {
+    var g$__0 = function() {
+      return 2;
+    };
+  }
+  {
+    var h$__1 = function() {
+      return 1;
+    };
+  }
+  function h() {
+    return 2;
+  }
+  return f() === 1 && g() === 2 && h() === 1;
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  {\n    var f = function() {\n      return 1;\n    };\n  }\n  function g() {\n    return 1;\n  }\n  {\n    var g$__0 = function() {\n      return 2;\n    };\n  }\n  {\n    var h$__1 = function() {\n      return 1;\n    };\n  }\n  function h() {\n    return 2;\n  }\n  return f() === 1 && g() === 2 && h() === 1;\n});\n")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -6517,36 +6547,6 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  if (!({__prot
 });
 ">
 test(function(){try{return eval("\"use strict\";\n(function() {\n  if (!({__proto__: []} instanceof Array)) {\n    return false;\n  }\n  return !({__proto__: function() {}} instanceof Function);\n});\n")()}catch(e){return false;}}());
-</script>
-
-        </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="&quot;use strict&quot;;
-(function() {
-  var passed = f() === 2 && g() === 4;
-  if (true) {
-    var f = function() {
-      return 1;
-    };
-  } else {
-    var f$__0 = function() {
-      return 2;
-    };
-  }
-  if (false) {
-    var g = function() {
-      return 3;
-    };
-  } else {
-    var g$__1 = function() {
-      return 4;
-    };
-  }
-  return passed;
-});
-">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  var passed = f() === 2 && g() === 4;\n  if (true) {\n    var f = function() {\n      return 1;\n    };\n  } else {\n    var f$__0 = function() {\n      return 2;\n    };\n  }\n  if (false) {\n    var g = function() {\n      return 3;\n    };\n  } else {\n    var g$__1 = function() {\n      return 4;\n    };\n  }\n  return passed;\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -6626,9 +6626,6 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/compilers/typescript.html
+++ b/es6/compilers/typescript.html
@@ -2952,12 +2952,12 @@ test(function(){try{return Function("/* Error during compilation: \n(2,20): erro
         <tr>
           <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
 <script data-source="/* Error during compilation: 
-(4,10): error TS2393: Duplicate function implementation.
-(4,39): error TS2393: Duplicate function implementation.
+(4,12): error TS2393: Duplicate function implementation.
 (5,12): error TS2393: Duplicate function implementation.
-(5,41): error TS2393: Duplicate function implementation.
+(6,12): error TS2393: Duplicate function implementation.
+(7,12): error TS2393: Duplicate function implementation.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(4,10): error TS2393: Duplicate function implementation.\n(4,39): error TS2393: Duplicate function implementation.\n(5,12): error TS2393: Duplicate function implementation.\n(5,41): error TS2393: Duplicate function implementation.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(4,12): error TS2393: Duplicate function implementation.\n(5,12): error TS2393: Duplicate function implementation.\n(6,12): error TS2393: Duplicate function implementation.\n(7,12): error TS2393: Duplicate function implementation.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/typescript.html
+++ b/es6/compilers/typescript.html
@@ -377,6 +377,21 @@ test(function(){try{return eval("(function () {\n    return (function (a, b) {\n
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
 
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="(function () {
+    return (function (a) {
+        if (a === void 0) { a = function () {
+            return typeof b === 'undefined';
+        }; }
+        var b = 1;
+        return a();
+    }());
+});
+">
+test(function(){try{return eval("(function () {\n    return (function (a) {\n        if (a === void 0) { a = function () {\n            return typeof b === 'undefined';\n        }; }\n        var b = 1;\n        return a();\n    }());\n});\n")()}catch(e){return false;}}());
+</script>
+
         </tr>
         <tr>
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
@@ -705,72 +720,56 @@ test(function(){try{return Function("/* Error during compilation: \n(4,15): erro
         <tr class="subtest" data-parent="generators">
           <td><span>basic functionality</span></td>
 <script data-source="/* Error during compilation: 
-(2,9): error TS1003: Identifier expected.
-(2,22): error TS1005: ';' expected.
+(2,10): error TS1003: Identifier expected.
+(2,23): error TS1005: ';' expected.
 (3,9): error TS1005: ';' expected.
 (3,18): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,9): error TS1003: Identifier expected.\n(2,22): error TS1005: ';' expected.\n(3,9): error TS1005: ';' expected.\n(3,18): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,10): error TS1003: Identifier expected.\n(2,23): error TS1005: ';' expected.\n(3,9): error TS1005: ';' expected.\n(3,18): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, arrays</span></td>
 <script data-source="/* Error during compilation: 
-(2,25): error TS1005: '(' expected.
-(2,39): error TS1005: ')' expected.
+(2,26): error TS1005: '(' expected.
+(2,40): error TS1005: ')' expected.
 (4,3): error TS1109: Expression expected.
 (4,4): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,25): error TS1005: '(' expected.\n(2,39): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,26): error TS1005: '(' expected.\n(2,40): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, strings</span></td>
 <script data-source="/* Error during compilation: 
-(2,25): error TS1005: '(' expected.
-(2,39): error TS1005: ')' expected.
+(2,26): error TS1005: '(' expected.
+(2,40): error TS1005: ')' expected.
 (4,3): error TS1109: Expression expected.
 (4,4): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,25): error TS1005: '(' expected.\n(2,39): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,26): error TS1005: '(' expected.\n(2,40): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, generic iterables</span></td>
 <script data-source="/* Error during compilation: 
-(2,25): error TS1005: '(' expected.
-(2,39): error TS1005: ')' expected.
-(3,20): error TS1005: '(' expected.
-(3,23): error TS1109: Expression expected.
-(3,25): error TS1005: ')' expected.
-(4,11): error TS1005: ';' expected.
-(4,20): error TS1005: ';' expected.
-(5,5): error TS1109: Expression expected.
-(5,6): error TS1005: ';' expected.
-(6,3): error TS1109: Expression expected.
-(6,4): error TS1005: ';' expected.
+(2,26): error TS1005: '(' expected.
+(2,40): error TS1005: ')' expected.
+(4,3): error TS1109: Expression expected.
+(4,4): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,25): error TS1005: '(' expected.\n(2,39): error TS1005: ')' expected.\n(3,20): error TS1005: '(' expected.\n(3,23): error TS1109: Expression expected.\n(3,25): error TS1005: ')' expected.\n(4,11): error TS1005: ';' expected.\n(4,20): error TS1005: ';' expected.\n(5,5): error TS1109: Expression expected.\n(5,6): error TS1005: ';' expected.\n(6,3): error TS1109: Expression expected.\n(6,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,26): error TS1005: '(' expected.\n(2,40): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, instances of iterables</span></td>
 <script data-source="/* Error during compilation: 
-(2,25): error TS1005: '(' expected.
-(2,39): error TS1005: ')' expected.
-(3,33): error TS1005: '(' expected.
-(3,36): error TS1109: Expression expected.
-(3,38): error TS1005: ',' expected.
-(4,11): error TS1005: ':' expected.
-(4,12): error TS1005: ',' expected.
-(4,20): error TS1005: ';' expected.
-(5,5): error TS1109: Expression expected.
-(5,6): error TS1005: ';' expected.
-(13,1): error TS1108: A 'return' statement can only be used within a function body.
-(14,7): error TS1128: Declaration or statement expected.
-(14,8): error TS1128: Declaration or statement expected.
+(2,26): error TS1005: '(' expected.
+(2,40): error TS1005: ')' expected.
+(4,3): error TS1109: Expression expected.
+(4,4): error TS1005: ';' expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,25): error TS1005: '(' expected.\n(2,39): error TS1005: ')' expected.\n(3,33): error TS1005: '(' expected.\n(3,36): error TS1109: Expression expected.\n(3,38): error TS1005: ',' expected.\n(4,11): error TS1005: ':' expected.\n(4,12): error TS1005: ',' expected.\n(4,20): error TS1005: ';' expected.\n(5,5): error TS1109: Expression expected.\n(5,6): error TS1005: ';' expected.\n(13,1): error TS1108: A 'return' statement can only be used within a function body.\n(14,7): error TS1128: Declaration or statement expected.\n(14,8): error TS1128: Declaration or statement expected.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,26): error TS1005: '(' expected.\n(2,40): error TS1005: ')' expected.\n(4,3): error TS1109: Expression expected.\n(4,4): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
@@ -2265,10 +2264,19 @@ test(function(){try{return Function("/* Error during compilation: \n(3,14): erro
         <tr class="subtest" data-parent="function_name_property">
           <td><span>symbol-keyed methods</span></td>
 <script data-source="/* Error during compilation: 
-(3,11): error TS2304: Cannot find name 'Symbol'.
-(4,12): error TS2304: Cannot find name 'Symbol'.
+(5,3): error TS1136: Property assignment expected.
+(5,9): error TS1005: ',' expected.
+(5,11): error TS1134: Variable declaration expected.
+(5,19): error TS1003: Identifier expected.
+(5,23): error TS1129: Statement expected.
+(6,9): error TS1005: ';' expected.
+(6,19): error TS1003: Identifier expected.
+(7,2): error TS1005: ')' expected.
+(9,1): error TS1108: A 'return' statement can only be used within a function body.
+(11,7): error TS1128: Declaration or statement expected.
+(11,8): error TS1128: Declaration or statement expected.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(3,11): error TS2304: Cannot find name 'Symbol'.\n(4,12): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(5,3): error TS1136: Property assignment expected.\n(5,9): error TS1005: ',' expected.\n(5,11): error TS1134: Variable declaration expected.\n(5,19): error TS1003: Identifier expected.\n(5,23): error TS1129: Statement expected.\n(6,9): error TS1005: ';' expected.\n(6,19): error TS1003: Identifier expected.\n(7,2): error TS1005: ')' expected.\n(9,1): error TS1108: A 'return' statement can only be used within a function body.\n(11,7): error TS1128: Declaration or statement expected.\n(11,8): error TS1128: Declaration or statement expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
@@ -2354,12 +2362,12 @@ test(function(){try{return Function("/* Error during compilation: \n(2,1): error
         <tr class="subtest" data-parent="function_name_property">
           <td><span>isn't writable, is configurable</span></td>
 <script data-source="(function () {
-    var descriptor = Object.getOwnPropertyDescriptor(function () {
+    var descriptor = Object.getOwnPropertyDescriptor(function f() {
     }, &quot;name&quot;);
     return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;
 });
 ">
-test(function(){try{return eval("(function () {\n    var descriptor = Object.getOwnPropertyDescriptor(function () {\n    }, \"name\");\n    return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("(function () {\n    var descriptor = Object.getOwnPropertyDescriptor(function f() {\n    }, \"name\");\n    return descriptor.enumerable === false && descriptor.writable === false && descriptor.configurable === true;\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2547,9 +2555,9 @@ test(function(){try{return Function("/* Error during compilation: \n(2,14): erro
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.hasInstance</span></td>
 <script data-source="/* Error during compilation: 
-(5,3): error TS2304: Cannot find name 'Symbol'.
+(5,26): error TS2304: Cannot find name 'Symbol'.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(5,3): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(5,26): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -2941,6 +2949,18 @@ test(function(){try{return Function("/* Error during compilation: \n(2,20): erro
         <tr>
           <th colspan="3" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="/* Error during compilation: 
+(4,10): error TS2393: Duplicate function implementation.
+(4,39): error TS2393: Duplicate function implementation.
+(5,12): error TS2393: Duplicate function implementation.
+(5,41): error TS2393: Duplicate function implementation.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(4,10): error TS2393: Duplicate function implementation.\n(4,39): error TS2393: Duplicate function implementation.\n(5,12): error TS2393: Duplicate function implementation.\n(5,41): error TS2393: Duplicate function implementation.\n*/")()}catch(e){return false;}}());
+</script>
+
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[2]</sup></a></span></td>
 
@@ -2989,18 +3009,6 @@ test(function(){try{return Function("/* Error during compilation: \n(6,22): erro
 });
 ">
 test(function(){try{return eval("(function () {\n    if (!({ __proto__: [] } instanceof Array)) {\n        return false;\n    }\n    return !({ __proto__: function () {\n    } } instanceof Function);\n});\n")()}catch(e){return false;}}());
-</script>
-
-        </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[3]</sup></a></span></td>
-<script data-source="/* Error during compilation: 
-(4,22): error TS2393: Duplicate function implementation.
-(4,57): error TS2393: Duplicate function implementation.
-(5,22): error TS2393: Duplicate function implementation.
-(5,57): error TS2393: Duplicate function implementation.
-*/">
-test(function(){try{return Function("/* Error during compilation: \n(4,22): error TS2393: Duplicate function implementation.\n(4,57): error TS2393: Duplicate function implementation.\n(5,22): error TS2393: Duplicate function implementation.\n(5,57): error TS2393: Duplicate function implementation.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3073,9 +3081,6 @@ test(function(){try{return eval("(function () {\n    return typeof RegExp.protot
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[2]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[3]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/index.html
+++ b/es6/index.html
@@ -13,19 +13,18 @@
         var global = this;
       }
       function __createIterableObject(a, b, c) {
-        try {
-          return eval("(function*() { yield a; yield b; yield c; }())");
-        }
-        catch (e) {
-          var iterable;
+        if (typeof Symbol === "function" && Symbol.iterator) {
           var arr = [a, b, c, ,];
-          iterable = {
+          var iterable = {
             next: function() {
-              return { value: arr.shift(), done: arr.length <= 0 };
+              return { value: arr.shift(), done: arr.length <= 0 }; 
             },
           };
           iterable[Symbol.iterator] = function(){ return iterable; }
           return iterable;
+        }
+        else {
+          return eval("(function*() { yield a; yield b; yield c; }())");
         }
       }
     </script>
@@ -1981,55 +1980,55 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
         <tr class="supertest">
           <td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 
-          <td class="tally tr" data-tally="0.75">3/4</td>
-          <td class="tally _6to5" data-tally="0.75">3/4</td>
-          <td class="tally ejs" data-tally="0.75">3/4</td>
-          <td class="tally closure" data-tally="0.75">3/4</td>
-          <td class="tally ie10" data-tally="0">0/4</td>
-          <td class="tally ie11" data-tally="0">0/4</td>
-          <td class="tally ie11tp" data-tally="0">0/4</td>
-          <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
-          <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
-          <td class="tally firefox16 obsolete" data-tally="0.5">2/4</td>
-          <td class="tally firefox17 obsolete" data-tally="0.5">2/4</td>
-          <td class="tally firefox18 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox23 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox24 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox25 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox27 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox28 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox29 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox30 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox31" data-tally="0.75">3/4</td>
-          <td class="tally firefox32 obsolete" data-tally="0.75">3/4</td>
-          <td class="tally firefox33" data-tally="0.75">3/4</td>
-          <td class="tally firefox34" data-tally="0.75">3/4</td>
-          <td class="tally firefox35" data-tally="0.75">3/4</td>
-          <td class="tally chrome obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome30 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome31 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome33 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome34 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome35 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome36 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome37 obsolete" data-tally="0">0/4</td>
-          <td class="tally chrome38" data-tally="0">0/4</td>
-          <td class="tally chrome39" data-tally="0">0/4</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/4</td>
-          <td class="tally safari6" data-tally="0">0/4</td>
-          <td class="tally safari7" data-tally="0">0/4</td>
-          <td class="tally safari71_8" data-tally="0">0/4</td>
-          <td class="tally webkit" data-tally="0">0/4</td>
-          <td class="tally opera" data-tally="0">0/4</td>
-          <td class="tally konq49" data-tally="0">0/4</td>
-          <td class="tally rhino17" data-tally="0">0/4</td>
-          <td class="tally phantom" data-tally="0">0/4</td>
-          <td class="tally node" data-tally="0">0/4</td>
-          <td class="tally nodeharmony" data-tally="0">0/4</td>
-          <td class="tally ios7" data-tally="0">0/4</td>
-          <td class="tally ios8" data-tally="0">0/4</td>
+          <td class="tally tr" data-tally="0.6">3/5</td>
+          <td class="tally _6to5" data-tally="0.6">3/5</td>
+          <td class="tally ejs" data-tally="0.6">3/5</td>
+          <td class="tally closure" data-tally="0.6">3/5</td>
+          <td class="tally ie10" data-tally="0">0/5</td>
+          <td class="tally ie11" data-tally="0">0/5</td>
+          <td class="tally ie11tp" data-tally="0">0/5</td>
+          <td class="tally firefox11 obsolete" data-tally="0">0/5</td>
+          <td class="tally firefox13 obsolete" data-tally="0">0/5</td>
+          <td class="tally firefox16 obsolete" data-tally="0.4">2/5</td>
+          <td class="tally firefox17 obsolete" data-tally="0.4">2/5</td>
+          <td class="tally firefox18 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox23 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox24 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox25 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox27 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox28 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox29 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox30 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox31" data-tally="0.6">3/5</td>
+          <td class="tally firefox32 obsolete" data-tally="0.6">3/5</td>
+          <td class="tally firefox33" data-tally="0.6">3/5</td>
+          <td class="tally firefox34" data-tally="0.6">3/5</td>
+          <td class="tally firefox35" data-tally="0.6">3/5</td>
+          <td class="tally chrome obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome21dev obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome30 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome31 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome33 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome34 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome35 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome36 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome37 obsolete" data-tally="0">0/5</td>
+          <td class="tally chrome38" data-tally="0">0/5</td>
+          <td class="tally chrome39" data-tally="0">0/5</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/5</td>
+          <td class="tally safari6" data-tally="0">0/5</td>
+          <td class="tally safari7" data-tally="0">0/5</td>
+          <td class="tally safari71_8" data-tally="0">0/5</td>
+          <td class="tally webkit" data-tally="0">0/5</td>
+          <td class="tally opera" data-tally="0">0/5</td>
+          <td class="tally konq49" data-tally="0">0/5</td>
+          <td class="tally rhino17" data-tally="0">0/5</td>
+          <td class="tally phantom" data-tally="0">0/5</td>
+          <td class="tally node" data-tally="0">0/5</td>
+          <td class="tally nodeharmony" data-tally="0">0/5</td>
+          <td class="tally ios7" data-tally="0">0/5</td>
+          <td class="tally ios8" data-tally="0">0/5</td>
         <tr class="subtest" data-parent="default_function_parameters">
           <td><span>basic functionality</span></td>
 <script data-source="
@@ -2213,14 +2212,72 @@ return (function(x = 1) {
     eval(&quot;(function(a=b,b){}())&quot;);
     return false;
   } catch(e) {}
-  try {
-    eval(&quot;(function(a=function(){ return b; }){ var b = 1;}())&quot;);
-    return false;
-  } catch(e) {}
   return true;
 }());
       ">
-test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    eval(\"(function(a=a){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=b,b){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=function(){ return b; }){ var b = 1;}())\");\n    return false;\n  } catch(e) {}\n  return true;\n}());\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    eval(\"(function(a=a){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=b,b){}())\");\n    return false;\n  } catch(e) {}\n  return true;\n}());\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="default_function_parameters">
+          <td><span>separate scope</span></td>
+<script data-source="
+return (function(a=function(){
+  return typeof b === 'undefined';
+}){
+  var b = 1;
+  return a();
+}());
+      ">
+test(function(){try{return Function("\nreturn (function(a=function(){\n  return typeof b === 'undefined';\n}){\n  var b = 1;\n  return a();\n}());\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -3881,11 +3938,11 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
           <td class="tally chrome31 obsolete" data-tally="0.25">1/4</td>
           <td class="tally chrome33 obsolete" data-tally="0.25">1/4</td>
           <td class="tally chrome34 obsolete" data-tally="0.25">1/4</td>
-          <td class="tally chrome35 obsolete" data-tally="0.25">1/4</td>
-          <td class="tally chrome36 obsolete" data-tally="0.25">1/4</td>
-          <td class="tally chrome37 obsolete" data-tally="0.25">1/4</td>
-          <td class="tally chrome38" data-tally="0.75">3/4</td>
-          <td class="tally chrome39" data-tally="0.75">3/4</td>
+          <td class="tally chrome35 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome36 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome37 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome38" data-tally="1">4/4</td>
+          <td class="tally chrome39" data-tally="1">4/4</td>
           <td class="tally safari51 obsolete" data-tally="0">0/4</td>
           <td class="tally safari6" data-tally="0">0/4</td>
           <td class="tally safari7" data-tally="0">0/4</td>
@@ -4124,11 +4181,11 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="no chrome31 obsolete">No</td>
           <td class="no chrome33 obsolete">No</td>
           <td class="no chrome34 obsolete">No</td>
-          <td class="no chrome35 obsolete">No</td>
-          <td class="no chrome36 obsolete">No</td>
-          <td class="no chrome37 obsolete">No</td>
-          <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome35 obsolete">Yes</td>
+          <td class="yes chrome36 obsolete">Yes</td>
+          <td class="yes chrome37 obsolete">Yes</td>
+          <td class="yes chrome38">Yes</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -4161,15 +4218,15 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="tally firefox23 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox24 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox25 obsolete" data-tally="0">0/6</td>
-          <td class="tally firefox27 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox28 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox29 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox30 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox31" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox32 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox33" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox34" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox35" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally firefox27 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox28 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox29 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox30 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox31" data-tally="0.5">3/6</td>
+          <td class="tally firefox32 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox33" data-tally="0.5">3/6</td>
+          <td class="tally firefox34" data-tally="0.5">3/6</td>
+          <td class="tally firefox35" data-tally="0.6666666666666666">4/6</td>
           <td class="tally chrome obsolete" data-tally="0">0/6</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/6</td>
           <td class="tally chrome21dev obsolete" data-tally="0.3333333333333333">2/6</td>
@@ -4177,11 +4234,11 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="tally chrome31 obsolete" data-tally="0.3333333333333333">2/6</td>
           <td class="tally chrome33 obsolete" data-tally="0.3333333333333333">2/6</td>
           <td class="tally chrome34 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome35 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome36 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome37 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome38" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally chrome39" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally chrome35 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome36 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome37 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome38" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally chrome39" data-tally="1">6/6</td>
           <td class="tally safari51 obsolete" data-tally="0">0/6</td>
           <td class="tally safari6" data-tally="0">0/6</td>
           <td class="tally safari7" data-tally="0">0/6</td>
@@ -4198,7 +4255,7 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
         <tr class="subtest" data-parent="generators">
           <td><span>basic functionality</span></td>
 <script data-source="
-function* generator(){
+function * generator(){
   yield 5; yield 6;
 };
 var iterator = generator();
@@ -4210,7 +4267,7 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nfunction* generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -4265,7 +4322,7 @@ test(function(){try{return Function("\nfunction* generator(){\n  yield 5; yield 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, arrays</span></td>
 <script data-source="
-var iterator = (function* generator() {
+var iterator = (function * generator() {
   yield * [5, 6];
 }());
 var item = iterator.next();
@@ -4276,7 +4333,7 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nvar iterator = (function* generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -4331,7 +4388,7 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, strings</span></td>
 <script data-source="
-var iterator = (function* generator() {
+var iterator = (function * generator() {
   yield * &quot;56&quot;;
 }());
 var item = iterator.next();
@@ -4342,7 +4399,7 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nvar iterator = (function* generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -4397,20 +4454,20 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, generic iterables</span></td>
 <script data-source="
-var iterator = (function* generator() {
-  yield * (function* () {
-    yield 5; yield 6;
-  }());
+var iterator = (function * generator() {
+  yield * __createIterableObject(5, 6, 7);
 }());
 var item = iterator.next();
 var passed = item.value === 5 && item.done === false;
 item = iterator.next();
 passed    &= item.value === 6 && item.done === false;
 item = iterator.next();
+passed    &= item.value === 7 && item.done === false;
+item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nvar iterator = (function* generator() {\n  yield * (function* () {\n    yield 5; yield 6;\n  }());\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * __createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -4428,15 +4485,15 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox28 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32 obsolete">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes firefox35">Yes</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -4465,20 +4522,20 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, instances of iterables</span></td>
 <script data-source="
-var iterator = (function* generator() {
-  yield * Object.create(function* () {
-    yield 5; yield 6;
-  }());
+var iterator = (function * generator() {
+  yield * Object.create(__createIterableObject(5, 6, 7));
 }());
 var item = iterator.next();
 var passed = item.value === 5 && item.done === false;
 item = iterator.next();
 passed    &= item.value === 6 && item.done === false;
 item = iterator.next();
+passed    &= item.value === 7 && item.done === false;
+item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nvar iterator = (function* generator() {\n  yield * Object.create(function* () {\n    yield 5; yield 6;\n  }());\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
@@ -4512,11 +4569,11 @@ test(function(){try{return Function("\nvar iterator = (function* generator() {\n
           <td class="no chrome31 obsolete">No</td>
           <td class="no chrome33 obsolete">No</td>
           <td class="no chrome34 obsolete">No</td>
-          <td class="no chrome35 obsolete">No</td>
-          <td class="no chrome36 obsolete">No</td>
-          <td class="no chrome37 obsolete">No</td>
-          <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
+          <td class="yes chrome35 obsolete">Yes</td>
+          <td class="yes chrome36 obsolete">Yes</td>
+          <td class="yes chrome37 obsolete">Yes</td>
+          <td class="yes chrome38">Yes</td>
+          <td class="yes chrome39">Yes</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -10283,14 +10340,15 @@ Object.defineProperty(
   new Proxy(proxied, {
     defineProperty: function (t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
+      return true;
     }
   }),
   &quot;foo&quot;,
-  { value: 5 }
+  { value: 5, configurable: true }
 );
 return passed;
       ">
-test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n    }\n  }),\n  \"foo\",\n  { value: 5 }\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -13218,9 +13276,9 @@ var o = { foo: function(){}, bar: function baz(){}};
 o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       ">
-test(function(){try{return Function("\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -13275,12 +13333,12 @@ test(function(){try{return Function("\nvar o = { foo: function(){}, bar: functio
         <tr class="subtest" data-parent="function_name_property">
           <td><span>accessor properties</span></td>
 <script data-source="
-var o = { get foo(){}, set foo(){} };
+var o = { get foo(){}, set foo(x){} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &&
-       descriptor.get.name === &quot;set foo&quot;;
+       descriptor.set.name === &quot;set foo&quot;;
       ">
-test(function(){try{return Function("\nvar o = { get foo(){}, set foo(){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.get.name === \"set foo\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -13393,17 +13451,17 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
         <tr class="subtest" data-parent="function_name_property">
           <td><span>symbol-keyed methods</span></td>
 <script data-source="
-var o = {};
-var sym = Symbol(&quot;foo&quot;);
+var sym1 = Symbol(&quot;foo&quot;);
 var sym2 = Symbol();
-
-o[sym] = function(){};
-o[sym2] = function(){};
+var o = {
+  [sym1]: function(){},
+  [sym2]: function(){}
+};
 
 return o[sym].name === &quot;[foo]&quot; &&
        o[sym2].name === &quot;&quot;;
       ">
-test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol(\"foo\");\nvar sym2 = Symbol();\n\no[sym] = function(){};\no[sym2] = function(){};\n\nreturn o[sym].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -13642,9 +13700,9 @@ var o = { foo: class {}, bar: class baz {}};
 o.qux = class {};
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
-       o.qux.name === &quot;qux&quot;;
+       o.qux.name === &quot;&quot;;
       ">
-test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"qux\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -13815,12 +13873,12 @@ test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo
         <tr class="subtest" data-parent="function_name_property">
           <td><span>isn't writable, is configurable</span></td>
 <script data-source="
-var descriptor = Object.getOwnPropertyDescriptor(function(){},&quot;name&quot;);
+var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;);
 return descriptor.enumerable   === false &&
        descriptor.writable     === false &&
        descriptor.configurable === true;
       ">
-test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDescriptor(function(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -15232,11 +15290,13 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
 var passed = false;
 var obj = { foo: true };
 var C = function(){};
-C[Symbol.hasInstance] = function(inst) { passed = inst.foo; return false; };
+Object.defineProperty(C, Symbol.hasInstance, {
+  value: function(inst) { passed = inst.foo; return false; }
+});
 obj instanceof C;
 return passed;
       ">
-test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nC[Symbol.hasInstance] = function(inst) { passed = inst.foo; return false; };\nobj instanceof C;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -18105,6 +18165,69 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
         <tr>
           <th colspan="52" class="separator"></th>
         </tr>
+        <tr>
+          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
+<script data-source="
+// Note: only available outside of strict mode.
+{ function f() { return 1; } }
+  function g() { return 1; } { function g() { return 2; } }
+{ function h() { return 1; } } function h() { return 2; }
+
+return f() === 1 && g() === 2 && h() === 1;
+  ">
+test(function(){try{return Function("\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; } { function g() { return 2; } }\n{ function h() { return 1; } } function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")()}catch(e){return false;}}());
+</script>
+
+          <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td class="no ie10">No</td>
+          <td class="yes ie11">Yes</td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="yes firefox11 obsolete">Yes</td>
+          <td class="yes firefox13 obsolete">Yes</td>
+          <td class="yes firefox16 obsolete">Yes</td>
+          <td class="yes firefox17 obsolete">Yes</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td title="This feature is optional on non-browser platforms." class="yes rhino17 not-applicable ">Yes</td>
+          <td title="This feature is optional on non-browser platforms." class="no phantom not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no node not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no nodeharmony not-applicable ">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        </tr>
         <tr class="supertest">
           <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
 
@@ -18459,68 +18582,6 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td title="This feature is optional on non-browser platforms." class="no nodeharmony not-applicable ">No</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
-        </tr>
-        <tr>
-          <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a><a href="#hoisted-block-level-function-note"><sup>[19]</sup></a></span></td>
-<script data-source="
-// Note: only available outside of strict mode.
-var passed = f() === 2 && g() === 4;
-if (true) { function f(){ return 1; } } else { function f(){ return 2; } }
-if (false){ function g(){ return 3; } } else { function g(){ return 4; } }
-return passed;
-  ">
-test(function(){try{return Function("\n// Note: only available outside of strict mode.\nvar passed = f() === 2 && g() === 4;\nif (true) { function f(){ return 1; } } else { function f(){ return 2; } }\nif (false){ function g(){ return 3; } } else { function g(){ return 4; } }\nreturn passed;\n  ")()}catch(e){return false;}}());
-</script>
-
-          <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
-          <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
-          <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
-          <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
-          <td class="yes ie10">Yes</td>
-          <td class="no ie11">No</td>
-          <td class="no ie11tp">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
-          <td class="no firefox35">No</td>
-          <td class="yes chrome obsolete">Yes</td>
-          <td class="yes chrome19dev obsolete">Yes</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome31 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35 obsolete">Yes</td>
-          <td class="yes chrome36 obsolete">Yes</td>
-          <td class="yes chrome37 obsolete">Yes</td>
-          <td class="yes chrome38">Yes</td>
-          <td class="yes chrome39">Yes</td>
-          <td class="yes safari51 obsolete">Yes</td>
-          <td class="yes safari6">Yes</td>
-          <td class="yes safari7">Yes</td>
-          <td class="yes safari71_8">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="yes opera">Yes</td>
-          <td class="yes konq49">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="no rhino17 not-applicable ">No</td>
-          <td title="This feature is optional on non-browser platforms." class="yes phantom not-applicable ">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="yes node not-applicable ">Yes</td>
-          <td title="This feature is optional on non-browser platforms." class="yes nodeharmony not-applicable ">Yes</td>
-          <td class="yes ios7">Yes</td>
-          <td class="yes ios8">Yes</td>
         </tr>
         <tr class="supertest">
           <td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
@@ -18935,9 +18996,6 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
       </p>
       <p id="proto-in-object-literals-note">
         <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
-      </p>
-      <p id="hoisted-block-level-function-note">
-        <sup>[19]</sup> Note that the specified semantics is identical to that used by Internet Explorer prior to IE 11.
       </p>
     </div>
   </div>

--- a/es6/index.html
+++ b/es6/index.html
@@ -4218,15 +4218,15 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="tally firefox23 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox24 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox25 obsolete" data-tally="0">0/6</td>
-          <td class="tally firefox27 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox28 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox29 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox30 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox31" data-tally="0.5">3/6</td>
-          <td class="tally firefox32 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox33" data-tally="0.5">3/6</td>
-          <td class="tally firefox34" data-tally="0.5">3/6</td>
-          <td class="tally firefox35" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox27 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox28 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox29 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox30 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox31" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox32 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox33" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox34" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox35" data-tally="0.8333333333333334">5/6</td>
           <td class="tally chrome obsolete" data-tally="0">0/6</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/6</td>
           <td class="tally chrome21dev obsolete" data-tally="0.3333333333333333">2/6</td>
@@ -4485,15 +4485,15 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
-          <td class="no firefox35">No</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -18170,12 +18170,14 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
 <script data-source="
 // Note: only available outside of strict mode.
 { function f() { return 1; } }
-  function g() { return 1; } { function g() { return 2; } }
-{ function h() { return 1; } } function h() { return 2; }
+  function g() { return 1; }
+{ function g() { return 2; } }
+{ function h() { return 1; } }
+  function h() { return 2; }
 
 return f() === 1 && g() === 2 && h() === 1;
   ">
-test(function(){try{return Function("\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; } { function g() { return 2; } }\n{ function h() { return 1; } } function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")()}catch(e){return false;}}());
+test(function(){try{return Function("\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")()}catch(e){return false;}}());
 </script>
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -13,19 +13,18 @@
         var global = this;
       }
       function __createIterableObject(a, b, c) {
-        try {
-          return eval("(function*() { yield a; yield b; yield c; }())");
-        }
-        catch (e) {
-          var iterable;
+        if (typeof Symbol === "function" && Symbol.iterator) {
           var arr = [a, b, c, ,];
-          iterable = {
+          var iterable = {
             next: function() {
-              return { value: arr.shift(), done: arr.length <= 0 };
+              return { value: arr.shift(), done: arr.length <= 0 }; 
             },
           };
           iterable[Symbol.iterator] = function(){ return iterable; }
           return iterable;
+        }
+        else {
+          return eval("(function*() { yield a; yield b; yield c; }())");
         }
       }
     </script>

--- a/node.js
+++ b/node.js
@@ -21,19 +21,19 @@ $('#body tbody tr').each(function () {
         result = result || expression
       }
     , __createIterableObject = function(a, b, c) {
-      try {
-        return eval("(function*() { yield a; yield b; yield c; }())");
-      }
-      catch (e) {
-        var arr = [a, b, c, ,];
-        var iterable = {
-          next: function() {
-            return { value: arr.shift(), done: arr.length <= 0 }; 
-          },
-        };
+      if (typeof Symbol === "function" && Symbol.iterator) {
+        var arr = [a, b, c, ,]
+          , iterable = {
+            next: function() {
+              return { value: arr.shift(), done: arr.length <= 0 }
+            }
+          }
         iterable[Symbol.iterator] = function(){ return iterable; }
+        return iterable;
       }
-      return iterable;
+      else {
+        return eval("(function*() { yield a; yield b; yield c; }())")
+      }
     }
 
   // can be multiple scripts


### PR DESCRIPTION
Fixes #329, #330, #331, #332, #333, #334, via the following:
- Changes the definition of `__createIterableObject` to use `Symbol.iterator` first, thus correcting the "instances of generic iterables" tests (which wrongly failed implementation with both `Symbol.iterator` and generators).
- Changes the "`yield *`, generic iterables" and "`yield *`, instances of iterables" tests to use `__createIterableObject` instead of generators to produce the iterable.
- Split off the defaults "temporal dead zone test" into a "separate scope" test.
- Fixed the Proxy "define property" handler test not making the handler return a boolean.
- Fixed several mistakes in the function "name" property tests.
- Redid the "hoisted block-level function declaration" test, updating its results accordingly.
- Fixed the `Symbol.hasInstance` test to use Object.defineProperty, to overcome a limitation of Function instances.
