### PR TITLE
November ES6 spec changes

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -503,7 +503,7 @@ exports.tests = [
         ie11:        true,
       }
     },
-    'redefining a const is a syntax error': {
+    'redefining a const is an error': {
       exec: function() {/*
         const baz = 1;
         try {
@@ -2402,21 +2402,6 @@ exports.tests = [
         nodeharmony: true,
       },
     },
-    'WeakMap.prototype.clear': {
-      exec: function () {/*
-        return typeof WeakMap.prototype.clear === "function";
-      */},
-      res: {
-        ejs:         true,
-        ie11:        true,
-        firefox23:   true,
-        chrome21dev: true,
-        safari71_8:  true,
-        ios8:        true,
-        webkit:      true,
-        nodeharmony: true,
-      },
-    },
   },
 },
 {
@@ -2468,18 +2453,6 @@ exports.tests = [
     'WeakSet.prototype.delete': {
       exec: function () {/*
         return typeof WeakSet.prototype.delete === "function";
-      */},
-      res: {
-        ejs:         true,
-        ie11tp:      true,
-        firefox34:   true,
-        chrome30:    true,
-        nodeharmony: true,
-      },
-    },
-    'WeakSet.prototype.clear': {
-      exec: function () {/*
-        return typeof WeakSet.prototype.clear === "function";
       */},
       res: {
         ejs:         true,
@@ -2794,6 +2767,23 @@ exports.tests = [
         firefox34:   true,
       },
     },
+    'Array.isArray support': {
+      exec: function () {/*
+        return Array.isArray(new Proxy([], {}));
+      */},
+      res: {
+        firefox18: true,
+      },
+    },
+    'JSON.stringify support': {
+      exec: function () {/*
+        return JSON.stringify(new Proxy(['foo'], {})) === '["foo"]';
+      */},
+      res: {
+        firefox18: true,  // a bug in FF18
+        firefox23: false,
+      },
+    },
   },
 },
 {
@@ -3083,7 +3073,7 @@ exports.tests = [
       */},
       res: temp.destructuringResults,
     },
-    'parameters': {
+    'in parameters': {
       exec: function(){/*
         return (function({a, x:b, y:e}, [c, d]) {
           return a === 1 && b === 2 && c === 3 &&
@@ -3113,6 +3103,15 @@ exports.tests = [
         _6to5:       true,
         closure:     true,
         firefox34:   true,
+      },
+    },
+    'nested rest': {
+      exec: function(){/*
+        var a = [1, 2, 3], first, last;
+        [first, ...[a[2], last]] = a;
+        return first === 1 && last === 3 && (a + "") === "1,2,2";
+      */},
+      res: {
       },
     },
     'defaults': {
@@ -3637,19 +3636,23 @@ exports.tests = [
         nodeharmony: true,
       },
     },
-    'String.prototype.contains': {
+    'String.prototype.includes': {
       exec: function () {/*
-        return typeof String.prototype.contains === 'function'
-          && "foobar".contains("oba");
+        return typeof String.prototype.includes === 'function'
+          && "foobar".includes("oba");
       */},
       res: {
-        tr:          true,
-        _6to5:       true,
-        ejs:         true,
-        firefox18:   true,
-        chrome30:    true,
-        webkit:      true,
-        nodeharmony: true,
+        tr:          {
+          val: false,
+          note_id: 'string-contains',
+          note_html: 'Available as the draft standard <code>String.prototype.contains</code>'
+        },
+        _6to5:       { val: false, note_id: 'string-contains' },
+        ejs:         { val: false, note_id: 'string-contains' },
+        firefox18:   { val: false, note_id: 'string-contains' },
+        chrome30:    { val: false, note_id: 'string-contains' },
+        webkit:      { val: false, note_id: 'string-contains' },
+        nodeharmony: { val: false, note_id: 'string-contains' },
       },
     },
   },
@@ -3998,13 +4001,6 @@ exports.tests = [
        ejs:         true,
       },
     },
-    'Symbol.isRegExp': {
-      exec: function() {/*
-        return RegExp.prototype[Symbol.isRegExp] === true;
-      */},
-      res: {
-      },
-    },
     'Symbol.iterator': {
       exec: function() {/*
         var a = 0, b = {};
@@ -4027,6 +4023,15 @@ exports.tests = [
         ie11tp:      true,
         chrome37:    true,
         ejs:         true,
+      },
+    },
+    'Symbol.species': {
+      exec: function() {/*
+        return RegExp[Symbol.species] === RegExp
+          && Array[Symbol.species] === Array
+          && !(Symbol.species in Object);
+      */},
+      res: {
       },
     },
     'Symbol.toPrimitive': {
@@ -4074,27 +4079,27 @@ exports.tests = [
   name: 'RegExp.prototype methods',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype',
   subtests: {
-    'RegExp.prototype.match': {
+    'RegExp.prototype[Symbol.match]': {
       exec: function () {/*
-        return typeof RegExp.prototype.match === 'function';
+        return typeof RegExp.prototype[Symbol.match] === 'function';
       */},
       res: {},
     },
-    'RegExp.prototype.replace': {
+    'RegExp.prototype[Symbol.replace]': {
       exec: function () {/*
-        return typeof RegExp.prototype.replace === 'function';
+        return typeof RegExp.prototype[Symbol.replace] === 'function';
       */},
       res: {},
     },
-    'RegExp.prototype.split': {
+    'RegExp.prototype[Symbol.split]': {
       exec: function () {/*
-        return typeof RegExp.prototype.split === 'function';
+        return typeof RegExp.prototype[Symbol.split] === 'function';
       */},
       res: {},
     },
-    'RegExp.prototype.search': {
+    'RegExp.prototype[Symbol.search]': {
       exec: function () {/*
-        return typeof RegExp.prototype.search === 'function';
+        return typeof RegExp.prototype[Symbol.search] === 'function';
       */},
       res: {},
     },

--- a/es6/compilers/6to5-polyfill.html
+++ b/es6/compilers/6to5-polyfill.html
@@ -234,7 +234,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
@@ -587,23 +587,15 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <script data-source="&quot;use strict&quot;;
 
-var _argumentsToArray = function (args) {
-  var target = new Array(args.length);
-  for (var i = 0; i < args.length; i++) {
-    target[i] = args[i];
-  }
-
-  return target;
-};
-
+var _slice = Array.prototype.slice;
 (function () {
   return (function () {
-    var args = _argumentsToArray(arguments);
+    var args = _slice.call(arguments);
 
     return typeof args !== &quot;undefined&quot;;
   }());
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _argumentsToArray = function (args) {\n  var target = new Array(args.length);\n  for (var i = 0; i < args.length; i++) {\n    target[i] = args[i];\n  }\n\n  return target;\n};\n\n(function () {\n  return (function () {\n    var args = _argumentsToArray(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _slice = Array.prototype.slice;\n(function () {\n  return (function () {\n    var args = _slice.call(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2219,16 +2211,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var weakma
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakMap.prototype[\"delete\"] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return typeof WeakMap.prototype.clear === &quot;function&quot;;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakMap.prototype.clear === \"function\";\n});")()}catch(e){return false;}}());
-</script>
-
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -2282,16 +2264,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var weakse
   return typeof WeakSet.prototype[&quot;delete&quot;] === &quot;function&quot;;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakSet.prototype[\"delete\"] === \"function\";\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return typeof WeakSet.prototype.clear === &quot;function&quot;;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakSet.prototype.clear === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2567,6 +2539,26 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxie
   return passed;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var obj = Proxy.revocable({}, { get: function () {\n      return 5;\n    } });\n  var passed = (obj.proxy.foo === 5);\n  obj.revoke();\n  try {\n    obj.proxy.foo;\n  } catch (e) {\n    passed &= e instanceof TypeError;\n  }\n  return passed;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return Array.isArray(new Proxy([], {}));
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Array.isArray(new Proxy([], {}));\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return JSON.stringify(new Proxy([&quot;foo&quot;], {})) === &quot;[\&quot;foo\&quot;]&quot;;
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return JSON.stringify(new Proxy([\"foo\"], {})) === \"[\\\"foo\\\"]\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2878,7 +2870,7 @@ test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="&quot;use strict&quot;;
 
 var _toArray = function (arr) {
@@ -2926,6 +2918,29 @@ var _toArray = function (arr) {
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
 test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _toArray(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = _toArray(_ref3);\n\n  var c = _ref4[0];\n  var d = _toArray(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="&quot;use strict&quot;;
+
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
+(function () {
+  var a = [1, 2, 3], first, last;
+  var _ref = a;
+  var _ref2 = _toArray(_ref);
+
+  first = _ref2[0];
+  var _ref3 = _toArray(_toArray(_ref2).slice(1));
+
+  a[2] = _ref3[0];
+  last = _ref3[1];
+  return first === 1 && last === 3 && (a + &quot;&quot;) === &quot;1,2,2&quot;;
+});">
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var a = [1, 2, 3], first, last;\n  var _ref = a;\n  var _ref2 = _toArray(_ref);\n\n  first = _ref2[0];\n  var _ref3 = _toArray(_toArray(_ref2).slice(1));\n\n  a[2] = _ref3[0];\n  last = _ref3[1];\n  return first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3388,13 +3403,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof String.prototype.contains === &quot;function&quot; && &quot;foobar&quot;.contains(&quot;oba&quot;);
+  return typeof String.prototype.includes === &quot;function&quot; && &quot;foobar&quot;.includes(&quot;oba&quot;);
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof String.prototype.contains === \"function\" && \"foobar\".contains(\"oba\");\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof String.prototype.includes === \"function\" && \"foobar\".includes(\"oba\");\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3585,16 +3600,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = []
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return RegExp.prototype[Symbol.isRegExp] === true;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return RegExp.prototype[Symbol.isRegExp] === true;\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
 <script data-source="&quot;use strict&quot;;
 
@@ -3618,6 +3623,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Reg
   return c === &quot;foo&quot;;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = 0, b = {};\n  b[Symbol.iterator] = function () {\n    return {\n      next: function () {\n        return {\n          done: a++ === 1,\n          value: \"foo\"\n        };\n      }\n    };\n  };\n  var c;\n  for (var _iterator = b[Symbol.iterator](), _step; !(_step = _iterator.next()).done;) {\n    c = _step.value;\n  }\n\n  return c === \"foo\";\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -3676,43 +3691,43 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = { 
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.match === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.match] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.match === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.match] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.replace === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.replace] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.replace === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.replace] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.split === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.split] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.split === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.split] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.search === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.search] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.search === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.search] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/6to5.html
+++ b/es6/compilers/6to5.html
@@ -232,7 +232,7 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  {\n    var
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
@@ -585,23 +585,15 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return (fu
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <script data-source="&quot;use strict&quot;;
 
-var _argumentsToArray = function (args) {
-  var target = new Array(args.length);
-  for (var i = 0; i < args.length; i++) {
-    target[i] = args[i];
-  }
-
-  return target;
-};
-
+var _slice = Array.prototype.slice;
 (function () {
   return (function () {
-    var args = _argumentsToArray(arguments);
+    var args = _slice.call(arguments);
 
     return typeof args !== &quot;undefined&quot;;
   }());
 });">
-test(function(){try{return eval("\"use strict\";\n\nvar _argumentsToArray = function (args) {\n  var target = new Array(args.length);\n  for (var i = 0; i < args.length; i++) {\n    target[i] = args[i];\n  }\n\n  return target;\n};\n\n(function () {\n  return (function () {\n    var args = _argumentsToArray(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\nvar _slice = Array.prototype.slice;\n(function () {\n  return (function () {\n    var args = _slice.call(arguments);\n\n    return typeof args !== \"undefined\";\n  }());\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2217,16 +2209,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var weakma
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakMap.prototype[\"delete\"] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return typeof WeakMap.prototype.clear === &quot;function&quot;;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakMap.prototype.clear === \"function\";\n});")()}catch(e){return false;}}());
-</script>
-
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -2280,16 +2262,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var weakse
   return typeof WeakSet.prototype[&quot;delete&quot;] === &quot;function&quot;;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakSet.prototype[\"delete\"] === \"function\";\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return typeof WeakSet.prototype.clear === &quot;function&quot;;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof WeakSet.prototype.clear === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2565,6 +2537,26 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var proxie
   return passed;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var obj = Proxy.revocable({}, { get: function () {\n      return 5;\n    } });\n  var passed = (obj.proxy.foo === 5);\n  obj.revoke();\n  try {\n    obj.proxy.foo;\n  } catch (e) {\n    passed &= e instanceof TypeError;\n  }\n  return passed;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return Array.isArray(new Proxy([], {}));
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Array.isArray(new Proxy([], {}));\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return JSON.stringify(new Proxy([&quot;foo&quot;], {})) === &quot;[\&quot;foo\&quot;]&quot;;
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return JSON.stringify(new Proxy([\"foo\"], {})) === \"[\\\"foo\\\"]\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2876,7 +2868,7 @@ test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="&quot;use strict&quot;;
 
 var _toArray = function (arr) {
@@ -2924,6 +2916,29 @@ var _toArray = function (arr) {
   return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; && c === 6 && d instanceof Array && d.length === 0;
 });">
 test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var _ref = [3, 4, 5];\n\n  var _ref2 = _toArray(_ref);\n\n  var a = _ref2[0];\n  var b = _toArray(_ref2).slice(1);\n\n  var _ref3 = [6];\n\n  var _ref4 = _toArray(_ref3);\n\n  var c = _ref4[0];\n  var d = _toArray(_ref4).slice(1);\n\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="&quot;use strict&quot;;
+
+var _toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
+(function () {
+  var a = [1, 2, 3], first, last;
+  var _ref = a;
+  var _ref2 = _toArray(_ref);
+
+  first = _ref2[0];
+  var _ref3 = _toArray(_toArray(_ref2).slice(1));
+
+  a[2] = _ref3[0];
+  last = _ref3[1];
+  return first === 1 && last === 3 && (a + &quot;&quot;) === &quot;1,2,2&quot;;
+});">
+test(function(){try{return eval("\"use strict\";\n\nvar _toArray = function (arr) {\n  return Array.isArray(arr) ? arr : Array.from(arr);\n};\n\n(function () {\n  var a = [1, 2, 3], first, last;\n  var _ref = a;\n  var _ref2 = _toArray(_ref);\n\n  first = _ref2[0];\n  var _ref3 = _toArray(_toArray(_ref2).slice(1));\n\n  a[2] = _ref3[0];\n  last = _ref3[1];\n  return first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3386,13 +3401,13 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typ
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof String.prototype.contains === &quot;function&quot; && &quot;foobar&quot;.contains(&quot;oba&quot;);
+  return typeof String.prototype.includes === &quot;function&quot; && &quot;foobar&quot;.includes(&quot;oba&quot;);
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof String.prototype.contains === \"function\" && \"foobar\".contains(\"oba\");\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof String.prototype.includes === \"function\" && \"foobar\".includes(\"oba\");\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3583,16 +3598,6 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = []
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="&quot;use strict&quot;;
-
-(function () {
-  return RegExp.prototype[Symbol.isRegExp] === true;
-});">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return RegExp.prototype[Symbol.isRegExp] === true;\n});")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
 <script data-source="&quot;use strict&quot;;
 
@@ -3616,6 +3621,16 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return Reg
   return c === &quot;foo&quot;;
 });">
 test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = 0, b = {};\n  b[Symbol.iterator] = function () {\n    return {\n      next: function () {\n        return {\n          done: a++ === 1,\n          value: \"foo\"\n        };\n      }\n    };\n  };\n  var c;\n  for (var _iterator = b[Symbol.iterator](), _step; !(_step = _iterator.next()).done;) {\n    c = _step.value;\n  }\n\n  return c === \"foo\";\n});")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="&quot;use strict&quot;;
+
+(function () {
+  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);
+});">
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -3674,43 +3689,43 @@ test(function(){try{return eval("\"use strict\";\n\n(function () {\n  var a = { 
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.match === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.match] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.match === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.match] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.replace === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.replace] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.replace === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.replace] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.split === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.split] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.split === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.split] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
 <script data-source="&quot;use strict&quot;;
 
 (function () {
-  return typeof RegExp.prototype.search === &quot;function&quot;;
+  return typeof RegExp.prototype[Symbol.search] === &quot;function&quot;;
 });">
-test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype.search === \"function\";\n});")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n\n(function () {\n  return typeof RegExp.prototype[Symbol.search] === \"function\";\n});")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/es6-transpiler.html
+++ b/es6/compilers/es6-transpiler.html
@@ -55,16 +55,8 @@
       <tbody>
         <tr>
           <td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
-<script data-source="(function(){
-&quot;use strict&quot;;
-return (function f(n){
-  if (n <= 0) {
-    return  &quot;foo&quot;;
-  }
-  return f(n - 1);
-}(1e6)) === &quot;foo&quot;;
-  })">
-test(function(){try{return eval("(function(){\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -171,7 +163,7 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
@@ -188,18 +180,14 @@ test(function(){try{return eval("(function(){\nvar passed = (function(){ try { q
 
         <tr class="subtest" data-parent="const">
           <td><span>basic support (strict mode)</span></td>
-<script data-source="(function(){
-&quot;use strict&quot;;
-var foo = 123;
-return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\n\"use strict\";\nvar foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -210,13 +198,8 @@ test(function(){try{return Function("/* Error during compilation: This test's co
 
         <tr class="subtest" data-parent="const">
           <td><span>temporal dead zone (strict mode)</span></td>
-<script data-source="(function(){
-'use strict';
-var passed = (function(){ try { qux; } catch(e) { return true; }}());
-var qux = 456;
-return passed;
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nvar qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -262,41 +245,32 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
 
         <tr class="subtest" data-parent="let">
           <td><span>basic support (strict mode)</span></td>
-<script data-source="(function(){
-'use strict';
-var foo = 123;
-return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nvar foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope (strict mode)</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>temporal dead zone (strict mode)</span></td>
-<script data-source="(function(){
-'use strict';
-var passed = (function(){ try {  qux; } catch(e) { return true; }}());
-var qux = 456;
-return passed;
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nvar qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop iteration scope (strict mode)</span></td>
-<script data-source="">
-test(function(){try{return eval("")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -791,10 +765,8 @@ test(function(){try{return eval("(function(){\nvar re = new RegExp('\\\\w');\nva
 
         <tr class="subtest" data-parent="RegExp_y_and_u_flags">
           <td><span>"u" flag</span></td>
-<script data-source="(RegExp[&quot;__polyfill__&quot;]||function(obj1, obj2){var arr=RegExp[&quot;__polyfill__&quot;];if(!arr)arr=RegExp[&quot;__polyfill__&quot;]=[];arr.push([obj1,obj2])})({&quot;.&quot;:&quot;(?:[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|.)&quot;}, {});(function(){
-return &quot;𠮷&quot;.match((new RegExp(&quot;.&quot;, &quot;u&quot;)))[0].length === 2;
-      })">
-test(function(){try{return eval("(RegExp[\"__polyfill__\"]||function(obj1, obj2){var arr=RegExp[\"__polyfill__\"];if(!arr)arr=RegExp[\"__polyfill__\"]=[];arr.push([obj1,obj2])})({\".\":\"(?:[\\\\uD800-\\\\uDBFF][\\\\uDC00-\\\\uDFFF]|.)\"}, {});(function(){\nreturn \"𠮷\".match((new RegExp(\".\", \"u\")))[0].length === 2;\n      })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1625,14 +1597,6 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 test(function(){try{return eval("(function(){\nreturn typeof WeakMap.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
 </script>
 
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="(function(){
-return typeof WeakMap.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakMap.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
-</script>
-
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -1678,14 +1642,6 @@ test(function(){try{return eval("(function(){\nvar weakset = new WeakSet();\nvar
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
       })">
 test(function(){try{return eval("(function(){\nreturn typeof WeakSet.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="(function(){
-return typeof WeakSet.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakSet.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1950,6 +1906,22 @@ return passed;
 test(function(){try{return eval("(function(){\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      })")()}catch(e){return false;}}());
 </script>
 
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="(function(){
+return Array.isArray(new Proxy([], {}));
+      })">
+test(function(){try{return eval("(function(){\nreturn Array.isArray(new Proxy([], {}));\n      })")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="(function(){
+return JSON.stringify(new Proxy(['foo'], {})) === '[&quot;foo&quot;]';
+      })">
+test(function(){try{return eval("(function(){\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      })")()}catch(e){return false;}}());
+</script>
+
         </tr>
         <tr class="supertest">
           <td id="Reflect"><span><a class="anchor" href="#Reflect">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
@@ -2041,14 +2013,8 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
         </tr>
         <tr>
           <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[1]</sup></a></span></td>
-<script data-source="(function(){
-'use strict';
-{
-  function f(){}
-}
-return typeof f === &quot;undefined&quot;;
-  })">
-test(function(){try{return eval("(function(){\n'use strict';\n{\n  function f(){}\n}\nreturn typeof f === \"undefined\";\n  })")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: undefined is not a function*/">
+test(function(){try{return Function("/* Error during compilation: undefined is not a function*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2104,7 +2070,7 @@ test(function(){try{return eval("(function(){\nvar e = (g = [9, {x:10}])[0], f =
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="(function(){
 return (function(e, d) {var a = e.a, b = e.x, e = e.y;var c = d[0], d = d[1];
   return a === 1 && b === 2 && c === 3 &&
@@ -2123,6 +2089,12 @@ return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; &
    c === 6 && d instanceof Array && d.length === 0;
       })">
 test(function(){try{return eval("(function(){var SLICE$0 = Array.prototype.slice;\nvar a = (b = [3, 4, 5])[0], b = SLICE$0.call(b, 1);\nvar c = (d = [6])[0], d = SLICE$0.call(d, 1);\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      })")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="/* Error during compilation: false == true*/">
+test(function(){try{return Function("/* Error during compilation: false == true*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2434,12 +2406,12 @@ test(function(){try{return eval("(function(){\nreturn typeof String.prototype.en
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="(function(){
-return typeof String.prototype.contains === 'function'
-  && &quot;foobar&quot;.contains(&quot;oba&quot;);
+return typeof String.prototype.includes === 'function'
+  && &quot;foobar&quot;.includes(&quot;oba&quot;);
       })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.contains === 'function'\n  && \"foobar\".contains(\"oba\");\n      })")()}catch(e){return false;}}());
+test(function(){try{return eval("(function(){\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      })")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2527,13 +2499,13 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
+          <td><span>Symbol.iterator</span></td>
 <script data-source="">
 test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.iterator</span></td>
+          <td><span>Symbol.species</span></td>
 <script data-source="">
 test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
@@ -2561,35 +2533,27 @@ test(function(){try{return eval("")()}catch(e){return false;}}());
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.match === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.match === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.replace === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.replace === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.split === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.split === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.search === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.search === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
+<script data-source="">
+test(function(){try{return eval("")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/esnext.html
+++ b/es6/compilers/esnext.html
@@ -55,16 +55,16 @@
       <tbody>
         <tr>
           <td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 &quot;use strict&quot;;
-return (function f(n){
+return (function f(n) {
   if (n <= 0) {
     return  &quot;foo&quot;;
   }
   return f(n - 1);
 }(1e6)) === &quot;foo&quot;;
-  })">
-test(function(){try{return eval("(function(){\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\n\"use strict\";\nreturn (function f(n) {\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -73,75 +73,75 @@ test(function(){try{return eval("(function(){\n\"use strict\";\nreturn (function
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>0 parameters</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function() {
       return 5;
 })() === 5;
-      })">
-test(function(){try{return eval("(function(){\nreturn (function() {\n      return 5;\n})() === 5;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function() {\n      return 5;\n})() === 5;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>1 parameter, no brackets</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var b = function(x) {
       return x + &quot;foo&quot;;
 };
 return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
-      })">
-test(function(){try{return eval("(function(){\nvar b = function(x) {\n      return x + \"foo\";\n};\nreturn (b(\"fee fie foe \") === \"fee fie foe foo\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar b = function(x) {\n      return x + \"foo\";\n};\nreturn (b(\"fee fie foe \") === \"fee fie foe foo\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>multiple parameters</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var c = function(v, w, x, y, z) {
       return &quot;&quot; + v + w + x + y + z;
 };
 return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
-      })">
-test(function(){try{return eval("(function(){\nvar c = function(v, w, x, y, z) {\n      return \"\" + v + w + x + y + z;\n};\nreturn (c(6, 5, 4, 3, 2) === \"65432\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar c = function(v, w, x, y, z) {\n      return \"\" + v + w + x + y + z;\n};\nreturn (c(6, 5, 4, 3, 2) === \"65432\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>lexical "this" binding</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var d = { x : &quot;bar&quot;, y : function() { return function(z) {
       return this.x + z;
 }.bind(this); }}.y();
 var e = { x : &quot;baz&quot;, y : d };
 return d(&quot;ley&quot;) === &quot;barley&quot; && e.y(&quot;ley&quot;) === &quot;barley&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar d = { x : \"bar\", y : function() { return function(z) {\n      return this.x + z;\n}.bind(this); }}.y();\nvar e = { x : \"baz\", y : d };\nreturn d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar d = { x : \"bar\", y : function() { return function(z) {\n      return this.x + z;\n}.bind(this); }}.y();\nvar e = { x : \"baz\", y : d };\nreturn d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>"this" unchanged by call or apply</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var d = { x : &quot;foo&quot;, y : function() { return function() {
       return this.x;
 }.bind(this); }};
 var e = { x : &quot;bar&quot; };
 return d.y().call(e) === &quot;foo&quot; && d.y().apply(e) === &quot;foo&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar d = { x : \"foo\", y : function() { return function() {\n      return this.x;\n}.bind(this); }};\nvar e = { x : \"bar\" };\nreturn d.y().call(e) === \"foo\" && d.y().apply(e) === \"foo\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar d = { x : \"foo\", y : function() { return function() {\n      return this.x;\n}.bind(this); }};\nvar e = { x : \"bar\" };\nreturn d.y().call(e) === \"foo\" && d.y().apply(e) === \"foo\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>can't be bound, can be curried</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var d = { x : &quot;bar&quot;, y : function() { return function(z) {
       return this.x + z;
 }.bind(this); }};
 var e = { x : &quot;baz&quot; };
 return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar d = { x : \"bar\", y : function() { return function(z) {\n      return this.x + z;\n}.bind(this); }};\nvar e = { x : \"baz\" };\nreturn d.y().bind(e, \"ley\")() === \"barley\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar d = { x : \"bar\", y : function() { return function(z) {\n      return this.x + z;\n}.bind(this); }};\nvar e = { x : \"baz\" };\nreturn d.y().bind(e, \"ley\")() === \"barley\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>lexical "arguments" binding</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var f = (function() {
       var $__arguments0 = arguments;
       var $__arguments = $__arguments0;
@@ -150,8 +150,8 @@ var f = (function() {
       };
 }(5));
 return f(6) === 5;
-      })">
-test(function(){try{return eval("(function(){\nvar f = (function() {\n      var $__arguments0 = arguments;\n      var $__arguments = $__arguments0;\n      return function(z) {\n            return $__arguments[0];\n      };\n}(5));\nreturn f(6) === 5;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar f = (function() {\n      var $__arguments0 = arguments;\n      var $__arguments = $__arguments0;\n      return function(z) {\n            return $__arguments[0];\n      };\n}(5));\nreturn f(6) === 5;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="arrow_functions">
@@ -162,13 +162,13 @@ test(function(){try{return Function("/* Error during compilation: This test's co
 
         <tr class="subtest" data-parent="arrow_functions">
           <td><span>no "prototype" property</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = function() {
       return 5;
 };
 return !a.hasOwnProperty(&quot;prototype&quot;);
-      })">
-test(function(){try{return eval("(function(){\nvar a = function() {\n      return 5;\n};\nreturn !a.hasOwnProperty(\"prototype\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = function() {\n      return 5;\n};\nreturn !a.hasOwnProperty(\"prototype\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -177,56 +177,56 @@ test(function(){try{return eval("(function(){\nvar a = function() {\n      retur
 
         <tr class="subtest" data-parent="const">
           <td><span>basic support</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 const foo = 123;
 return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\nconst foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nconst foo = 123;\nreturn (foo === 123);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 { const bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\n{ const bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { bar; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\n{ const bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
           <td><span>temporal dead zone</span></td>
-<script data-source="(function(){
-var passed = (function(){ try { qux; } catch(e) { return true; }}());
+<script data-source="((function() {
+var passed = (function() { try { qux; } catch(e) { return true; }}());
 const qux = 456;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar passed = (function() { try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
           <td><span>basic support (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 &quot;use strict&quot;;
 const foo = 123;
 return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\n\"use strict\";\nconst foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\n\"use strict\";\nconst foo = 123;\nreturn (foo === 123);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 { const bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\n{ const bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { bar; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\n{ const bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="const">
@@ -237,13 +237,13 @@ test(function(){try{return Function("/* Error during compilation: This test's co
 
         <tr class="subtest" data-parent="const">
           <td><span>temporal dead zone (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
-var passed = (function(){ try { qux; } catch(e) { return true; }}());
+var passed = (function() { try { qux; } catch(e) { return true; }}());
 const qux = 456;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\nvar passed = (function() { try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -252,119 +252,119 @@ test(function(){try{return eval("(function(){\n'use strict';\nvar passed = (func
 
         <tr class="subtest" data-parent="let">
           <td><span>basic support</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 let foo = 123;
 return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\nlet foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nlet foo = 123;\nreturn (foo === 123);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 { let bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\n{ let bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { bar; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\n{ let bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 for(let baz = 0; false; false) {}
-return (function(){ try { baz; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\nfor(let baz = 0; false; false) {}\nreturn (function(){ try { baz; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { baz; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\nfor(let baz = 0; false; false) {}\nreturn (function() { try { baz; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>temporal dead zone</span></td>
-<script data-source="(function(){
-var passed = (function(){ try {  qux; } catch(e) { return true; }}());
+<script data-source="((function() {
+var passed = (function() { try {  qux; } catch(e) { return true; }}());
 let qux = 456;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar passed = (function() { try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop iteration scope</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 let scopes = [];
 for(let i = 0; i < 2; i++) {
-  scopes.push(function(){ return i; });
+  scopes.push(function() { return i; });
 }
 let passed = (scopes[0]() === 0 && scopes[1]() === 1);
 
 scopes = [];
 for(let i in { a:1, b:1 }) {
-  scopes.push(function(){ return i; });
+  scopes.push(function() { return i; });
 }
 passed &= (scopes[0]() === &quot;a&quot; && scopes[1]() === &quot;b&quot;);
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function() { return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function() { return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>basic support (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 let foo = 123;
 return (foo === 123);
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nlet foo = 123;\nreturn (foo === 123);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\nlet foo = 123;\nreturn (foo === 123);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>is block-scoped (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 { let bar = 456; }
-return (function(){ try { bar; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\n{ let bar = 456; }\nreturn (function(){ try { bar; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { bar; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\n{ let bar = 456; }\nreturn (function() { try { bar; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop statement scope (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 for(let baz = 0; false; false) {}
-return (function(){ try { baz; } catch(e) { return true; }}());
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nfor(let baz = 0; false; false) {}\nreturn (function(){ try { baz; } catch(e) { return true; }}());\n      })")()}catch(e){return false;}}());
+return (function() { try { baz; } catch(e) { return true; }}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\nfor(let baz = 0; false; false) {}\nreturn (function() { try { baz; } catch(e) { return true; }}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>temporal dead zone (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
-var passed = (function(){ try {  qux; } catch(e) { return true; }}());
+var passed = (function() { try {  qux; } catch(e) { return true; }}());
 let qux = 456;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\nvar passed = (function() { try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="let">
           <td><span>for-loop iteration scope (strict mode)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 let scopes = [];
 for(let i = 0; i < 2; i++) {
-  scopes.push(function(){ return i; });
+  scopes.push(function() { return i; });
 }
 let passed = (scopes[0]() === 0 && scopes[1]() === 1);
 
 scopes = [];
 for(let i in { a:1, b:1 }) {
-  scopes.push(function(){ return i; });
+  scopes.push(function() { return i; });
 }
 passed &= (scopes[0]() === &quot;a&quot; && scopes[1]() === &quot;b&quot;);
 return passed;
-      })">
-test(function(){try{return eval("(function(){\n'use strict';\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\n'use strict';\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function() { return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function() { return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -373,37 +373,37 @@ test(function(){try{return eval("(function(){\n'use strict';\nlet scopes = [];\n
 
         <tr class="subtest" data-parent="default_function_parameters">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function() {
       var a = (arguments[0] !== void 0 ? arguments[0] : 1);
       var b = (arguments[1] !== void 0 ? arguments[1] : 2);
       return a === 3 && b === 2;
 }(3));
-      })">
-test(function(){try{return eval("(function(){\nreturn (function() {\n      var a = (arguments[0] !== void 0 ? arguments[0] : 1);\n      var b = (arguments[1] !== void 0 ? arguments[1] : 2);\n      return a === 3 && b === 2;\n}(3));\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function() {\n      var a = (arguments[0] !== void 0 ? arguments[0] : 1);\n      var b = (arguments[1] !== void 0 ? arguments[1] : 2);\n      return a === 3 && b === 2;\n}(3));\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="default_function_parameters">
           <td><span>explicit undefined defers to the default</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function() {
       var a = (arguments[0] !== void 0 ? arguments[0] : 1);
       var b = (arguments[1] !== void 0 ? arguments[1] : 2);
       return a === 1 && b === 3;
 }(undefined, 3));
-      })">
-test(function(){try{return eval("(function(){\nreturn (function() {\n      var a = (arguments[0] !== void 0 ? arguments[0] : 1);\n      var b = (arguments[1] !== void 0 ? arguments[1] : 2);\n      return a === 1 && b === 3;\n}(undefined, 3));\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function() {\n      var a = (arguments[0] !== void 0 ? arguments[0] : 1);\n      var b = (arguments[1] !== void 0 ? arguments[1] : 2);\n      return a === 1 && b === 3;\n}(undefined, 3));\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="default_function_parameters">
           <td><span>defaults can refer to previous params</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function(a) {
       var b = (arguments[1] !== void 0 ? arguments[1] : a);
       return b === 5;
 }(5));
-      })">
-test(function(){try{return eval("(function(){\nreturn (function(a) {\n      var b = (arguments[1] !== void 0 ? arguments[1] : a);\n      return b === 5;\n}(5));\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function(a) {\n      var b = (arguments[1] !== void 0 ? arguments[1] : a);\n      return b === 5;\n}(5));\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="default_function_parameters">
@@ -414,30 +414,30 @@ test(function(){try{return Function("/* Error during compilation: This test's co
 
         <tr class="subtest" data-parent="default_function_parameters">
           <td><span>separate scope</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function() {
-  var a = (arguments[0] !== void 0 ? arguments[0] : function(){
+  var a = (arguments[0] !== void 0 ? arguments[0] : function() {
     return typeof b === 'undefined';
   });
 
   var b = 1;
   return a();
 }());
-      })">
-test(function(){try{return eval("(function(){\nreturn (function() {\n  var a = (arguments[0] !== void 0 ? arguments[0] : function(){\n    return typeof b === 'undefined';\n  });\n\n  var b = 1;\n  return a();\n}());\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function() {\n  var a = (arguments[0] !== void 0 ? arguments[0] : function() {\n    return typeof b === 'undefined';\n  });\n\n  var b = 1;\n  return a();\n}());\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (function() {
   var $__arguments = arguments;
   var args = [].slice.call($__arguments, 0);
   return typeof args !== &quot;undefined&quot;;
 }())
-  })">
-test(function(){try{return eval("(function(){\nreturn (function() {\n  var $__arguments = arguments;\n  var args = [].slice.call($__arguments, 0);\n  return typeof args !== \"undefined\";\n}())\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nreturn (function() {\n  var $__arguments = arguments;\n  var args = [].slice.call($__arguments, 0);\n  return typeof args !== \"undefined\";\n}())\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -487,11 +487,11 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
       var $__0;
       return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator([1, 2, 3]))) === 3;
-});">
-test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\n      var $__0;\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator([1, 2, 3]))) === 3;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\n      var $__0;\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator([1, 2, 3]))) === 3;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
@@ -537,10 +537,10 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 return $__accumulateIteratorValues($__getIterator([1, 2, 3]))[2] === 3;
-      });">
-test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nreturn $__accumulateIteratorValues($__getIterator([1, 2, 3]))[2] === 3;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nreturn $__accumulateIteratorValues($__getIterator([1, 2, 3]))[2] === 3;\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
@@ -586,11 +586,11 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
       var $__0;
       return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(&quot;1234&quot;))) === 4;
-});">
-test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\n      var $__0;\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(\"1234\"))) === 4;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\n      var $__0;\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(\"1234\"))) === 4;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
@@ -642,12 +642,12 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
       var $__0;
       var iterable = __createIterableObject(1, 2, 3);
       return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(iterable))) === 3;
-});">
-test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\n      var $__0;\n      var iterable = __createIterableObject(1, 2, 3);\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(iterable))) === 3;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\n      var $__0;\n      var iterable = __createIterableObject(1, 2, 3);\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(iterable))) === 3;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
@@ -699,12 +699,12 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
       var $__0;
       var iterable = __createIterableObject(1, 2, 3);
       return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(Object.create(iterable)))) === 3;
-});">
-test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\n      var $__0;\n      var iterable = __createIterableObject(1, 2, 3);\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(Object.create(iterable)))) === 3;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__accumulateIteratorValues = function(iterator) {\n      var result = [];\n\n      for (var item; !(item = iterator.next()).done; )\n            result.push(item.value);\n\n      return result;\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\n      var $__0;\n      var iterable = __createIterableObject(1, 2, 3);\n      return ($__0 = Math).max.apply($__0, $__accumulateIteratorValues($__getIterator(Object.create(iterable)))) === 3;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="spread_(...)_operator">
@@ -719,7 +719,7 @@ test(function(){try{return Function("/* Error during compilation: Line 3: Spread
 
         <tr class="subtest" data-parent="class">
           <td><span>class statement</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
       var C = function() {
             &quot;use strict&quot;;
             function C() {}
@@ -727,13 +727,13 @@ test(function(){try{return Function("/* Error during compilation: Line 3: Spread
       }();
 
       return typeof C === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\n      var C = function() {\n            \"use strict\";\n            function C() {}\n            return C;\n      }();\n\n      return typeof C === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n      var C = function() {\n            \"use strict\";\n            function C() {}\n            return C;\n      }();\n\n      return typeof C === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>is block-scoped</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var C = function() {
     &quot;use strict&quot;;
     function C() {}
@@ -748,25 +748,25 @@ test(function(){try{return eval("(function(){\n      var C = function() {\n     
     }();
   }
   return typeof C === &quot;function&quot; && typeof D === &quot;undefined&quot;;
-})">
-test(function(){try{return eval("(function(){\n  var C = function() {\n    \"use strict\";\n    function C() {}\n    return C;\n  }();\n\n  {\n    var D = function() {\n      \"use strict\";\n      function D() {}\n      return D;\n    }();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var C = function() {\n    \"use strict\";\n    function C() {}\n    return C;\n  }();\n\n  {\n    var D = function() {\n      \"use strict\";\n      function D() {}\n      return D;\n    }();\n  }\n  return typeof C === \"function\" && typeof D === \"undefined\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>class expression</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof function() {
       &quot;use strict&quot;;
       function C() {}
       return C;
 }() === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof function() {\n      \"use strict\";\n      function C() {}\n      return C;\n}() === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof function() {\n      \"use strict\";\n      function C() {}\n      return C;\n}() === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>constructor</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var C = function() {
     &quot;use strict&quot;;
     function C() { this.x = 1; }
@@ -775,14 +775,14 @@ test(function(){try{return eval("(function(){\nreturn typeof function() {\n     
 
   return C.prototype.constructor === C
     && new C().x === 1;
-})">
-test(function(){try{return eval("(function(){\n  var C = function() {\n    \"use strict\";\n    function C() { this.x = 1; }\n    return C;\n  }();\n\n  return C.prototype.constructor === C\n    && new C().x === 1;\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var C = function() {\n    \"use strict\";\n    function C() { this.x = 1; }\n    return C;\n  }();\n\n  return C.prototype.constructor === C\n    && new C().x === 1;\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>prototype methods</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
   var C = function() {
     &quot;use strict&quot;;
     function C() {}
@@ -800,14 +800,14 @@ test(function(){try{return eval("(function(){\n  var C = function() {\n    \"use
 
   return typeof C.prototype.method === &quot;function&quot;
     && new C().method() === 2;
-});">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\n  var C = function() {\n    \"use strict\";\n    function C() {}\n\n    $__Object$defineProperties(C.prototype, {\n      method: {\n        value: function() { return 2; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return C;\n  }();\n\n  return typeof C.prototype.method === \"function\"\n    && new C().method() === 2;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\n  var C = function() {\n    \"use strict\";\n    function C() {}\n\n    $__Object$defineProperties(C.prototype, {\n      method: {\n        value: function() { return 2; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return C;\n  }();\n\n  return typeof C.prototype.method === \"function\"\n    && new C().method() === 2;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>static methods</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
   var C = function() {
     &quot;use strict&quot;;
     function C() {}
@@ -825,14 +825,14 @@ test(function(){try{return eval("var $__Object$defineProperties = Object.defineP
 
   return typeof C.method === &quot;function&quot;
     && C.method() === 3;
-});">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\n  var C = function() {\n    \"use strict\";\n    function C() {}\n\n    $__Object$defineProperties(C, {\n      method: {\n        value: function() { return 3; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return C;\n  }();\n\n  return typeof C.method === \"function\"\n    && C.method() === 3;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\n  var C = function() {\n    \"use strict\";\n    function C() {}\n\n    $__Object$defineProperties(C, {\n      method: {\n        value: function() { return 3; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return C;\n  }();\n\n  return typeof C.method === \"function\"\n    && C.method() === 3;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
           <td><span>implicit strict mode</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
 var c = function() {
   &quot;use strict&quot;;
   function C() {}
@@ -849,8 +849,8 @@ var c = function() {
 }().method;
 
 return c();
-      });">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\nvar c = function() {\n  \"use strict\";\n  function C() {}\n\n  $__Object$defineProperties(C, {\n    method: {\n      value: function() { return this === undefined; },\n      enumerable: false,\n      writable: true\n    }\n  });\n\n  return C;\n}().method;\n\nreturn c();\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\nvar c = function() {\n  \"use strict\";\n  function C() {}\n\n  $__Object$defineProperties(C, {\n    method: {\n      value: function() { return this === undefined; },\n      enumerable: false,\n      writable: true\n    }\n  });\n\n  return C;\n}().method;\n\nreturn c();\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="class">
@@ -858,7 +858,7 @@ test(function(){try{return eval("var $__Object$defineProperties = Object.defineP
 <script data-source="var $__Object$defineProperty = Object.defineProperty;
 var $__Object$create = Object.create;
 var $__Object$getPrototypeOf = Object.getPrototypeOf;
-(function(){
+((function() {
   var C = function($__super) {
     &quot;use strict&quot;;
 
@@ -882,8 +882,8 @@ var $__Object$getPrototypeOf = Object.getPrototypeOf;
 
   return Array.isPrototypeOf(C)
     && Array.prototype.isPrototypeOf(C.prototype);
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n(function(){\n  var C = function($__super) {\n    \"use strict\";\n\n    function C() {\n      var $__arguments = arguments;\n      var $__0 = $__Object$getPrototypeOf(C.prototype);\n\n      if ($__0 !== null)\n        $__0.constructor.apply(this, $__arguments);\n    }\n\n    C.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    C.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(C.prototype, \"constructor\", {\n      value: C\n    });\n\n    return C;\n  }(Array);\n\n  return Array.isPrototypeOf(C)\n    && Array.prototype.isPrototypeOf(C.prototype);\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n((function() {\n  var C = function($__super) {\n    \"use strict\";\n\n    function C() {\n      var $__arguments = arguments;\n      var $__0 = $__Object$getPrototypeOf(C.prototype);\n\n      if ($__0 !== null)\n        $__0.constructor.apply(this, $__arguments);\n    }\n\n    C.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    C.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(C.prototype, \"constructor\", {\n      value: C\n    });\n\n    return C;\n  }(Array);\n\n  return Array.isPrototypeOf(C)\n    && Array.prototype.isPrototypeOf(C.prototype);\n}));")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -895,7 +895,7 @@ test(function(){try{return eval("var $__Object$defineProperty = Object.definePro
 <script data-source="var $__Object$defineProperty = Object.defineProperty;
 var $__Object$create = Object.create;
 var $__Object$getPrototypeOf = Object.getPrototypeOf;
-(function(){
+((function() {
   var B = function($__super) {
     &quot;use strict&quot;;
     function B(a) { return $__Object$getPrototypeOf(B.prototype).constructor.call(this, &quot;bar&quot; + a); }
@@ -914,8 +914,8 @@ var $__Object$getPrototypeOf = Object.getPrototypeOf;
   }());
 
   return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n(function(){\n  var B = function($__super) {\n    \"use strict\";\n    function B(a) { return $__Object$getPrototypeOf(B.prototype).constructor.call(this, \"bar\" + a); }\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0(a) { return [\"foo\" + a]; }\n    return $__0;\n  }());\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n((function() {\n  var B = function($__super) {\n    \"use strict\";\n    function B(a) { return $__Object$getPrototypeOf(B.prototype).constructor.call(this, \"bar\" + a); }\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0(a) { return [\"foo\" + a]; }\n    return $__0;\n  }());\n\n  return new B(\"baz\")[0] === \"foobarbaz\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -949,7 +949,7 @@ var $__get = function get(object, property, receiver) {
 };
 
 var $__Object$getPrototypeOf = Object.getPrototypeOf;
-(function(){
+((function() {
   var B = function($__super) {
     &quot;use strict&quot;;
 
@@ -993,8 +993,8 @@ var $__Object$getPrototypeOf = Object.getPrototypeOf;
   }());
 
   return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$defineProperties = Object.defineProperties;\n\nvar $__get = function get(object, property, receiver) {\n  var desc = Object.getOwnPropertyDescriptor(object, property);\n\n  if (desc === void 0) {\n    var parent = Object.getPrototypeOf(object);\n\n    if (parent === null) {\n      return void 0;\n    } else {\n      return get(parent, property, receiver);\n    }\n  } else if (\"value\" in desc && \"writable\" in desc) {\n    return desc.value;\n  } else {\n    var getter = desc.get;\n\n    if (getter === void 0) {\n      return void 0;\n    }\n\n    return getter.call(receiver);\n  }\n};\n\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n(function(){\n  var B = function($__super) {\n    \"use strict\";\n\n    function B() {\n      var $__arguments = arguments;\n      var $__1 = $__Object$getPrototypeOf(B.prototype);\n\n      if ($__1 !== null)\n        $__1.constructor.apply(this, $__arguments);\n    }\n\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    $__Object$defineProperties(B.prototype, {\n      qux: {\n        value: function(a) { return $__get($__Object$getPrototypeOf(B.prototype), \"qux\", this).call(this, \"bar\" + a); },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0() {}\n\n    $__Object$defineProperties($__0.prototype, {\n      qux: {\n        value: function(a) { return \"foo\" + a; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return $__0;\n  }());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$defineProperties = Object.defineProperties;\n\nvar $__get = function get(object, property, receiver) {\n  var desc = Object.getOwnPropertyDescriptor(object, property);\n\n  if (desc === void 0) {\n    var parent = Object.getPrototypeOf(object);\n\n    if (parent === null) {\n      return void 0;\n    } else {\n      return get(parent, property, receiver);\n    }\n  } else if (\"value\" in desc && \"writable\" in desc) {\n    return desc.value;\n  } else {\n    var getter = desc.get;\n\n    if (getter === void 0) {\n      return void 0;\n    }\n\n    return getter.call(receiver);\n  }\n};\n\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n((function() {\n  var B = function($__super) {\n    \"use strict\";\n\n    function B() {\n      var $__arguments = arguments;\n      var $__1 = $__Object$getPrototypeOf(B.prototype);\n\n      if ($__1 !== null)\n        $__1.constructor.apply(this, $__arguments);\n    }\n\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    $__Object$defineProperties(B.prototype, {\n      qux: {\n        value: function(a) { return $__get($__Object$getPrototypeOf(B.prototype), \"qux\", this).call(this, \"bar\" + a); },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0() {}\n\n    $__Object$defineProperties($__0.prototype, {\n      qux: {\n        value: function(a) { return \"foo\" + a; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return $__0;\n  }());\n\n  return new B().qux(\"baz\") === \"foobarbaz\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="super">
@@ -1028,7 +1028,7 @@ var $__get = function get(object, property, receiver) {
 };
 
 var $__Object$getPrototypeOf = Object.getPrototypeOf;
-(function(){
+((function() {
   var B = function($__super) {
     &quot;use strict&quot;;
 
@@ -1076,8 +1076,8 @@ var $__Object$getPrototypeOf = Object.getPrototypeOf;
     corge: &quot;ley&quot;
   };
   return obj.qux() === &quot;barley&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$defineProperties = Object.defineProperties;\n\nvar $__get = function get(object, property, receiver) {\n  var desc = Object.getOwnPropertyDescriptor(object, property);\n\n  if (desc === void 0) {\n    var parent = Object.getPrototypeOf(object);\n\n    if (parent === null) {\n      return void 0;\n    } else {\n      return get(parent, property, receiver);\n    }\n  } else if (\"value\" in desc && \"writable\" in desc) {\n    return desc.value;\n  } else {\n    var getter = desc.get;\n\n    if (getter === void 0) {\n      return void 0;\n    }\n\n    return getter.call(receiver);\n  }\n};\n\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n(function(){\n  var B = function($__super) {\n    \"use strict\";\n\n    function B() {\n      var $__arguments = arguments;\n      var $__1 = $__Object$getPrototypeOf(B.prototype);\n\n      if ($__1 !== null)\n        $__1.constructor.apply(this, $__arguments);\n    }\n\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    $__Object$defineProperties(B.prototype, {\n      qux: {\n        value: function() { return $__get($__Object$getPrototypeOf(B.prototype), \"qux\", this).call(this) + this.corge; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0() {}\n\n    $__Object$defineProperties($__0.prototype, {\n      qux: {\n        value: function() { return \"bar\"; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return $__0;\n  }());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\nvar $__Object$create = Object.create;\nvar $__Object$defineProperties = Object.defineProperties;\n\nvar $__get = function get(object, property, receiver) {\n  var desc = Object.getOwnPropertyDescriptor(object, property);\n\n  if (desc === void 0) {\n    var parent = Object.getPrototypeOf(object);\n\n    if (parent === null) {\n      return void 0;\n    } else {\n      return get(parent, property, receiver);\n    }\n  } else if (\"value\" in desc && \"writable\" in desc) {\n    return desc.value;\n  } else {\n    var getter = desc.get;\n\n    if (getter === void 0) {\n      return void 0;\n    }\n\n    return getter.call(receiver);\n  }\n};\n\nvar $__Object$getPrototypeOf = Object.getPrototypeOf;\n((function() {\n  var B = function($__super) {\n    \"use strict\";\n\n    function B() {\n      var $__arguments = arguments;\n      var $__1 = $__Object$getPrototypeOf(B.prototype);\n\n      if ($__1 !== null)\n        $__1.constructor.apply(this, $__arguments);\n    }\n\n    B.__proto__ = ($__super !== null ? $__super : Function.prototype);\n    B.prototype = $__Object$create(($__super !== null ? $__super.prototype : null));\n\n    $__Object$defineProperty(B.prototype, \"constructor\", {\n      value: B\n    });\n\n    $__Object$defineProperties(B.prototype, {\n      qux: {\n        value: function() { return $__get($__Object$getPrototypeOf(B.prototype), \"qux\", this).call(this) + this.corge; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return B;\n  }(function() {\n    \"use strict\";\n    function $__0() {}\n\n    $__Object$defineProperties($__0.prototype, {\n      qux: {\n        value: function() { return \"bar\"; },\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return $__0;\n  }());\n\n  var obj = {\n    qux: B.prototype.qux,\n    corge: \"ley\"\n  };\n  return obj.qux() === \"barley\";\n}));")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1087,7 +1087,7 @@ test(function(){try{return eval("var $__Object$defineProperty = Object.definePro
         <tr class="subtest" data-parent="object_literal_extensions">
           <td><span>computed properties</span></td>
 <script data-source="var $__Object$defineProperty = Object.defineProperty;
-(function(){
+((function() {
       var $__0;
       var x = 'y';
       return (($__0 = {}, $__Object$defineProperty($__0, x, {
@@ -1096,25 +1096,25 @@ test(function(){try{return eval("var $__Object$defineProperty = Object.definePro
             configurable: true,
             writable: true
       }), $__0)).y === 1;
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n(function(){\n      var $__0;\n      var x = 'y';\n      return (($__0 = {}, $__Object$defineProperty($__0, x, {\n            value: 1,\n            enumerable: true,\n            configurable: true,\n            writable: true\n      }), $__0)).y === 1;\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n((function() {\n      var $__0;\n      var x = 'y';\n      return (($__0 = {}, $__Object$defineProperty($__0, x, {\n            value: 1,\n            enumerable: true,\n            configurable: true,\n            writable: true\n      }), $__0)).y === 1;\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="object_literal_extensions">
           <td><span>shorthand properties</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = 7, b = 8, c = {a: a,b: b};
 return c.a === 7 && c.b === 8;
-      })">
-test(function(){try{return eval("(function(){\nvar a = 7, b = 8, c = {a: a,b: b};\nreturn c.a === 7 && c.b === 8;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = 7, b = 8, c = {a: a,b: b};\nreturn c.a === 7 && c.b === 8;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="object_literal_extensions">
           <td><span>shorthand methods</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return ({ y: function y() { return 2; } }).y() === 2;
-      })">
-test(function(){try{return eval("(function(){\nreturn ({ y: function y() { return 2; } }).y() === 2;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn ({ y: function y() { return 2; } }).y() === 2;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1123,20 +1123,20 @@ test(function(){try{return eval("(function(){\nreturn ({ y: function y() { retur
 
         <tr class="subtest" data-parent="for..of_loops">
           <td><span>with arrays</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var arr = [5];
 
   for (var item, t$1$0 = regeneratorRuntime.values(arr), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {
     item = t$1$1.value;
     return item === 5;
   }
-})">
-test(function(){try{return eval("(function(){\n  var arr = [5];\n\n  for (var item, t$1$0 = regeneratorRuntime.values(arr), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    return item === 5;\n  }\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var arr = [5];\n\n  for (var item, t$1$0 = regeneratorRuntime.values(arr), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    return item === 5;\n  }\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="for..of_loops">
           <td><span>with strings</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var str = &quot;&quot;;
 
   for (var item, t$1$0 = regeneratorRuntime.values(&quot;foo&quot;), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {
@@ -1145,13 +1145,13 @@ test(function(){try{return eval("(function(){\n  var arr = [5];\n\n  for (var it
   }
 
   return str === &quot;foo&quot;;
-})">
-test(function(){try{return eval("(function(){\n  var str = \"\";\n\n  for (var item, t$1$0 = regeneratorRuntime.values(\"foo\"), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    str += item;\n  }\n\n  return str === \"foo\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var str = \"\";\n\n  for (var item, t$1$0 = regeneratorRuntime.values(\"foo\"), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    str += item;\n  }\n\n  return str === \"foo\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="for..of_loops">
           <td><span>with generic iterables</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var result = &quot;&quot;;
   var iterable = __createIterableObject(1, 2, 3);
 
@@ -1161,13 +1161,13 @@ test(function(){try{return eval("(function(){\n  var str = \"\";\n\n  for (var i
   }
 
   return result === &quot;123&quot;;
-})">
-test(function(){try{return eval("(function(){\n  var result = \"\";\n  var iterable = __createIterableObject(1, 2, 3);\n\n  for (var item, t$1$0 = regeneratorRuntime.values(iterable), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    result += item;\n  }\n\n  return result === \"123\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var result = \"\";\n  var iterable = __createIterableObject(1, 2, 3);\n\n  for (var item, t$1$0 = regeneratorRuntime.values(iterable), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    result += item;\n  }\n\n  return result === \"123\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="for..of_loops">
           <td><span>with instances of generic iterables</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var result = &quot;&quot;;
   var iterable = __createIterableObject(1, 2, 3);
 
@@ -1177,8 +1177,8 @@ test(function(){try{return eval("(function(){\n  var result = \"\";\n  var itera
   }
 
   return result === &quot;123&quot;;
-})">
-test(function(){try{return eval("(function(){\n  var result = \"\";\n  var iterable = __createIterableObject(1, 2, 3);\n\n  for (var item, t$1$0 = regeneratorRuntime.values(Object.create(iterable)), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    result += item;\n  }\n\n  return result === \"123\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var result = \"\";\n  var iterable = __createIterableObject(1, 2, 3);\n\n  for (var item, t$1$0 = regeneratorRuntime.values(Object.create(iterable)), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    item = t$1$1.value;\n    result += item;\n  }\n\n  return result === \"123\";\n}))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1187,7 +1187,7 @@ test(function(){try{return eval("(function(){\n  var result = \"\";\n  var itera
 
         <tr class="subtest" data-parent="generators">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var generator = regeneratorRuntime.mark(function generator() {
     return regeneratorRuntime.wrap(function generator$(context$2$0) {
       while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -1212,13 +1212,13 @@ test(function(){try{return eval("(function(){\n  var result = \"\";\n  var itera
   item = iterator.next();
   passed    &= item.value === undefined && item.done === true;
   return passed;
-})">
-test(function(){try{return eval("(function(){\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (1) switch (context$2$0.prev = context$2$0.next) {\n      case 0:\n        context$2$0.next = 2;\n        return 5;\n      case 2:\n        context$2$0.next = 4;\n        return 6;\n      case 4:\n      case \"end\":\n        return context$2$0.stop();\n      }\n    }, generator, this);\n  });\n\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed    &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed    &= item.value === undefined && item.done === true;\n  return passed;\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var generator = regeneratorRuntime.mark(function generator() {\n    return regeneratorRuntime.wrap(function generator$(context$2$0) {\n      while (1) switch (context$2$0.prev = context$2$0.next) {\n      case 0:\n        context$2$0.next = 2;\n        return 5;\n      case 2:\n        context$2$0.next = 4;\n        return 6;\n      case 4:\n      case \"end\":\n        return context$2$0.stop();\n      }\n    }, generator, this);\n  });\n\n  var iterator = generator();\n  var item = iterator.next();\n  var passed = item.value === 5 && item.done === false;\n  item = iterator.next();\n  passed    &= item.value === 6 && item.done === false;\n  item = iterator.next();\n  passed    &= item.value === undefined && item.done === true;\n  return passed;\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, arrays</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -1237,13 +1237,13 @@ passed    &= item.value === 6 && item.done === false;
 item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield([5, 6], \"t0\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield([5, 6], \"t0\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, strings</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -1262,13 +1262,13 @@ passed    &= item.value === &quot;6&quot; && item.done === false;
 item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(\"56\", \"t1\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(\"56\", \"t1\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, generic iterables</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -1289,13 +1289,13 @@ passed    &= item.value === 7 && item.done === false;
 item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(__createIterableObject(5, 6, 7), \"t2\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>yield *, instances of iterables</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var iterator = (regeneratorRuntime.mark(function generator() {
   return regeneratorRuntime.wrap(function generator$(context$2$0) {
     while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -1316,14 +1316,14 @@ passed    &= item.value === 7 && item.done === false;
 item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar iterator = (regeneratorRuntime.mark(function generator() {\n  return regeneratorRuntime.wrap(function generator$(context$2$0) {\n    while (1) switch (context$2$0.prev = context$2$0.next) {\n    case 0:\n      return context$2$0.delegateYield(Object.create(__createIterableObject(5, 6, 7)), \"t3\", 1);\n    case 1:\n    case \"end\":\n      return context$2$0.stop();\n    }\n  }, generator, this);\n})());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="generators">
           <td><span>shorthand generator methods</span></td>
-<script data-source="/* Error during compilation: {callee: [object Object], arguments: [object Object], type: CallExpression, loc: null} does not match type FunctionExpression*/">
-test(function(){try{return Function("/* Error during compilation: {callee: [object Object], arguments: [object Object], type: CallExpression, loc: null} does not match type FunctionExpression*/")()}catch(e){return false;}}());
+<script data-source="/* Error during compilation: {callee: [object Object], arguments: [object Object], loc: null, type: CallExpression} does not match type FunctionExpression*/">
+test(function(){try{return Function("/* Error during compilation: {callee: [object Object], arguments: [object Object], loc: null, type: CallExpression} does not match type FunctionExpression*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1332,34 +1332,34 @@ test(function(){try{return Function("/* Error during compilation: {callee: [obje
 
         <tr class="subtest" data-parent="octal_and_binary_literals">
           <td><span>octal literals</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return 0o10 === 8 && 0O10 === 8;
-      })">
-test(function(){try{return eval("(function(){\nreturn 0o10 === 8 && 0O10 === 8;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn 0o10 === 8 && 0O10 === 8;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="octal_and_binary_literals">
           <td><span>binary literals</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return 0b10 === 2 && 0B10 === 2;
-      })">
-test(function(){try{return eval("(function(){\nreturn 0b10 === 2 && 0B10 === 2;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn 0b10 === 2 && 0B10 === 2;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="octal_and_binary_literals">
           <td><span>octal supported by Number()</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Number('0o1') === 1;
-      })">
-test(function(){try{return eval("(function(){\nreturn Number('0o1') === 1;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Number('0o1') === 1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="octal_and_binary_literals">
           <td><span>binary supported by Number()</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Number('0b1') === 1;
-      })">
-test(function(){try{return eval("(function(){\nreturn Number('0b1') === 1;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Number('0b1') === 1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1368,16 +1368,16 @@ test(function(){try{return eval("(function(){\nreturn Number('0b1') === 1;\n    
 
         <tr class="subtest" data-parent="template_strings">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = &quot;ba&quot;, b = &quot;QUX&quot;;
 return &quot;foo bar\n&quot; + (a + &quot;z&quot;) + &quot; &quot; + b.toLowerCase() + &quot;&quot; === &quot;foo bar\nbaz qux&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar a = \"ba\", b = \"QUX\";\nreturn \"foo bar\\n\" + (a + \"z\") + \" \" + b.toLowerCase() + \"\" === \"foo bar\\nbaz qux\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = \"ba\", b = \"QUX\";\nreturn \"foo bar\\n\" + (a + \"z\") + \" \" + b.toLowerCase() + \"\" === \"foo bar\\nbaz qux\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="template_strings">
           <td><span>tagged template strings</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var called = false;
 function fn(parts, a, b) {
   called = true;
@@ -1394,8 +1394,8 @@ return fn(function() {
   strings.raw = [&quot;foo&quot;, &quot;bar\\n&quot;, &quot;&quot;];
   return strings;
 }(), 123, 456) && called;
-      })">
-test(function(){try{return eval("(function(){\nvar called = false;\nfunction fn(parts, a, b) {\n  called = true;\n  return parts instanceof Array &&\n    parts[0]     === \"foo\"      &&\n    parts[1]     === \"bar\\n\"    &&\n    parts.raw[0] === \"foo\"      &&\n    parts.raw[1] === \"bar\\\\n\"   &&\n    a === 123                   &&\n    b === 456;\n}\nreturn fn(function() {\n  var strings = [\"foo\", \"bar\\n\", \"\"];\n  strings.raw = [\"foo\", \"bar\\\\n\", \"\"];\n  return strings;\n}(), 123, 456) && called;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar called = false;\nfunction fn(parts, a, b) {\n  called = true;\n  return parts instanceof Array &&\n    parts[0]     === \"foo\"      &&\n    parts[1]     === \"bar\\n\"    &&\n    parts.raw[0] === \"foo\"      &&\n    parts.raw[1] === \"bar\\\\n\"   &&\n    a === 123                   &&\n    b === 456;\n}\nreturn fn(function() {\n  var strings = [\"foo\", \"bar\\n\", \"\"];\n  strings.raw = [\"foo\", \"bar\\\\n\", \"\"];\n  return strings;\n}(), 123, 456) && called;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1404,22 +1404,22 @@ test(function(){try{return eval("(function(){\nvar called = false;\nfunction fn(
 
         <tr class="subtest" data-parent="RegExp_y_and_u_flags">
           <td><span>"y" flag</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var re = new RegExp('\\w');
 var re2 = new RegExp('\\w', 'y');
 re.exec('xy');
 re2.exec('xy');
 return (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');
-      })">
-test(function(){try{return eval("(function(){\nvar re = new RegExp('\\\\w');\nvar re2 = new RegExp('\\\\w', 'y');\nre.exec('xy');\nre2.exec('xy');\nreturn (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar re = new RegExp('\\\\w');\nvar re2 = new RegExp('\\\\w', 'y');\nre.exec('xy');\nre2.exec('xy');\nreturn (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp_y_and_u_flags">
           <td><span>"u" flag</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return &quot;𠮷&quot;.match(/(?:[\0-\t\x0B\f\x0E-\u2027\u202A-\uD7FF\uDC00-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF])/)[0].length === 2;
-      })">
-test(function(){try{return eval("(function(){\nreturn \"𠮷\".match(/(?:[\\0-\\t\\x0B\\f\\x0E-\\u2027\\u202A-\\uD7FF\\uDC00-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF])/)[0].length === 2;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn \"𠮷\".match(/(?:[\\0-\\t\\x0B\\f\\x0E-\\u2027\\u202A-\\uD7FF\\uDC00-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF]|[\\uD800-\\uDBFF])/)[0].length === 2;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1428,185 +1428,185 @@ test(function(){try{return eval("(function(){\nreturn \"𠮷\".match(/(?:[\\0-\\
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Int8Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Int8Array(buffer);         view[0] = 0x80;
 return view[0] === -0x80;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Uint8Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Uint8Array(buffer);        view[0] = 0x100;
 return view[0] === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Uint8ClampedArray</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Uint8ClampedArray(buffer); view[0] = 0x100;
 return view[0] === 0xFF;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Int16Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Int16Array(buffer);        view[0] = 0x8000;
 return view[0] === -0x8000;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Uint16Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Uint16Array(buffer);       view[0] = 0x10000;
 return view[0] === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Int32Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Int32Array(buffer);        view[0] = 0x80000000;
 return view[0] === -0x80000000;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Uint32Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Uint32Array(buffer);       view[0] = 0x100000000;
 return view[0] === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Float32Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Float32Array(buffer);       view[0] = 0.1;
 return view[0] === 0.10000000149011612;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>Float64Array</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new Float64Array(buffer);       view[0] = 0.1;
 return view[0] === 0.1;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Int8)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt8 (0, 0x80);
 return view.getInt8(0) === -0x80;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Uint8)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Int16)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Uint16)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Int32)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Uint32)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Float32)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>DataView (Float64)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
-      })">
-test(function(){try{return eval("(function(){\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.from</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.from === &quot;function&quot; &&
   typeof Uint8Array.from === &quot;function&quot; &&
   typeof Uint8ClampedArray.from === &quot;function&quot; &&
@@ -1616,13 +1616,13 @@ return typeof Int8Array.from === &quot;function&quot; &&
   typeof Uint32Array.from === &quot;function&quot; &&
   typeof Float32Array.from === &quot;function&quot; &&
   typeof Float64Array.from === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.of</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.of === &quot;function&quot; &&
   typeof Uint8Array.of === &quot;function&quot; &&
   typeof Uint8ClampedArray.of === &quot;function&quot; &&
@@ -1632,13 +1632,13 @@ return typeof Int8Array.of === &quot;function&quot; &&
   typeof Uint32Array.of === &quot;function&quot; &&
   typeof Float32Array.of === &quot;function&quot; &&
   typeof Float64Array.of === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.subarray</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.subarray === &quot;function&quot; &&
   typeof Uint8Array.prototype.subarray === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.subarray === &quot;function&quot; &&
@@ -1648,13 +1648,13 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &&
   typeof Uint32Array.prototype.subarray === &quot;function&quot; &&
   typeof Float32Array.prototype.subarray === &quot;function&quot; &&
   typeof Float64Array.prototype.subarray === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.join</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.join === &quot;function&quot; &&
   typeof Uint8Array.prototype.join === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.join === &quot;function&quot; &&
@@ -1664,13 +1664,13 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &&
   typeof Uint32Array.prototype.join === &quot;function&quot; &&
   typeof Float32Array.prototype.join === &quot;function&quot; &&
   typeof Float64Array.prototype.join === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.indexOf</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.indexOf === &quot;function&quot; &&
   typeof Uint8Array.prototype.indexOf === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.indexOf === &quot;function&quot; &&
@@ -1680,13 +1680,13 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &&
   typeof Uint32Array.prototype.indexOf === &quot;function&quot; &&
   typeof Float32Array.prototype.indexOf === &quot;function&quot; &&
   typeof Float64Array.prototype.indexOf === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.lastIndexOf</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &&
   typeof Uint8Array.prototype.lastIndexOf === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.lastIndexOf === &quot;function&quot; &&
@@ -1696,13 +1696,13 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &&
   typeof Uint32Array.prototype.lastIndexOf === &quot;function&quot; &&
   typeof Float32Array.prototype.lastIndexOf === &quot;function&quot; &&
   typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.slice</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.slice === &quot;function&quot; &&
   typeof Uint8Array.prototype.slice === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.slice === &quot;function&quot; &&
@@ -1712,13 +1712,13 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &&
   typeof Uint32Array.prototype.slice === &quot;function&quot; &&
   typeof Float32Array.prototype.slice === &quot;function&quot; &&
   typeof Float64Array.prototype.slice === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.every</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.every === &quot;function&quot; &&
   typeof Uint8Array.prototype.every === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.every === &quot;function&quot; &&
@@ -1728,13 +1728,13 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &&
   typeof Uint32Array.prototype.every === &quot;function&quot; &&
   typeof Float32Array.prototype.every === &quot;function&quot; &&
   typeof Float64Array.prototype.every === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.filter</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.filter === &quot;function&quot; &&
   typeof Uint8Array.prototype.filter === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.filter === &quot;function&quot; &&
@@ -1744,13 +1744,13 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &&
   typeof Uint32Array.prototype.filter === &quot;function&quot; &&
   typeof Float32Array.prototype.filter === &quot;function&quot; &&
   typeof Float64Array.prototype.filter === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.forEach</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.forEach === &quot;function&quot; &&
   typeof Uint8Array.prototype.forEach === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.forEach === &quot;function&quot; &&
@@ -1760,13 +1760,13 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &&
   typeof Uint32Array.prototype.forEach === &quot;function&quot; &&
   typeof Float32Array.prototype.forEach === &quot;function&quot; &&
   typeof Float64Array.prototype.forEach === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.map</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.map === &quot;function&quot; &&
   typeof Uint8Array.prototype.map === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.map === &quot;function&quot; &&
@@ -1776,13 +1776,13 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &&
   typeof Uint32Array.prototype.map === &quot;function&quot; &&
   typeof Float32Array.prototype.map === &quot;function&quot; &&
   typeof Float64Array.prototype.map === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.reduce</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.reduce === &quot;function&quot; &&
   typeof Uint8Array.prototype.reduce === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.reduce === &quot;function&quot; &&
@@ -1792,13 +1792,13 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &&
   typeof Uint32Array.prototype.reduce === &quot;function&quot; &&
   typeof Float32Array.prototype.reduce === &quot;function&quot; &&
   typeof Float64Array.prototype.reduce === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.reduceRight</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &&
   typeof Uint8Array.prototype.reduceRight === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.reduceRight === &quot;function&quot; &&
@@ -1808,13 +1808,13 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &&
   typeof Uint32Array.prototype.reduceRight === &quot;function&quot; &&
   typeof Float32Array.prototype.reduceRight === &quot;function&quot; &&
   typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.reverse</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.reverse === &quot;function&quot; &&
   typeof Uint8Array.prototype.reverse === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.reverse === &quot;function&quot; &&
@@ -1824,13 +1824,13 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &&
   typeof Uint32Array.prototype.reverse === &quot;function&quot; &&
   typeof Float32Array.prototype.reverse === &quot;function&quot; &&
   typeof Float64Array.prototype.reverse === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.some</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.some === &quot;function&quot; &&
   typeof Uint8Array.prototype.some === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.some === &quot;function&quot; &&
@@ -1840,13 +1840,13 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &&
   typeof Uint32Array.prototype.some === &quot;function&quot; &&
   typeof Float32Array.prototype.some === &quot;function&quot; &&
   typeof Float64Array.prototype.some === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.sort</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.sort === &quot;function&quot; &&
   typeof Uint8Array.prototype.sort === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.sort === &quot;function&quot; &&
@@ -1856,13 +1856,13 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &&
   typeof Uint32Array.prototype.sort === &quot;function&quot; &&
   typeof Float32Array.prototype.sort === &quot;function&quot; &&
   typeof Float64Array.prototype.sort === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.copyWithin</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &&
   typeof Uint8Array.prototype.copyWithin === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.copyWithin === &quot;function&quot; &&
@@ -1872,13 +1872,13 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &&
   typeof Uint32Array.prototype.copyWithin === &quot;function&quot; &&
   typeof Float32Array.prototype.copyWithin === &quot;function&quot; &&
   typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.find</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.find === &quot;function&quot; &&
   typeof Uint8Array.prototype.find === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.find === &quot;function&quot; &&
@@ -1888,13 +1888,13 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &&
   typeof Uint32Array.prototype.find === &quot;function&quot; &&
   typeof Float32Array.prototype.find === &quot;function&quot; &&
   typeof Float64Array.prototype.find === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.findIndex</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.findIndex === &quot;function&quot; &&
   typeof Uint8Array.prototype.findIndex === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.findIndex === &quot;function&quot; &&
@@ -1904,13 +1904,13 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &&
   typeof Uint32Array.prototype.findIndex === &quot;function&quot; &&
   typeof Float32Array.prototype.findIndex === &quot;function&quot; &&
   typeof Float64Array.prototype.findIndex === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.fill</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.fill === &quot;function&quot; &&
   typeof Uint8Array.prototype.fill === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.fill === &quot;function&quot; &&
@@ -1920,13 +1920,13 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &&
   typeof Uint32Array.prototype.fill === &quot;function&quot; &&
   typeof Float32Array.prototype.fill === &quot;function&quot; &&
   typeof Float64Array.prototype.fill === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.keys</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.keys === &quot;function&quot; &&
   typeof Uint8Array.prototype.keys === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.keys === &quot;function&quot; &&
@@ -1936,13 +1936,13 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &&
   typeof Uint32Array.prototype.keys === &quot;function&quot; &&
   typeof Float32Array.prototype.keys === &quot;function&quot; &&
   typeof Float64Array.prototype.keys === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.values</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.values === &quot;function&quot; &&
   typeof Uint8Array.prototype.values === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.values === &quot;function&quot; &&
@@ -1952,13 +1952,13 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &&
   typeof Uint32Array.prototype.values === &quot;function&quot; &&
   typeof Float32Array.prototype.values === &quot;function&quot; &&
   typeof Float64Array.prototype.values === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="typed_arrays">
           <td><span>%TypedArray%.prototype.entries</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Int8Array.prototype.entries === &quot;function&quot; &&
   typeof Uint8Array.prototype.entries === &quot;function&quot; &&
   typeof Uint8ClampedArray.prototype.entries === &quot;function&quot; &&
@@ -1968,8 +1968,8 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &&
   typeof Uint32Array.prototype.entries === &quot;function&quot; &&
   typeof Float32Array.prototype.entries === &quot;function&quot; &&
   typeof Float64Array.prototype.entries === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -1978,112 +1978,112 @@ test(function(){try{return eval("(function(){\nreturn typeof Int8Array.prototype
 
         <tr class="subtest" data-parent="Map">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var key = {};
 var map = new Map();
 
 map.set(key, 123);
 
 return map.has(key) && map.get(key) === 123;
-      })">
-test(function(){try{return eval("(function(){\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>constructor arguments</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var key1 = {};
 var key2 = {};
 var map = new Map([[key1, 123], [key2, 456]]);
 
 return map.has(key1) && map.get(key1) === 123 &&
        map.has(key2) && map.get(key2) === 456;
-      })">
-test(function(){try{return eval("(function(){\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.set returns this</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var map = new Map();
 return map.set(0, 0) === map;
-      })">
-test(function(){try{return eval("(function(){\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>-0 key converts to +0</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var map = new Map();
 map.set(-0, &quot;foo&quot;);
 var k;
-map.forEach(function (value, key) {
+map.forEach(function(value, key) {
   k = 1 / key;
 });
 return k === Infinity && map.get(+0) == &quot;foo&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function(value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.size</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var key = {};
 var map = new Map();
 
 map.set(key, 123);
 
 return map.size === 1;
-      })">
-test(function(){try{return eval("(function(){\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.delete</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.delete === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.delete === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.clear</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.clear === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.forEach</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.forEach === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.forEach === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.forEach === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.keys</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.keys === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.keys === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.keys === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.values</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.values === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.values === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.values === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Map">
           <td><span>Map.prototype.entries</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Map.prototype.entries === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.entries === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Map.prototype.entries === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2092,7 +2092,7 @@ test(function(){try{return eval("(function(){\nreturn typeof Map.prototype.entri
 
         <tr class="subtest" data-parent="Set">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 var set = new Set();
 
@@ -2100,48 +2100,48 @@ set.add(123);
 set.add(123);
 
 return set.has(123);
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>constructor arguments</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj1 = {};
 var obj2 = {};
 var set = new Set([obj1, obj2]);
 
 return set.has(obj1) && set.has(obj2);
-      })">
-test(function(){try{return eval("(function(){\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.add returns this</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var set = new Set();
 return set.add(0) === set;
-      })">
-test(function(){try{return eval("(function(){\nvar set = new Set();\nreturn set.add(0) === set;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar set = new Set();\nreturn set.add(0) === set;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>-0 key converts to +0</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var set = new Set();
 set.add(-0);
 var k;
-set.forEach(function (value) {
+set.forEach(function(value) {
   k = 1 / value;
 });
 return k === Infinity && set.has(+0);
-      })">
-test(function(){try{return eval("(function(){\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function(value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.size</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 var set = new Set();
 
@@ -2150,56 +2150,56 @@ set.add(123);
 set.add(456);
 
 return set.size === 2;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.delete</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.delete === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.delete === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.clear</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.clear === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.forEach</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.forEach === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.forEach === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.forEach === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.keys</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.keys === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.keys === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.keys === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.values</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.values === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.values === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.values === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Set">
           <td><span>Set.prototype.entries</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Set.prototype.entries === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.entries === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Set.prototype.entries === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2208,54 +2208,46 @@ test(function(){try{return eval("(function(){\nreturn typeof Set.prototype.entri
 
         <tr class="subtest" data-parent="WeakMap">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var key = {};
 var weakmap = new WeakMap();
 
 weakmap.set(key, 123);
 
 return weakmap.has(key) && weakmap.get(key) === 123;
-      })">
-test(function(){try{return eval("(function(){\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakMap">
           <td><span>constructor arguments</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var key1 = {};
 var key2 = {};
 var weakmap = new WeakMap([[key1, 123], [key2, 456]]);
 
 return weakmap.has(key1) && weakmap.get(key1) === 123 &&
        weakmap.has(key2) && weakmap.get(key2) === 456;
-      })">
-test(function(){try{return eval("(function(){\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakMap">
           <td><span>WeakMap.prototype.set returns this</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var weakmap = new WeakMap();
 var key = {};
 return weakmap.set(key, 0) === weakmap;
-      })">
-test(function(){try{return eval("(function(){\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakMap">
           <td><span>WeakMap.prototype.delete</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof WeakMap.prototype.delete === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakMap.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="(function(){
-return typeof WeakMap.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakMap.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof WeakMap.prototype.delete === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2264,7 +2256,7 @@ test(function(){try{return eval("(function(){\nreturn typeof WeakMap.prototype.c
 
         <tr class="subtest" data-parent="WeakSet">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj1 = {}, obj2 = {};
 var weakset = new WeakSet();
 
@@ -2272,45 +2264,37 @@ weakset.add(obj1);
 weakset.add(obj1);
 
 return weakset.has(obj1);
-      })">
-test(function(){try{return eval("(function(){\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakSet">
           <td><span>constructor arguments</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj1 = {}, obj2 = {};
 var weakset = new WeakSet([obj1, obj2]);
 
 return weakset.has(obj1) && weakset.has(obj2);
-      })">
-test(function(){try{return eval("(function(){\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakSet">
           <td><span>WeakSet.prototype.add returns this</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var weakset = new WeakSet();
 var obj = {};
 return weakset.add(obj) === weakset;
-      })">
-test(function(){try{return eval("(function(){\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="WeakSet">
           <td><span>WeakSet.prototype.delete</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakSet.prototype.delete === \"function\";\n      })")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="(function(){
-return typeof WeakSet.prototype.clear === &quot;function&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof WeakSet.prototype.clear === \"function\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof WeakSet.prototype.delete === \"function\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2319,72 +2303,72 @@ test(function(){try{return eval("(function(){\nreturn typeof WeakSet.prototype.c
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"get" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = { };
 var proxy = new Proxy(proxied, {
-  get: function (t, k, r) {
+  get: function(t, k, r) {
     return t === proxied && k === &quot;foo&quot; && r === proxy && 5;
   }
 });
 return proxy.foo === 5;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function(t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"set" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = { };
 var passed = false;
 var proxy = new Proxy(proxied, {
-  set: function (t, k, v, r) {
+  set: function(t, k, v, r) {
     passed = t === proxied && k + v === &quot;foobar&quot; && r === proxy;
   }
 });
 proxy.foo = &quot;bar&quot;;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function(t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"has" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 &quot;foo&quot; in new Proxy(proxied, {
-  has: function (t, k) {
+  has: function(t, k) {
     passed = t === proxied && k === &quot;foo&quot;;
   }
 });
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function(t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"deleteProperty" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
   var passed = false;
   delete new Proxy(proxied, {
-    deleteProperty: function (t, k) {
+    deleteProperty: function(t, k) {
       passed = t === proxied && k === &quot;foo&quot;;
     }
   }).foo;
   return passed;
-})">
-test(function(){try{return eval("(function(){\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function(t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"getOwnPropertyDescriptor" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var fakeDesc = { value: &quot;foo&quot;, configurable: true };
 var returnedDesc = Object.getOwnPropertyDescriptor(
   new Proxy(proxied, {
-    getOwnPropertyDescriptor: function (t, k) {
+    getOwnPropertyDescriptor: function(t, k) {
       return t === proxied && k === &quot;foo&quot; && fakeDesc;
     }
   }),
@@ -2394,18 +2378,18 @@ return (returnedDesc.value     === fakeDesc.value
   && returnedDesc.configurable === fakeDesc.configurable
   && returnedDesc.writable     === false
   && returnedDesc.enumerable   === false);
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function(t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"defineProperty" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 Object.defineProperty(
   new Proxy(proxied, {
-    defineProperty: function (t, k, d) {
+    defineProperty: function(t, k, d) {
       passed = t === proxied && k === &quot;foo&quot; && d.value === 5;
       return true;
     }
@@ -2414,34 +2398,34 @@ Object.defineProperty(
   { value: 5, configurable: true }
 );
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function(t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"getPrototypeOf" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var fakeProto = {};
 var proxy = new Proxy(proxied, {
-  getPrototypeOf: function (t) {
+  getPrototypeOf: function(t) {
     return t === proxied && fakeProto;
   }
 });
 return Object.getPrototypeOf(proxy) === fakeProto;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function(t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"setPrototypeOf" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var newProto = {};
 var passed = false;
 Object.setPrototypeOf(
   new Proxy(proxied, {
-    setPrototypeOf: function (t, p) {
+    setPrototypeOf: function(t, p) {
       passed = t === proxied && p === newProto;
       return true;
     }
@@ -2449,119 +2433,119 @@ Object.setPrototypeOf(
   newProto
 );
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function(t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"isExtensible" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 Object.isExtensible(
   new Proxy(proxied, {
-    isExtensible: function (t) {
+    isExtensible: function(t) {
       passed = t === proxied; return true;
     }
   })
 );
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function(t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"preventExtensions" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 Object.preventExtensions(
   new Proxy(proxied, {
-    preventExtensions: function (t) {
+    preventExtensions: function(t) {
       passed = t === proxied;
       return Object.preventExtensions(proxied);
     }
   })
 );
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function(t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"enumerate" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 for (var i in
   new Proxy(proxied, {
-    enumerate: function (t) {
+    enumerate: function(t) {
       passed = t === proxied;
       return {
-        next: function(){ return { done: true, value: null };}
+        next: function() { return { done: true, value: null };}
       };
     }
   })
 ) { }
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function(t) {\n      passed = t === proxied;\n      return {\n        next: function() { return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"ownKeys" handler</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var proxied = {};
 var passed = false;
 Object.keys(
   new Proxy(proxied, {
-    ownKeys: function (t) {
+    ownKeys: function(t) {
       passed = t === proxied; return [];
     }
   })
 );
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function(t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"apply" handler</span></td>
-<script data-source="(function(){
-var proxied = function(){};
+<script data-source="((function() {
+var proxied = function() {};
 var passed = false;
 var host = {
   method: new Proxy(proxied, {
-    apply: function (t, thisArg, args) {
+    apply: function(t, thisArg, args) {
       passed = t === proxied && thisArg === host && args + &quot;&quot; === &quot;foo,bar&quot;;
     }
   })
 };
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = function() {};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function(t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>"construct" handler</span></td>
-<script data-source="(function(){
-var proxied = function(){};
+<script data-source="((function() {
+var proxied = function() {};
 var passed = false;
 new new Proxy(proxied, {
-  construct: function (t, args) {
+  construct: function(t, args) {
     passed = t === proxied && args + &quot;&quot; === &quot;foo,bar&quot;;
     return {};
   }
 })(&quot;foo&quot;,&quot;bar&quot;);
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar proxied = function() {};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function(t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Proxy">
           <td><span>Proxy.revocable</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = Proxy.revocable({}, { get: function() { return 5; } });
 var passed = (obj.proxy.foo === 5);
 obj.revoke();
@@ -2571,8 +2555,24 @@ try {
   passed &= e instanceof TypeError;
 }
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      }))")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="((function() {
+return Array.isArray(new Proxy([], {}));
+      }))">
+test(function(){try{return eval("((function() {\nreturn Array.isArray(new Proxy([], {}));\n      }))")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="((function() {
+return JSON.stringify(new Proxy(['foo'], {})) === '[&quot;foo&quot;]';
+      }))">
+test(function(){try{return eval("((function() {\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2581,101 +2581,101 @@ test(function(){try{return eval("(function(){\nvar obj = Proxy.revocable({}, { g
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.get</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.set</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.has</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.deleteProperty</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = { bar: 456 };
 Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
-      })">
-test(function(){try{return eval("(function(){\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.getOwnPropertyDescriptor</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = { baz: 789 };
 var desc = Reflect.getOwnPropertyDescriptor(obj, &quot;baz&quot;);
 return desc.value === 789 &&
   desc.configurable && desc.writable && desc.enumerable;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.defineProperty</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.getPrototypeOf</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.getPrototypeOf([]) === Array.prototype;
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.setPrototypeOf</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.isExtensible</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.isExtensible({}) &&
   !Reflect.isExtensible(Object.preventExtensions({}));
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.preventExtensions</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = {};
 Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
-      })">
-test(function(){try{return eval("(function(){\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.enumerate</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = { foo: 1, bar: 2 };
 var iterator = Reflect.enumerate(obj);
 
@@ -2686,48 +2686,48 @@ passed    &= item.value === &quot;bar&quot; && item.done === false;
 item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.ownKeys</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var obj = { foo: 1, bar: 2 };
 return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.apply</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Reflect">
           <td><span>Reflect.construct</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Reflect.construct(function(a, b, c) {
   this.qux = a + b + c;
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[1]</sup></a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 'use strict';
 {
-  function f(){}
+  function f() {}
 }
 return typeof f === &quot;undefined&quot;;
-  })">
-test(function(){try{return eval("(function(){\n'use strict';\n{\n  function f(){}\n}\nreturn typeof f === \"undefined\";\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\n'use strict';\n{\n  function f() {}\n}\nreturn typeof f === \"undefined\";\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2799,7 +2799,7 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 var var$0 = [5, null, [6]],
     iterator$0 = $__getIterator(var$0),
     iteratorValue$0 = {
@@ -2815,8 +2815,8 @@ var var$0 = [5, null, [6]],
     b = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 0, 1), iteratorValue$1.range[0]),
     c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 3, 1), iteratorValue$0.range[0]);
 return a === 5 && b === 6 && c === undefined;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nvar var$0 = [5, null, [6]],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    iterator$1 = $__getIterator(\n          (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0])\n    ),\n    iteratorValue$1 = {\n          index: 0\n    },\n    b = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 0, 1), iteratorValue$1.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 3, 1), iteratorValue$0.range[0]);\nreturn a === 5 && b === 6 && c === undefined;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nvar var$0 = [5, null, [6]],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    iterator$1 = $__getIterator(\n          (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0])\n    ),\n    iteratorValue$1 = {\n          index: 0\n    },\n    b = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 0, 1), iteratorValue$1.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 3, 1), iteratorValue$0.range[0]);\nreturn a === 5 && b === 6 && c === undefined;\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2884,7 +2884,7 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 var var$0 = &quot;bar&quot;,
     iterator$0 = $__getIterator(var$0),
     iteratorValue$0 = {
@@ -2894,8 +2894,8 @@ var var$0 = &quot;bar&quot;,
     b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),
     c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);
 return a === &quot;b&quot; && b === &quot;a&quot; && c === &quot;r&quot;;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nvar var$0 = \"bar\",\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === \"b\" && b === \"a\" && c === \"r\";\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nvar var$0 = \"bar\",\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === \"b\" && b === \"a\" && c === \"r\";\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2963,7 +2963,7 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 var iterable = __createIterableObject(1, 2, 3);
 var iterator$0 = $__getIterator(iterable),
     iteratorValue$0 = {
@@ -2973,8 +2973,8 @@ var iterator$0 = $__getIterator(iterable),
     b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),
     c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);
 return a === 1 && b === 2 && c === 3;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nvar iterable = __createIterableObject(1, 2, 3);\nvar iterator$0 = $__getIterator(iterable),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === 1 && b === 2 && c === 3;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nvar iterable = __createIterableObject(1, 2, 3);\nvar iterator$0 = $__getIterator(iterable),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === 1 && b === 2 && c === 3;\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3042,7 +3042,7 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 var iterable = __createIterableObject(1, 2, 3);
 var var$0 = Object.create(iterable),
     iterator$0 = $__getIterator(var$0),
@@ -3053,17 +3053,17 @@ var var$0 = Object.create(iterable),
     b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),
     c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);
 return a === 1 && b === 2 && c === 3;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nvar iterable = __createIterableObject(1, 2, 3);\nvar var$0 = Object.create(iterable),\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === 1 && b === 2 && c === 3;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nvar iterable = __createIterableObject(1, 2, 3);\nvar var$0 = Object.create(iterable),\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 2, 1), iteratorValue$0.range[0]);\nreturn a === 1 && b === 2 && c === 3;\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with objects</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var var$0 = {c:7, x:8}, c = var$0.c, d = var$0.x, e = var$0.e;
 return c === 7 && d === 8 && e === undefined;
-      })">
-test(function(){try{return eval("(function(){\nvar var$0 = {c:7, x:8}, c = var$0.c, d = var$0.x, e = var$0.e;\nreturn c === 7 && d === 8 && e === undefined;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar var$0 = {c:7, x:8}, c = var$0.c, d = var$0.x, e = var$0.e;\nreturn c === 7 && d === 8 && e === undefined;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3131,7 +3131,7 @@ var $__getArrayIterator = function(array) {
       };
 };
 
-(function(){
+((function() {
 var var$0 = [9, {x:10}],
     iterator$0 = $__getIterator(var$0),
     iteratorValue$0 = {
@@ -3142,12 +3142,12 @@ var var$0 = [9, {x:10}],
     f = var$1.x,
     g = var$1.g;
 return e === 9 && f === 10 && g === undefined;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n(function(){\nvar var$0 = [9, {x:10}],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    e = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    var$1 = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    f = var$1.x,\n    g = var$1.g;\nreturn e === 9 && f === 10 && g === undefined;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n      if (index > begin) {\n            throw new RangeError();\n      }\n\n      if (typeof len === \"undefined\") {\n            len = Infinity;\n      }\n\n      var range = [], end = begin + len;\n\n      while (index < end) {\n            var next = iterator.next();\n\n            if (next.done) {\n                  break;\n            }\n\n            if (index >= begin) {\n                  range.push(next.value);\n            }\n\n            index++;\n      }\n\n      return {\n            range: range,\n            index: index\n      };\n};\n\nvar $__getIterator = function(iterable) {\n      var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n      if (typeof iterable[sym] === \"function\") {\n            return iterable[sym]();\n      } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n            return $__getArrayIterator(iterable);\n      } else {\n            throw new TypeError();\n      }\n};\n\nvar $__getArrayIterator = function(array) {\n      var index = 0;\n\n      return {\n            next: function() {\n                  if (index < array.length) {\n                        return {\n                              done: false,\n                              value: array[index++]\n                        };\n                  } else {\n                        return {\n                              done: true,\n                              value: void 0\n                        };\n                  }\n            }\n      };\n};\n\n((function() {\nvar var$0 = [9, {x:10}],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n          index: 0\n    },\n    e = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    var$1 = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]),\n    f = var$1.x,\n    g = var$1.g;\nreturn e === 9 && f === 10 && g === undefined;\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="var $__getIteratorRange = function(iterator, index, begin, len) {
   if (index > begin) {
     throw new RangeError();
@@ -3211,7 +3211,7 @@ var $__getArrayIterator = function(array) {
   };
 };
 
-(function(){
+((function() {
 return (function(arg$0, arg$1) {
   var a = arg$0.a,
       b = arg$0.x,
@@ -3226,8 +3226,8 @@ return (function(arg$0, arg$1) {
   return a === 1 && b === 2 && c === 3 &&
     d === 4 && e === undefined;
 }({a:1, x:2}, [3, 4]));
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n  if (index > begin) {\n    throw new RangeError();\n  }\n\n  if (typeof len === \"undefined\") {\n    len = Infinity;\n  }\n\n  var range = [], end = begin + len;\n\n  while (index < end) {\n    var next = iterator.next();\n\n    if (next.done) {\n      break;\n    }\n\n    if (index >= begin) {\n      range.push(next.value);\n    }\n\n    index++;\n  }\n\n  return {\n    range: range,\n    index: index\n  };\n};\n\nvar $__getIterator = function(iterable) {\n  var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n  if (typeof iterable[sym] === \"function\") {\n    return iterable[sym]();\n  } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n    return $__getArrayIterator(iterable);\n  } else {\n    throw new TypeError();\n  }\n};\n\nvar $__getArrayIterator = function(array) {\n  var index = 0;\n\n  return {\n    next: function() {\n      if (index < array.length) {\n        return {\n          done: false,\n          value: array[index++]\n        };\n      } else {\n        return {\n          done: true,\n          value: void 0\n        };\n      }\n    }\n  };\n};\n\n(function(){\nreturn (function(arg$0, arg$1) {\n  var a = arg$0.a,\n      b = arg$0.x,\n      e = arg$0.y,\n      iterator$0 = $__getIterator(arg$1),\n      iteratorValue$0 = {\n        index: 0\n      },\n      c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n      d = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]);\n\n  return a === 1 && b === 2 && c === 3 &&\n    d === 4 && e === undefined;\n}({a:1, x:2}, [3, 4]));\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n  if (index > begin) {\n    throw new RangeError();\n  }\n\n  if (typeof len === \"undefined\") {\n    len = Infinity;\n  }\n\n  var range = [], end = begin + len;\n\n  while (index < end) {\n    var next = iterator.next();\n\n    if (next.done) {\n      break;\n    }\n\n    if (index >= begin) {\n      range.push(next.value);\n    }\n\n    index++;\n  }\n\n  return {\n    range: range,\n    index: index\n  };\n};\n\nvar $__getIterator = function(iterable) {\n  var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n  if (typeof iterable[sym] === \"function\") {\n    return iterable[sym]();\n  } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n    return $__getArrayIterator(iterable);\n  } else {\n    throw new TypeError();\n  }\n};\n\nvar $__getArrayIterator = function(array) {\n  var index = 0;\n\n  return {\n    next: function() {\n      if (index < array.length) {\n        return {\n          done: false,\n          value: array[index++]\n        };\n      } else {\n        return {\n          done: true,\n          value: void 0\n        };\n      }\n    }\n  };\n};\n\n((function() {\nreturn (function(arg$0, arg$1) {\n  var a = arg$0.a,\n      b = arg$0.x,\n      e = arg$0.y,\n      iterator$0 = $__getIterator(arg$1),\n      iteratorValue$0 = {\n        index: 0\n      },\n      c = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n      d = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, 1), iteratorValue$0.range[0]);\n\n  return a === 1 && b === 2 && c === 3 &&\n    d === 4 && e === undefined;\n}({a:1, x:2}, [3, 4]));\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3295,7 +3295,7 @@ var $__getArrayIterator = function(array) {
    };
 };
 
-(function(){
+((function() {
 var var$0 = [3, 4, 5],
     iterator$0 = $__getIterator(var$0),
     iteratorValue$0 = {
@@ -3312,8 +3312,14 @@ var var$1 = [6],
     d = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 1, Infinity), iteratorValue$1.range);
 return a === 3 && b instanceof Array && (b + &quot;&quot;) === &quot;4,5&quot; &&
    c === 6 && d instanceof Array && d.length === 0;
-      });">
-test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n   if (index > begin) {\n      throw new RangeError();\n   }\n\n   if (typeof len === \"undefined\") {\n      len = Infinity;\n   }\n\n   var range = [], end = begin + len;\n\n   while (index < end) {\n      var next = iterator.next();\n\n      if (next.done) {\n         break;\n      }\n\n      if (index >= begin) {\n         range.push(next.value);\n      }\n\n      index++;\n   }\n\n   return {\n      range: range,\n      index: index\n   };\n};\n\nvar $__getIterator = function(iterable) {\n   var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n   if (typeof iterable[sym] === \"function\") {\n      return iterable[sym]();\n   } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n      return $__getArrayIterator(iterable);\n   } else {\n      throw new TypeError();\n   }\n};\n\nvar $__getArrayIterator = function(array) {\n   var index = 0;\n\n   return {\n      next: function() {\n         if (index < array.length) {\n            return {\n               done: false,\n               value: array[index++]\n            };\n         } else {\n            return {\n               done: true,\n               value: void 0\n            };\n         }\n      }\n   };\n};\n\n(function(){\nvar var$0 = [3, 4, 5],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n       index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, Infinity), iteratorValue$0.range);\nvar var$1 = [6],\n    iterator$1 = $__getIterator(var$1),\n    iteratorValue$1 = {\n       index: 0\n    },\n    c = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 0, 1), iteratorValue$1.range[0]),\n    d = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 1, Infinity), iteratorValue$1.range);\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__getIteratorRange = function(iterator, index, begin, len) {\n   if (index > begin) {\n      throw new RangeError();\n   }\n\n   if (typeof len === \"undefined\") {\n      len = Infinity;\n   }\n\n   var range = [], end = begin + len;\n\n   while (index < end) {\n      var next = iterator.next();\n\n      if (next.done) {\n         break;\n      }\n\n      if (index >= begin) {\n         range.push(next.value);\n      }\n\n      index++;\n   }\n\n   return {\n      range: range,\n      index: index\n   };\n};\n\nvar $__getIterator = function(iterable) {\n   var sym = typeof Symbol === \"function\" && Symbol.iterator || \"@@iterator\";\n\n   if (typeof iterable[sym] === \"function\") {\n      return iterable[sym]();\n   } else if (typeof iterable === \"object\" || typeof iterable === \"function\") {\n      return $__getArrayIterator(iterable);\n   } else {\n      throw new TypeError();\n   }\n};\n\nvar $__getArrayIterator = function(array) {\n   var index = 0;\n\n   return {\n      next: function() {\n         if (index < array.length) {\n            return {\n               done: false,\n               value: array[index++]\n            };\n         } else {\n            return {\n               done: true,\n               value: void 0\n            };\n         }\n      }\n   };\n};\n\n((function() {\nvar var$0 = [3, 4, 5],\n    iterator$0 = $__getIterator(var$0),\n    iteratorValue$0 = {\n       index: 0\n    },\n    a = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 0, 1), iteratorValue$0.range[0]),\n    b = (iteratorValue$0 = $__getIteratorRange(iterator$0, iteratorValue$0.index, 1, Infinity), iteratorValue$0.range);\nvar var$1 = [6],\n    iterator$1 = $__getIterator(var$1),\n    iteratorValue$1 = {\n       index: 0\n    },\n    c = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 0, 1), iteratorValue$1.range[0]),\n    d = (iteratorValue$1 = $__getIteratorRange(iterator$1, iteratorValue$1.index, 1, Infinity), iteratorValue$1.range);\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      }));")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="/* Error during compilation: undefined does not match field &quot;name&quot;: string of type Identifier*/">
+test(function(){try{return Function("/* Error during compilation: undefined does not match field \"name\": string of type Identifier*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -3331,11 +3337,11 @@ test(function(){try{return Function("/* Error during compilation: Line 2: Unexpe
         </tr>
         <tr>
           <td id="Promise"><span><a class="anchor" href="#Promise">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Promise !== 'undefined' &&
        typeof Promise.all === 'function';
-  })">
-test(function(){try{return eval("(function(){\nreturn typeof Promise !== 'undefined' &&\n       typeof Promise.all === 'function';\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nreturn typeof Promise !== 'undefined' &&\n       typeof Promise.all === 'function';\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3344,40 +3350,40 @@ test(function(){try{return eval("(function(){\nreturn typeof Promise !== 'undefi
 
         <tr class="subtest" data-parent="Object_static_methods">
           <td><span>Object.assign</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o && &quot;b&quot; in o && &quot;c&quot; in o;
-      })">
-test(function(){try{return eval("(function(){\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Object_static_methods">
           <td><span>Object.is</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Object.is === 'function' &&
   Object.is(NaN, NaN) &&
  !Object.is(-0, 0);
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Object_static_methods">
           <td><span>Object.getOwnPropertySymbols</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var o = {};
 var sym = Symbol();
 o[sym] = &quot;foo&quot;;
 return Object.getOwnPropertySymbols(o)[0] === sym;
-      })">
-test(function(){try{return eval("(function(){\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Object_static_methods">
           <td><span>Object.setPrototypeOf</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
-      })">
-test(function(){try{return eval("(function(){\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3386,97 +3392,97 @@ test(function(){try{return eval("(function(){\nreturn Object.setPrototypeOf({}, 
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>function statements</span></td>
-<script data-source="(function(){
-function foo(){};
+<script data-source="((function() {
+function foo() {};
 return foo.name === 'foo' &&
-  (function(){}).name === '';
-      })">
-test(function(){try{return eval("(function(){\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      })")()}catch(e){return false;}}());
+  (function() {}).name === '';
+      }))">
+test(function(){try{return eval("((function() {\nfunction foo() {};\nreturn foo.name === 'foo' &&\n  (function() {}).name === '';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>function expressions</span></td>
-<script data-source="(function(){
-return (function foo(){}).name === 'foo' &&
-  (function(){}).name === '';
-      })">
-test(function(){try{return eval("(function(){\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      })")()}catch(e){return false;}}());
+<script data-source="((function() {
+return (function foo() {}).name === 'foo' &&
+  (function() {}).name === '';
+      }))">
+test(function(){try{return eval("((function() {\nreturn (function foo() {}).name === 'foo' &&\n  (function() {}).name === '';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>new Function</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return (new Function).name === &quot;anonymous&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn (new Function).name === \"anonymous\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn (new Function).name === \"anonymous\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>bound functions</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 function foo() {};
 return foo.bind({}).name === &quot;bound foo&quot; &&
-  (function(){}).bind({}).name === &quot;bound &quot;;
-      })">
-test(function(){try{return eval("(function(){\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      })")()}catch(e){return false;}}());
+  (function() {}).bind({}).name === &quot;bound &quot;;
+      }))">
+test(function(){try{return eval("((function() {\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function() {}).bind({}).name === \"bound \";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>variables (function)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var foo = function() {};
 var bar = function baz() {};
 return foo.name === &quot;foo&quot; && bar.name === &quot;baz&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>object methods (function)</span></td>
-<script data-source="(function(){
-var o = { foo: function(){}, bar: function baz(){}};
-o.qux = function(){};
+<script data-source="((function() {
+var o = { foo: function() {}, bar: function baz() {}};
+o.qux = function() {};
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
        o.qux.name === &quot;&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = { foo: function() {}, bar: function baz() {}};\no.qux = function() {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>accessor properties</span></td>
-<script data-source="(function(){
-var o = { get foo(){}, set foo(x){} };
+<script data-source="((function() {
+var o = { get foo()function() {}, set foo(x)function(x) {} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &&
        descriptor.set.name === &quot;set foo&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = { get foo()function() {}, set foo(x)function(x) {} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>shorthand methods</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var o = { foo: function foo() {} };
 return o.foo.name === &quot;foo&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function foo() {} };\nreturn o.foo.name === \"foo\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = { foo: function foo() {} };\nreturn o.foo.name === \"foo\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>symbol-keyed methods</span></td>
 <script data-source="var $__Object$defineProperty = Object.defineProperty;
-(function(){
+((function() {
   var $__0;
   var sym1 = Symbol(&quot;foo&quot;);
   var sym2 = Symbol();
   var o = ($__0 = {}, $__Object$defineProperty($__0, sym1, {
-    value: function(){},
+    value: function() {},
     enumerable: true,
     configurable: true,
     writable: true
   }), $__Object$defineProperty($__0, sym2, {
-    value: function(){},
+    value: function() {},
     enumerable: true,
     configurable: true,
     writable: true
@@ -3484,14 +3490,14 @@ test(function(){try{return eval("(function(){\nvar o = { foo: function foo() {} 
 
   return o[sym].name === &quot;[foo]&quot; &&
          o[sym2].name === &quot;&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n(function(){\n  var $__0;\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = ($__0 = {}, $__Object$defineProperty($__0, sym1, {\n    value: function(){},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__Object$defineProperty($__0, sym2, {\n    value: function(){},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__0);\n\n  return o[sym].name === \"[foo]\" &&\n         o[sym2].name === \"\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n((function() {\n  var $__0;\n  var sym1 = Symbol(\"foo\");\n  var sym2 = Symbol();\n  var o = ($__0 = {}, $__Object$defineProperty($__0, sym1, {\n    value: function() {},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__Object$defineProperty($__0, sym2, {\n    value: function() {},\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__0);\n\n  return o[sym].name === \"[foo]\" &&\n         o[sym2].name === \"\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>class statements</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
   var foo = function() {
     &quot;use strict&quot;;
     function foo() {}
@@ -3515,14 +3521,14 @@ test(function(){try{return eval("var $__Object$defineProperty = Object.definePro
 
   return foo.name === &quot;foo&quot; &&
     typeof bar.name === &quot;function&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\n  var foo = function() {\n    \"use strict\";\n    function foo() {}\n    return foo;\n  }();\n\n  var bar = function() {\n    \"use strict\";\n    function bar() {}\n\n    $__Object$defineProperties(bar, {\n      name: {\n        value: function() {},\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return bar;\n  }();\n\n  return foo.name === \"foo\" &&\n    typeof bar.name === \"function\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\n  var foo = function() {\n    \"use strict\";\n    function foo() {}\n    return foo;\n  }();\n\n  var bar = function() {\n    \"use strict\";\n    function bar() {}\n\n    $__Object$defineProperties(bar, {\n      name: {\n        value: function() {},\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return bar;\n  }();\n\n  return foo.name === \"foo\" &&\n    typeof bar.name === \"function\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>class expressions</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
 return function() {
   &quot;use strict&quot;;
   function foo() {}
@@ -3542,14 +3548,14 @@ return function() {
 
     return bar;
   }().name === &quot;function&quot;;
-      });">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\nreturn function() {\n  \"use strict\";\n  function foo() {}\n  return foo;\n}().name === \"foo\" &&\n  typeof function() {\n    \"use strict\";\n    function bar() {}\n\n    $__Object$defineProperties(bar, {\n      name: {\n        value: function() {},\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return bar;\n  }().name === \"function\";\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\nreturn function() {\n  \"use strict\";\n  function foo() {}\n  return foo;\n}().name === \"foo\" &&\n  typeof function() {\n    \"use strict\";\n    function bar() {}\n\n    $__Object$defineProperties(bar, {\n      name: {\n        value: function() {},\n        enumerable: false,\n        writable: true\n      }\n    });\n\n    return bar;\n  }().name === \"function\";\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>variables (class)</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
 var foo = function() {
  &quot;use strict&quot;;
  function $__0() {}
@@ -3577,13 +3583,13 @@ var qux = function() {
 return foo.name === &quot;foo&quot; &&
        bar.name === &quot;baz&quot; &&
        typeof qux.name === &quot;function&quot;;
-      });">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\nvar foo = function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}();\nvar bar = function() {\n \"use strict\";\n function baz() {}\n return baz;\n}();\nvar qux = function() {\n \"use strict\";\n function $__1() {}\n\n $__Object$defineProperties($__1, {\n  name: {\n   value: function() {},\n   enumerable: false,\n   writable: true\n  }\n });\n\n return $__1;\n}();\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      });")()}catch(e){return false;}}());
+      }));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\nvar foo = function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}();\nvar bar = function() {\n \"use strict\";\n function baz() {}\n return baz;\n}();\nvar qux = function() {\n \"use strict\";\n function $__1() {}\n\n $__Object$defineProperties($__1, {\n  name: {\n   value: function() {},\n   enumerable: false,\n   writable: true\n  }\n });\n\n return $__1;\n}();\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      }));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>object methods (class)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var o = { foo: function() {
  &quot;use strict&quot;;
  function $__0() {}
@@ -3601,14 +3607,14 @@ o.qux = function() {
 return o.foo.name === &quot;foo&quot; &&
        o.bar.name === &quot;baz&quot; &&
        o.qux.name === &quot;&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar o = { foo: function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}(), bar: function() {\n \"use strict\";\n function baz() {}\n return baz;\n}()};\no.qux = function() {\n \"use strict\";\n function $__1() {}\n return $__1;\n}();\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = { foo: function() {\n \"use strict\";\n function $__0() {}\n return $__0;\n}(), bar: function() {\n \"use strict\";\n function baz() {}\n return baz;\n}()};\no.qux = function() {\n \"use strict\";\n function $__1() {}\n return $__1;\n}();\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>class prototype methods</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
       var C = function() {
             &quot;use strict&quot;;
             function C() {}
@@ -3625,14 +3631,14 @@ test(function(){try{return eval("(function(){\nvar o = { foo: function() {\n \"u
       }();
 
       return (new C).foo.name === &quot;foo&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\n      var C = function() {\n            \"use strict\";\n            function C() {}\n\n            $__Object$defineProperties(C.prototype, {\n                  foo: {\n                        value: function() {},\n                        enumerable: false,\n                        writable: true\n                  }\n            });\n\n            return C;\n      }();\n\n      return (new C).foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\n      var C = function() {\n            \"use strict\";\n            function C() {}\n\n            $__Object$defineProperties(C.prototype, {\n                  foo: {\n                        value: function() {},\n                        enumerable: false,\n                        writable: true\n                  }\n            });\n\n            return C;\n      }();\n\n      return (new C).foo.name === \"foo\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>class static methods</span></td>
 <script data-source="var $__Object$defineProperties = Object.defineProperties;
-(function(){
+((function() {
       var C = function() {
             &quot;use strict&quot;;
             function C() {}
@@ -3649,28 +3655,28 @@ test(function(){try{return eval("var $__Object$defineProperties = Object.defineP
       }();
 
       return C.foo.name === &quot;foo&quot;;
-});">
-test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n(function(){\n      var C = function() {\n            \"use strict\";\n            function C() {}\n\n            $__Object$defineProperties(C, {\n                  foo: {\n                        value: function() {},\n                        enumerable: false,\n                        writable: true\n                  }\n            });\n\n            return C;\n      }();\n\n      return C.foo.name === \"foo\";\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperties = Object.defineProperties;\n((function() {\n      var C = function() {\n            \"use strict\";\n            function C() {}\n\n            $__Object$defineProperties(C, {\n                  foo: {\n                        value: function() {},\n                        enumerable: false,\n                        writable: true\n                  }\n            });\n\n            return C;\n      }();\n\n      return C.foo.name === \"foo\";\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="function_name_property">
           <td><span>isn't writable, is configurable</span></td>
-<script data-source="(function(){
-var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;);
+<script data-source="((function() {
+var descriptor = Object.getOwnPropertyDescriptor(function f() {},&quot;name&quot;);
 return descriptor.enumerable   === false &&
        descriptor.writable     === false &&
        descriptor.configurable === true;
-      })">
-test(function(){try{return eval("(function(){\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar descriptor = Object.getOwnPropertyDescriptor(function f() {},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Function.prototype.toMethod === &quot;function&quot;;
-  })">
-test(function(){try{return eval("(function(){\nreturn typeof Function.prototype.toMethod === \"function\";\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nreturn typeof Function.prototype.toMethod === \"function\";\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3679,18 +3685,18 @@ test(function(){try{return eval("(function(){\nreturn typeof Function.prototype.
 
         <tr class="subtest" data-parent="String_static_methods">
           <td><span>String.raw</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.raw === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.raw === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.raw === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String_static_methods">
           <td><span>String.fromCodePoint</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.fromCodePoint === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.fromCodePoint === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.fromCodePoint === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3699,65 +3705,65 @@ test(function(){try{return eval("(function(){\nreturn typeof String.fromCodePoin
 
         <tr class="subtest" data-parent="String.prototype_methods">
           <td><span>String.prototype.codePointAt</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.prototype.codePointAt === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.codePointAt === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.codePointAt === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
           <td><span>String.prototype.normalize</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.prototype.normalize === &quot;function&quot;
   && &quot;c\u0327\u0301&quot;.normalize(&quot;NFC&quot;) === &quot;\u1e09&quot;
   && &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
           <td><span>String.prototype.repeat</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.prototype.repeat === 'function'
   && &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
           <td><span>String.prototype.startsWith</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.prototype.startsWith === 'function'
   && &quot;foobar&quot;.startsWith(&quot;foo&quot;);
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
           <td><span>String.prototype.endsWith</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof String.prototype.endsWith === 'function'
   && &quot;foobar&quot;.endsWith(&quot;bar&quot;);
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
-<script data-source="(function(){
-return typeof String.prototype.contains === 'function'
-  && &quot;foobar&quot;.contains(&quot;oba&quot;);
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof String.prototype.contains === 'function'\n  && \"foobar\".contains(\"oba\");\n      })")()}catch(e){return false;}}());
+          <td><span>String.prototype.includes</span></td>
+<script data-source="((function() {
+return typeof String.prototype.includes === 'function'
+  && &quot;foobar&quot;.includes(&quot;oba&quot;);
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return '\u{1d306}' == '\ud834\udf06';
-  })">
-test(function(){try{return eval("(function(){\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3766,27 +3772,27 @@ test(function(){try{return eval("(function(){\nreturn '\\u{1d306}' == '\\ud834\\
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>basic functionality</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var object = {};
 var symbol = Symbol();
 var value = {};
 object[symbol] = value;
 return object[symbol] === value;
-      })">
-test(function(){try{return eval("(function(){\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>typeof support</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Symbol() === &quot;symbol&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Symbol() === \"symbol\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Symbol() === \"symbol\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>symbol keys are hidden to pre-ES6 code</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var object = {};
 var symbol = Symbol();
 object[symbol] = 1;
@@ -3800,13 +3806,13 @@ if (Object.keys && Object.getOwnPropertyNames) {
 }
 
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>Object.defineProperty support</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var object = {};
 var symbol = Symbol();
 var value = {};
@@ -3817,13 +3823,13 @@ if (Object.defineProperty) {
 }
 
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>cannot coerce to string or number</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var symbol = Symbol();
 
 try {
@@ -3838,53 +3844,53 @@ try {
 } catch(e) {}
 
 return true;
-      })">
-test(function(){try{return eval("(function(){\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>can convert with String()</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
-      })">
-test(function(){try{return eval("(function(){\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>new Symbol() throws</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var symbol = Symbol();
 try {
   new Symbol();
 } catch(e) {
   return true;
 }
-      })">
-test(function(){try{return eval("(function(){\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Symbol">
           <td><span>Object(symbol)</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var symbol = Symbol();
 var symbolObject = Object(symbol);
 
 return typeof symbolObject === &quot;object&quot; &&
   symbolObject == symbol &&
   symbolObject.valueOf() === symbol;
-      })">
-test(function(){try{return eval("(function(){\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="global_symbol_registry"><span><a class="anchor" href="#global_symbol_registry">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol.for">global symbol registry</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var symbol = Symbol.for('foo');
 return Symbol.for('foo') === symbol &&
        Symbol.keyFor(symbol) === 'foo';
-  })">
-test(function(){try{return eval("(function(){\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n       Symbol.keyFor(symbol) === 'foo';\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n       Symbol.keyFor(symbol) === 'foo';\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3893,41 +3899,33 @@ test(function(){try{return eval("(function(){\nvar symbol = Symbol.for('foo');\n
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.hasInstance</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var passed = false;
 var obj = { foo: true };
-var C = function(){};
+var C = function() {};
 Object.defineProperty(C, Symbol.hasInstance, {
   value: function(inst) { passed = inst.foo; return false; }
 });
 obj instanceof C;
 return passed;
-      })">
-test(function(){try{return eval("(function(){\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar passed = false;\nvar obj = { foo: true };\nvar C = function() {};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.isConcatSpreadable</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = [], b = [];
 b[Symbol.isConcatSpreadable] = false;
 a = a.concat(b);
 return a[0] === b;
-      })">
-test(function(){try{return eval("(function(){\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      })")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="(function(){
-return RegExp.prototype[Symbol.isRegExp] === true;
-      })">
-test(function(){try{return eval("(function(){\nreturn RegExp.prototype[Symbol.isRegExp] === true;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
   var a = 0, b = {};
   b[Symbol.iterator] = function() {
     return {
@@ -3946,13 +3944,23 @@ test(function(){try{return eval("(function(){\nreturn RegExp.prototype[Symbol.is
   }
 
   return c === &quot;foo&quot;;
-})">
-test(function(){try{return eval("(function(){\n  var a = 0, b = {};\n  b[Symbol.iterator] = function() {\n    return {\n      next: function() {\n        return {\n          done: a++ === 1,\n          value: \"foo\"\n        };\n      }\n    };\n  };\n  var c;\n\n  for (var t$1$0 = regeneratorRuntime.values(b), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    c = t$1$1.value;\n  }\n\n  return c === \"foo\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\n  var a = 0, b = {};\n  b[Symbol.iterator] = function() {\n    return {\n      next: function() {\n        return {\n          done: a++ === 1,\n          value: \"foo\"\n        };\n      }\n    };\n  };\n  var c;\n\n  for (var t$1$0 = regeneratorRuntime.values(b), t$1$1; !(t$1$1 = t$1$0.next()).done; ) {\n    c = t$1$1.value;\n  }\n\n  return c === \"foo\";\n}))")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="((function() {
+return RegExp[Symbol.species] === RegExp
+  && Array[Symbol.species] === Array
+  && !(Symbol.species in Object);
+      }))">
+test(function(){try{return eval("((function() {\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.toPrimitive</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = {}, b = {}, c = {};
 var passed = 0;
 a[Symbol.toPrimitive] = function(hint) { passed += hint === &quot;number&quot;;  return 0; };
@@ -3963,30 +3971,30 @@ a >= 0;
 b in {};
 c == 0;
 return passed === 3;
-      })">
-test(function(){try{return eval("(function(){\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.toStringTag</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = {};
 a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
-      })">
-test(function(){try{return eval("(function(){\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.unscopables</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var a = { foo: 1, bar: 2 };
 a[Symbol.unscopables] = { bar: true };
 with (a) {
   return foo === 1 && typeof bar === &quot;undefined&quot;;
 }
-      })">
-test(function(){try{return eval("(function(){\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -3994,35 +4002,35 @@ test(function(){try{return eval("(function(){\nvar a = { foo: 1, bar: 2 };\na[Sy
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.match === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.match === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
+<script data-source="((function() {
+return typeof RegExp.prototype[Symbol.match] === 'function';
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.replace === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.replace === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
+<script data-source="((function() {
+return typeof RegExp.prototype[Symbol.replace] === 'function';
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.split === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.split === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
+<script data-source="((function() {
+return typeof RegExp.prototype[Symbol.split] === 'function';
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
-<script data-source="(function(){
-return typeof RegExp.prototype.search === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.search === 'function';\n      })")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
+<script data-source="((function() {
+return typeof RegExp.prototype[Symbol.search] === 'function';
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4031,19 +4039,19 @@ test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.se
 
         <tr class="subtest" data-parent="Array_static_methods">
           <td><span>Array.from</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.from === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.from === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.from === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array_static_methods">
           <td><span>Array.of</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.of === 'function' &&
   Array.of(2)[0] === 2;
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4052,63 +4060,63 @@ test(function(){try{return eval("(function(){\nreturn typeof Array.of === 'funct
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.copyWithin</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.copyWithin === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.copyWithin === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.copyWithin === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.find</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.find === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.find === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.find === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.findIndex</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.findIndex === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.findIndex === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.findIndex === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.fill</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.fill === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.fill === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.fill === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.keys</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.keys === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.keys === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.keys === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.values</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.values === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.values === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.values === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype.entries</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Array.prototype.entries === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Array.prototype.entries === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Array.prototype.entries === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Array.prototype_methods">
           <td><span>Array.prototype[Symbol.unscopables]</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var unscopables = Array.prototype[Symbol.unscopables];
 if (!unscopables) {
   return false;
@@ -4118,8 +4126,8 @@ for (var i = 0; i < ns.length; i++) {
   if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;
 }
 return true;
-      })">
-test(function(){try{return eval("(function(){\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4128,58 +4136,58 @@ test(function(){try{return eval("(function(){\nvar unscopables = Array.prototype
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.isFinite</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.isFinite === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.isFinite === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.isFinite === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.isInteger</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.isInteger === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.isInteger === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.isInteger === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.isSafeInteger</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.isSafeInteger === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.isSafeInteger === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.isSafeInteger === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.isNaN</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.isNaN === 'function';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.isNaN === 'function';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.isNaN === 'function';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.EPSILON</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.EPSILON === 'number';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.EPSILON === 'number';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.EPSILON === 'number';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.MIN_SAFE_INTEGER</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.MIN_SAFE_INTEGER === 'number';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Number_properties">
           <td><span>Number.MAX_SAFE_INTEGER</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Number.MAX_SAFE_INTEGER === 'number';
-      })">
-test(function(){try{return eval("(function(){\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4188,138 +4196,138 @@ test(function(){try{return eval("(function(){\nreturn typeof Number.MAX_SAFE_INT
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.clz32</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.clz32 === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.clz32 === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.clz32 === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.imul</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.imul === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.imul === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.imul === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.sign</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.sign === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.sign === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.sign === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.log10</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.log10 === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.log10 === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.log10 === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.log2</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.log2 === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.log2 === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.log2 === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.log1p</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.log1p === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.log1p === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.log1p === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.expm1</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.expm1 === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.expm1 === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.expm1 === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.cosh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.cosh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.cosh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.cosh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.sinh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.sinh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.sinh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.sinh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.tanh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.tanh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.tanh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.tanh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.acosh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.acosh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.acosh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.acosh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.asinh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.asinh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.asinh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.asinh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.atanh</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.atanh === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.atanh === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.atanh === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.hypot</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.hypot === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.hypot === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.hypot === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.trunc</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.trunc === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.trunc === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.trunc === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.fround</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.fround === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.fround === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.fround === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Math_methods">
           <td><span>Math.cbrt</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof Math.cbrt === &quot;function&quot;;
-})">
-test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"function\";\n})")()}catch(e){return false;}}());
+}))">
+test(function(){try{return eval("((function() {\nreturn typeof Math.cbrt === \"function\";\n}))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4328,7 +4336,7 @@ test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"fun
         </tr>
         <tr>
           <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 // Note: only available outside of strict mode.
 { function f() { return 1; } }
   function g() { return 1; }
@@ -4337,8 +4345,8 @@ test(function(){try{return eval("(function(){\nreturn typeof Math.cbrt === \"fun
   function h() { return 2; }
 
 return f() === 1 && g() === 2 && h() === 1;
-  })">
-test(function(){try{return eval("(function(){\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4347,11 +4355,11 @@ test(function(){try{return eval("(function(){\n// Note: only available outside o
 
         <tr class="subtest" data-parent="__proto___in_object_literals">
           <td><span>basic support</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return { __proto__ : [] } instanceof Array
   && !({ __proto__ : null } instanceof Object);
-      })">
-test(function(){try{return eval("(function(){\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="__proto___in_object_literals">
@@ -4363,7 +4371,7 @@ test(function(){try{return Function("/* Error during compilation: This test's co
         <tr class="subtest" data-parent="__proto___in_object_literals">
           <td><span>not a computed property</span></td>
 <script data-source="var $__Object$defineProperty = Object.defineProperty;
-(function(){
+((function() {
   var $__0;
   if (!({ __proto__ : [] } instanceof Array)) {
     return false;
@@ -4375,31 +4383,31 @@ test(function(){try{return Function("/* Error during compilation: This test's co
     configurable: true,
     writable: true
   }), $__0) instanceof Array);
-});">
-test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n(function(){\n  var $__0;\n  if (!({ __proto__ : [] } instanceof Array)) {\n    return false;\n  }\n  var a = \"__proto__\";\n  return !(($__0 = {}, $__Object$defineProperty($__0, a, {\n    value: [],\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__0) instanceof Array);\n});")()}catch(e){return false;}}());
+}));">
+test(function(){try{return eval("var $__Object$defineProperty = Object.defineProperty;\n((function() {\n  var $__0;\n  if (!({ __proto__ : [] } instanceof Array)) {\n    return false;\n  }\n  var a = \"__proto__\";\n  return !(($__0 = {}, $__Object$defineProperty($__0, a, {\n    value: [],\n    enumerable: true,\n    configurable: true,\n    writable: true\n  }), $__0) instanceof Array);\n}));")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="__proto___in_object_literals">
           <td><span>not a shorthand property</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 var __proto__ = [];
 return !({ __proto__: __proto__ } instanceof Array);
-      })">
-test(function(){try{return eval("(function(){\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__: __proto__ } instanceof Array);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__: __proto__ } instanceof Array);\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="__proto___in_object_literals">
           <td><span>not a shorthand method</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 return !({ __proto__: function __proto__() {} } instanceof Function);
-      })">
-test(function(){try{return eval("(function(){\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__: function __proto__() {} } instanceof Function);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__: function __proto__() {} } instanceof Function);\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -4408,42 +4416,42 @@ test(function(){try{return eval("(function(){\nif (!({ __proto__ : [] } instance
 
         <tr class="subtest" data-parent="Object.prototype.__proto__">
           <td><span>get prototype</span></td>
-<script data-source="(function(){
-var A = function(){};
+<script data-source="((function() {
+var A = function() {};
 return (new A()).__proto__ === A.prototype;
-      })">
-test(function(){try{return eval("(function(){\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar A = function() {};\nreturn (new A()).__proto__ === A.prototype;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Object.prototype.__proto__">
           <td><span>set prototype</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var o = {};
 o.__proto__ = Array.prototype;
 return o instanceof Array;
-      })">
-test(function(){try{return eval("(function(){\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      }))")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="Object.prototype.__proto__">
           <td><span>correct property descriptor</span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var desc = Object.getOwnPropertyDescriptor(Object.prototype,&quot;__proto__&quot;);
-var A = function(){};
+var A = function() {};
 
 return (desc
   && &quot;get&quot; in desc
   && &quot;set&quot; in desc
   && desc.configurable
   && !desc.enumerable);
-      })">
-test(function(){try{return eval("(function(){\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      })")()}catch(e){return false;}}());
+      }))">
+test(function(){try{return eval("((function() {\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function() {};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor">String.prototype HTML methods</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 var i, names = [&quot;anchor&quot;, &quot;big&quot;, &quot;bold&quot;, &quot;fixed&quot;, &quot;fontcolor&quot;, &quot;fontsize&quot;,
   &quot;italics&quot;, &quot;link&quot;, &quot;small&quot;, &quot;strike&quot;, &quot;sub&quot;, &quot;sup&quot;];
 for (i = 0; i < names.length; i++) {
@@ -4452,17 +4460,17 @@ for (i = 0; i < names.length; i++) {
   }
 }
 return true;
-  })">
-test(function(){try{return eval("(function(){\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>
         <tr>
           <td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span></td>
-<script data-source="(function(){
+<script data-source="((function() {
 return typeof RegExp.prototype.compile === 'function';
-  })">
-test(function(){try{return eval("(function(){\nreturn typeof RegExp.prototype.compile === 'function';\n  })")()}catch(e){return false;}}());
+  }))">
+test(function(){try{return eval("((function() {\nreturn typeof RegExp.prototype.compile === 'function';\n  }))")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/traceur.html
+++ b/es6/compilers/traceur.html
@@ -423,6 +423,9 @@
 })();
 (function() {
   'use strict';
+  if (typeof $traceurRuntime !== 'object') {
+    throw new Error('traceur runtime not found.');
+  }
   var createPrivateName = $traceurRuntime.createPrivateName;
   var $defineProperties = $traceurRuntime.defineProperties;
   var $defineProperty = $traceurRuntime.defineProperty;
@@ -844,6 +847,33 @@
       return stack.join('\n');
     }
   }, {}, Error);
+  function beforeLines(lines, number) {
+    var result = [];
+    var first = number - 3;
+    if (first < 0)
+      first = 0;
+    for (var i = first; i < number; i++) {
+      result.push(lines[i]);
+    }
+    return result;
+  }
+  function afterLines(lines, number) {
+    var last = number + 1;
+    if (last > lines.length - 1)
+      last = lines.length - 1;
+    var result = [];
+    for (var i = number; i <= last; i++) {
+      result.push(lines[i]);
+    }
+    return result;
+  }
+  function columnSpacing(columns) {
+    var result = '';
+    for (var i = 0; i < columns - 1; i++) {
+      result += '-';
+    }
+    return result;
+  }
   var UncoatedModuleInstantiator = function UncoatedModuleInstantiator(url, func) {
     $traceurRuntime.superConstructor($UncoatedModuleInstantiator).call(this, url, null);
     this.func = func;
@@ -853,11 +883,34 @@
       if (this.value_)
         return this.value_;
       try {
-        return this.value_ = this.func.call(global);
+        var relativeRequire;
+        if (typeof $traceurRuntime !== undefined) {
+          relativeRequire = $traceurRuntime.require.bind(null, this.url);
+        }
+        return this.value_ = this.func.call(global, relativeRequire);
       } catch (ex) {
         if (ex instanceof ModuleEvaluationError) {
           ex.loadedBy(this.url);
           throw ex;
+        }
+        if (ex.stack) {
+          var lines = this.func.toString().split('\n');
+          var evaled = [];
+          ex.stack.split('\n').some(function(frame) {
+            if (frame.indexOf('UncoatedModuleInstantiator.getUncoatedModule') > 0)
+              return true;
+            var m = /(at\s[^\s]*\s).*>:(\d*):(\d*)\)/.exec(frame);
+            if (m) {
+              var line = parseInt(m[2], 10);
+              evaled = evaled.concat(beforeLines(lines, line));
+              evaled.push(columnSpacing(m[3]) + '^');
+              evaled = evaled.concat(afterLines(lines, line));
+              evaled.push('= = = = = = = = =');
+            } else {
+              evaled.push(frame);
+            }
+          });
+          ex.stack = evaled.join('\n');
         }
         throw new ModuleEvaluationError(this.url, ex);
       }
@@ -898,8 +951,8 @@
   }
   var ModuleStore = {
     normalize: function(name, refererName, refererAddress) {
-      if (typeof name !== "string")
-        throw new TypeError("module name must be a string, not " + typeof name);
+      if (typeof name !== 'string')
+        throw new TypeError('module name must be a string, not ' + typeof name);
       if (isAbsolute(name))
         return canonicalizeUrl(name);
       if (/[^\.]\/\.\.\//.test(name)) {
@@ -932,7 +985,7 @@
     set baseURL(v) {
       baseURL = String(v);
     },
-    registerModule: function(name, func) {
+    registerModule: function(name, deps, func) {
       var normalizedName = ModuleStore.normalize(name);
       if (moduleInstantiators[normalizedName])
         throw new Error('duplicate module named ' + normalizedName);
@@ -941,7 +994,7 @@
     bundleStore: Object.create(null),
     register: function(name, deps, func) {
       if (!deps || !deps.length && !func.length) {
-        this.registerModule(name, func);
+        this.registerModule(name, deps, func);
       } else {
         this.bundleStore[name] = {
           deps: deps,
@@ -975,7 +1028,9 @@
       return this.get(this.testingPrefix_ + name);
     }
   };
-  ModuleStore.set('@traceur/src/runtime/ModuleStore', new Module({ModuleStore: ModuleStore}));
+  var moduleStoreModule = new Module({ModuleStore: ModuleStore});
+  ModuleStore.set('@traceur/src/runtime/ModuleStore', moduleStoreModule);
+  ModuleStore.set('@traceur/src/runtime/ModuleStore.js', moduleStoreModule);
   var setupGlobals = $traceurRuntime.setupGlobals;
   $traceurRuntime.setupGlobals = function(global) {
     setupGlobals(global);
@@ -983,6 +1038,7 @@
   $traceurRuntime.ModuleStore = ModuleStore;
   global.System = {
     register: ModuleStore.register.bind(ModuleStore),
+    registerModule: ModuleStore.registerModule.bind(ModuleStore),
     get: ModuleStore.get,
     set: ModuleStore.set,
     normalize: ModuleStore.normalize
@@ -992,12 +1048,9 @@
     return instantiator && instantiator.getUncoatedModule();
   };
 })(typeof global !== 'undefined' ? global : this);
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/utils", [], function() {
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/utils";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/utils", path);
-  }
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/utils.js";
   var $ceil = Math.ceil;
   var $floor = Math.floor;
   var $isFinite = isFinite;
@@ -1155,13 +1208,10 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/utils", [], functi
     }
   };
 });
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Map", [], function() {
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Map.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Map";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Map", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Map.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       isObject = $__0.isObject,
       maybeAddIterator = $__0.maybeAddIterator,
       registerPolyfill = $__0.registerPolyfill;
@@ -1423,18 +1473,15 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Map", [], function
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Map" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Set", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Map.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Set.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Set";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Set", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Set.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       isObject = $__0.isObject,
       maybeAddIterator = $__0.maybeAddIterator,
       registerPolyfill = $__0.registerPolyfill;
-  var Map = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Map").Map;
+  var Map = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Map.js").Map;
   var getOwnHashObject = $traceurRuntime.getOwnHashObject;
   var $hasOwnProperty = Object.prototype.hasOwnProperty;
   function initSet(set) {
@@ -1579,13 +1626,10 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Set", [], function
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Set" + '');
-System.register("traceur-runtime@0.0.74/node_modules/rsvp/lib/rsvp/asap", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Set.js" + '');
+System.registerModule("traceur-runtime@0.0.76/node_modules/rsvp/lib/rsvp/asap.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/node_modules/rsvp/lib/rsvp/asap";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/node_modules/rsvp/lib/rsvp/asap", path);
-  }
+  var __moduleName = "traceur-runtime@0.0.76/node_modules/rsvp/lib/rsvp/asap.js";
   var len = 0;
   function asap(callback, arg) {
     queue[len] = callback;
@@ -1650,14 +1694,11 @@ System.register("traceur-runtime@0.0.74/node_modules/rsvp/lib/rsvp/asap", [], fu
       return $__default;
     }};
 });
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Promise", [], function() {
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Promise.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Promise";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Promise", path);
-  }
-  var async = System.get("traceur-runtime@0.0.74/node_modules/rsvp/lib/rsvp/asap").default;
-  var registerPolyfill = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils").registerPolyfill;
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Promise.js";
+  var async = System.get("traceur-runtime@0.0.76/node_modules/rsvp/lib/rsvp/asap.js").default;
+  var registerPolyfill = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js").registerPolyfill;
   var promiseRaw = {};
   function isPromise(x) {
     return x && typeof x === 'object' && x.status_ !== undefined;
@@ -1894,15 +1935,12 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Promise", [], func
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Promise" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/StringIterator", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Promise.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/StringIterator.js", [], function() {
   "use strict";
   var $__2;
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/StringIterator";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/StringIterator", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/StringIterator.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       createIteratorResultObject = $__0.createIteratorResultObject,
       isObject = $__0.isObject;
   var toProperty = $traceurRuntime.toProperty;
@@ -1963,14 +2001,11 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/StringIterator", [
       return createStringIterator;
     }};
 });
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/String", [], function() {
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/String.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/String";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/String", path);
-  }
-  var createStringIterator = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/StringIterator").createStringIterator;
-  var $__1 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/String.js";
+  var createStringIterator = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/StringIterator.js").createStringIterator;
+  var $__1 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       maybeAddFunctions = $__1.maybeAddFunctions,
       maybeAddIterator = $__1.maybeAddIterator,
       registerPolyfill = $__1.registerPolyfill;
@@ -2018,20 +2053,26 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/String", [], funct
     }
     return $lastIndexOf.call(string, searchString, start) == start;
   }
-  function contains(search) {
+  function includes(search) {
     if (this == null) {
       throw TypeError();
     }
     var string = String(this);
+    if (search && $toString.call(search) == '[object RegExp]') {
+      throw TypeError();
+    }
     var stringLength = string.length;
     var searchString = String(search);
     var searchLength = searchString.length;
     var position = arguments.length > 1 ? arguments[1] : undefined;
     var pos = position ? Number(position) : 0;
-    if (isNaN(pos)) {
+    if (pos != pos) {
       pos = 0;
     }
     var start = Math.min(Math.max(pos, 0), stringLength);
+    if (searchLength + start > stringLength) {
+      return false;
+    }
     return $indexOf.call(string, searchString, pos) != -1;
   }
   function repeat(count) {
@@ -2125,7 +2166,7 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/String", [], funct
   }
   function polyfillString(global) {
     var String = global.String;
-    maybeAddFunctions(String.prototype, ['codePointAt', codePointAt, 'contains', contains, 'endsWith', endsWith, 'startsWith', startsWith, 'repeat', repeat]);
+    maybeAddFunctions(String.prototype, ['codePointAt', codePointAt, 'endsWith', endsWith, 'includes', includes, 'repeat', repeat, 'startsWith', startsWith]);
     maybeAddFunctions(String, ['fromCodePoint', fromCodePoint, 'raw', raw]);
     maybeAddIterator(String.prototype, stringPrototypeIterator, Symbol);
   }
@@ -2137,8 +2178,8 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/String", [], funct
     get endsWith() {
       return endsWith;
     },
-    get contains() {
-      return contains;
+    get includes() {
+      return includes;
     },
     get repeat() {
       return repeat;
@@ -2160,15 +2201,12 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/String", [], funct
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/String" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/ArrayIterator", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/String.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/ArrayIterator.js", [], function() {
   "use strict";
   var $__2;
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/ArrayIterator";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/ArrayIterator", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/ArrayIterator.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       toObject = $__0.toObject,
       toUint32 = $__0.toUint32,
       createIteratorResultObject = $__0.createIteratorResultObject;
@@ -2237,17 +2275,14 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/ArrayIterator", []
     }
   };
 });
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Array", [], function() {
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Array.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Array";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Array", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/ArrayIterator"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Array.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/ArrayIterator.js"),
       entries = $__0.entries,
       keys = $__0.keys,
       values = $__0.values;
-  var $__1 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var $__1 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       checkIterable = $__1.checkIterable,
       isCallable = $__1.isCallable,
       isConstructor = $__1.isConstructor,
@@ -2384,14 +2419,11 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Array", [], functi
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Array" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Object", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Array.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Object.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Object";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Object", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Object.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       maybeAddFunctions = $__0.maybeAddFunctions,
       registerPolyfill = $__0.registerPolyfill;
   var $__1 = $traceurRuntime,
@@ -2454,14 +2486,11 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Object", [], funct
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Object" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Number", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Object.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/Number.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/Number";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/Number", path);
-  }
-  var $__0 = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils"),
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/Number.js";
+  var $__0 = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js"),
       isNumber = $__0.isNumber,
       maybeAddConsts = $__0.maybeAddConsts,
       maybeAddFunctions = $__0.maybeAddFunctions,
@@ -2525,14 +2554,11 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/Number", [], funct
     }
   };
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/Number" + '');
-System.register("traceur-runtime@0.0.74/src/runtime/polyfills/polyfills", [], function() {
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/Number.js" + '');
+System.registerModule("traceur-runtime@0.0.76/src/runtime/polyfills/polyfills.js", [], function() {
   "use strict";
-  var __moduleName = "traceur-runtime@0.0.74/src/runtime/polyfills/polyfills";
-  function require(path) {
-    return $traceurRuntime.require("traceur-runtime@0.0.74/src/runtime/polyfills/polyfills", path);
-  }
-  var polyfillAll = System.get("traceur-runtime@0.0.74/src/runtime/polyfills/utils").polyfillAll;
+  var __moduleName = "traceur-runtime@0.0.76/src/runtime/polyfills/polyfills.js";
+  var polyfillAll = System.get("traceur-runtime@0.0.76/src/runtime/polyfills/utils.js").polyfillAll;
   polyfillAll(this);
   var setupGlobals = $traceurRuntime.setupGlobals;
   $traceurRuntime.setupGlobals = function(global) {
@@ -2541,7 +2567,7 @@ System.register("traceur-runtime@0.0.74/src/runtime/polyfills/polyfills", [], fu
   };
   return {};
 });
-System.get("traceur-runtime@0.0.74/src/runtime/polyfills/polyfills" + '');
+System.get("traceur-runtime@0.0.76/src/runtime/polyfills/polyfills.js" + '');
 </script>
 
     <script>
@@ -2780,7 +2806,7 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  {\n    var ba
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
@@ -4695,16 +4721,6 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var weakmap =
 test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof WeakMap.prototype.delete === \"function\";\n});\n")()}catch(e){return false;}}());
 </script>
 
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-(function() {
-  return typeof WeakMap.prototype.clear === &quot;function&quot;;
-});
-">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof WeakMap.prototype.clear === \"function\";\n});\n")()}catch(e){return false;}}());
-</script>
-
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -4757,16 +4773,6 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var weakset =
 });
 ">
 test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof WeakSet.prototype.delete === \"function\";\n});\n")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="&quot;use strict&quot;;
-(function() {
-  return typeof WeakSet.prototype.clear === &quot;function&quot;;
-});
-">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof WeakSet.prototype.clear === \"function\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -5021,6 +5027,26 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var proxied =
 });
 ">
 test(function(){try{return eval("\"use strict\";\n(function() {\n  var obj = Proxy.revocable({}, {get: function() {\n      return 5;\n    }});\n  var passed = (obj.proxy.foo === 5);\n  obj.revoke();\n  try {\n    obj.proxy.foo;\n  } catch (e) {\n    passed &= e instanceof TypeError;\n  }\n  return passed;\n});\n")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  return Array.isArray(new Proxy([], {}));
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return Array.isArray(new Proxy([], {}));\n});\n")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  return JSON.stringify(new Proxy(['foo'], {})) === '[&quot;foo&quot;]';
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -5306,7 +5332,7 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var $__0 = [9
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
   return (function($__0, $__1) {
@@ -5341,6 +5367,22 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return (funct
 });
 ">
 test(function(){try{return eval("\"use strict\";\n(function() {\n  var $__0 = [3, 4, 5],\n      a = $__0[0],\n      b = Array.prototype.slice.call($__0, 1);\n  var $__1 = [6],\n      c = $__1[0],\n      d = Array.prototype.slice.call($__1, 1);\n  return a === 3 && b instanceof Array && (b + \"\") === \"4,5\" && c === 6 && d instanceof Array && d.length === 0;\n});\n")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  var $__0,
+      $__1;
+  var a = [1, 2, 3],
+      first,
+      last;
+  ($__0 = a, first = $__0[0], ($__1 = Array.prototype.slice.call($__0, 1), a[2] = $__1[0], last = $__1[1], $__1), $__0);
+  return first === 1 && last === 3 && (a + &quot;&quot;) === &quot;1,2,2&quot;;
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  var $__0,\n      $__1;\n  var a = [1, 2, 3],\n      first,\n      last;\n  ($__0 = a, first = $__0[0], ($__1 = Array.prototype.slice.call($__0, 1), a[2] = $__1[0], last = $__1[1], $__1), $__0);\n  return first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -5768,13 +5810,13 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  return typeof String.prototype.contains === 'function' && &quot;foobar&quot;.contains(&quot;oba&quot;);
+  return typeof String.prototype.includes === 'function' && &quot;foobar&quot;.includes(&quot;oba&quot;);
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof String.prototype.contains === 'function' && \"foobar\".contains(\"oba\");\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof String.prototype.includes === 'function' && \"foobar\".includes(\"oba\");\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -5956,16 +5998,6 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  var a = [],\n
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="&quot;use strict&quot;;
-(function() {
-  return RegExp.prototype[Symbol.isRegExp] === true;
-});
-">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return RegExp.prototype[Symbol.isRegExp] === true;\n});\n")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
@@ -5989,6 +6021,16 @@ test(function(){try{return eval("\"use strict\";\n(function() {\n  return RegExp
 });
 ">
 test(function(){try{return eval("\"use strict\";\n(function() {\n  var a = 0,\n      b = {};\n  b[Symbol.iterator] = function() {\n    return {next: function() {\n        return {\n          done: a++ === 1,\n          value: \"foo\"\n        };\n      }};\n  };\n  var c;\n  for (var $__0 = b[$traceurRuntime.toProperty(Symbol.iterator)](),\n      $__1; !($__1 = $__0.next()).done; ) {\n    c = $__1.value;\n    {}\n  }\n  return c === \"foo\";\n});\n")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="&quot;use strict&quot;;
+(function() {
+  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);
+});
+">
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return RegExp[Symbol.species] === RegExp && Array[Symbol.species] === Array && !(Symbol.species in Object);\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -6043,43 +6085,43 @@ test(function(){try{return Function("/* Error during compilation: undefined*/")(
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  return typeof RegExp.prototype.match === 'function';
+  return typeof RegExp.prototype[Symbol.match] === 'function';
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype.match === 'function';\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype[Symbol.match] === 'function';\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  return typeof RegExp.prototype.replace === 'function';
+  return typeof RegExp.prototype[Symbol.replace] === 'function';
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype.replace === 'function';\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype[Symbol.replace] === 'function';\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  return typeof RegExp.prototype.split === 'function';
+  return typeof RegExp.prototype[Symbol.split] === 'function';
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype.split === 'function';\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype[Symbol.split] === 'function';\n});\n")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
 <script data-source="&quot;use strict&quot;;
 (function() {
-  return typeof RegExp.prototype.search === 'function';
+  return typeof RegExp.prototype[Symbol.search] === 'function';
 });
 ">
-test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype.search === 'function';\n});\n")()}catch(e){return false;}}());
+test(function(){try{return eval("\"use strict\";\n(function() {\n  return typeof RegExp.prototype[Symbol.search] === 'function';\n});\n")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/compilers/typescript.html
+++ b/es6/compilers/typescript.html
@@ -188,7 +188,7 @@ test(function(){try{return Function("/* Error during compilation: \n(2,3): error
 </script>
 
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/">
 test(function(){try{return Function("/* Error during compilation: This test's code invokes eval() and cannot be compiled.*/")()}catch(e){return false;}}());
 </script>
@@ -1711,15 +1711,6 @@ test(function(){try{return eval("(function () {\n    var weakmap = new WeakMap()
 test(function(){try{return eval("(function () {\n    return typeof WeakMap.prototype.delete === \"function\";\n});\n")()}catch(e){return false;}}());
 </script>
 
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="(function () {
-    return typeof WeakMap.prototype.clear === &quot;function&quot;;
-});
-">
-test(function(){try{return eval("(function () {\n    return typeof WeakMap.prototype.clear === \"function\";\n});\n")()}catch(e){return false;}}());
-</script>
-
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
@@ -1750,14 +1741,6 @@ test(function(){try{return Function("/* Error during compilation: \n(2,19): erro
 
         <tr class="subtest" data-parent="WeakSet">
           <td><span>WeakSet.prototype.delete</span></td>
-<script data-source="/* Error during compilation: 
-(2,15): error TS2304: Cannot find name 'WeakSet'.
-*/">
-test(function(){try{return Function("/* Error during compilation: \n(2,15): error TS2304: Cannot find name 'WeakSet'.\n*/")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
 <script data-source="/* Error during compilation: 
 (2,15): error TS2304: Cannot find name 'WeakSet'.
 */">
@@ -1889,6 +1872,22 @@ test(function(){try{return Function("/* Error during compilation: \n(4,9): error
 (8,3): error TS2447: The '&=' operator is not allowed for boolean types. Consider using '&&' instead.
 */">
 test(function(){try{return Function("/* Error during compilation: \n(2,11): error TS2304: Cannot find name 'Proxy'.\n(8,3): error TS2447: The '&=' operator is not allowed for boolean types. Consider using '&&' instead.\n*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="/* Error during compilation: 
+(2,26): error TS2304: Cannot find name 'Proxy'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,26): error TS2304: Cannot find name 'Proxy'.\n*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="/* Error during compilation: 
+(2,27): error TS2304: Cannot find name 'Proxy'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,27): error TS2304: Cannot find name 'Proxy'.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2084,7 +2083,7 @@ test(function(){try{return Function("/* Error during compilation: \n(2,5): error
 </script>
 
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="/* Error during compilation: 
 (2,18): error TS1005: ')' expected.
 (2,23): error TS1005: ';' expected.
@@ -2104,6 +2103,14 @@ test(function(){try{return Function("/* Error during compilation: \n(2,18): erro
 (3,9): error TS1137: Expression or comma expected.
 */">
 test(function(){try{return Function("/* Error during compilation: \n(2,5): error TS1134: Variable declaration expected.\n(2,9): error TS1137: Expression or comma expected.\n(3,5): error TS1134: Variable declaration expected.\n(3,9): error TS1137: Expression or comma expected.\n*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="/* Error during compilation: 
+(3,9): error TS1137: Expression or comma expected.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(3,9): error TS1137: Expression or comma expected.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="destructuring">
@@ -2449,12 +2456,12 @@ test(function(){try{return Function("/* Error during compilation: \n(2,32): erro
 </script>
 
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="/* Error during compilation: 
-(2,32): error TS2339: Property 'contains' does not exist on type 'String'.
-(3,15): error TS2339: Property 'contains' does not exist on type 'string'.
+(2,32): error TS2339: Property 'includes' does not exist on type 'String'.
+(3,15): error TS2339: Property 'includes' does not exist on type 'string'.
 */">
-test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2339: Property 'contains' does not exist on type 'String'.\n(3,15): error TS2339: Property 'contains' does not exist on type 'string'.\n*/")()}catch(e){return false;}}());
+test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2339: Property 'includes' does not exist on type 'String'.\n(3,15): error TS2339: Property 'includes' does not exist on type 'string'.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>
@@ -2569,20 +2576,23 @@ test(function(){try{return Function("/* Error during compilation: \n(3,3): error
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="/* Error during compilation: 
-(2,25): error TS2304: Cannot find name 'Symbol'.
-*/">
-test(function(){try{return Function("/* Error during compilation: \n(2,25): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
-</script>
-
-        <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
 <script data-source="/* Error during compilation: 
 (14,8): error TS1005: ';' expected.
 (14,11): error TS1005: ';' expected.
 */">
 test(function(){try{return Function("/* Error during compilation: \n(14,8): error TS1005: ';' expected.\n(14,11): error TS1005: ';' expected.\n*/")()}catch(e){return false;}}());
+</script>
+
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="/* Error during compilation: 
+(2,15): error TS2304: Cannot find name 'Symbol'.
+(3,12): error TS2304: Cannot find name 'Symbol'.
+(4,8): error TS2304: Cannot find name 'Symbol'.
+(4,8): error TS2360: The left-hand side of an 'in' expression must be of types 'any', 'string' or 'number'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,15): error TS2304: Cannot find name 'Symbol'.\n(3,12): error TS2304: Cannot find name 'Symbol'.\n(4,8): error TS2304: Cannot find name 'Symbol'.\n(4,8): error TS2360: The left-hand side of an 'in' expression must be of types 'any', 'string' or 'number'.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="well-known_symbols">
@@ -2621,39 +2631,35 @@ test(function(){try{return Function("/* Error during compilation: \n(3,3): error
           <td id="RegExp.prototype_methods"><span><a class="anchor" href="#RegExp.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype methods</a></span></td>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
-<script data-source="(function () {
-    return typeof RegExp.prototype.match === 'function';
-});
-">
-test(function(){try{return eval("(function () {\n    return typeof RegExp.prototype.match === 'function';\n});\n")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
+<script data-source="/* Error during compilation: 
+(2,32): error TS2304: Cannot find name 'Symbol'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
-<script data-source="(function () {
-    return typeof RegExp.prototype.replace === 'function';
-});
-">
-test(function(){try{return eval("(function () {\n    return typeof RegExp.prototype.replace === 'function';\n});\n")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
+<script data-source="/* Error during compilation: 
+(2,32): error TS2304: Cannot find name 'Symbol'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
-<script data-source="(function () {
-    return typeof RegExp.prototype.split === 'function';
-});
-">
-test(function(){try{return eval("(function () {\n    return typeof RegExp.prototype.split === 'function';\n});\n")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
+<script data-source="/* Error during compilation: 
+(2,32): error TS2304: Cannot find name 'Symbol'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
 </script>
 
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
-<script data-source="(function () {
-    return typeof RegExp.prototype.search === 'function';
-});
-">
-test(function(){try{return eval("(function () {\n    return typeof RegExp.prototype.search === 'function';\n});\n")()}catch(e){return false;}}());
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
+<script data-source="/* Error during compilation: 
+(2,32): error TS2304: Cannot find name 'Symbol'.
+*/">
+test(function(){try{return Function("/* Error during compilation: \n(2,32): error TS2304: Cannot find name 'Symbol'.\n*/")()}catch(e){return false;}}());
 </script>
 
         </tr>

--- a/es6/index.html
+++ b/es6/index.html
@@ -955,7 +955,7 @@ test(function(){try{return Function("\n{ const bar = 456; }\nreturn (function(){
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="const">
-          <td><span>redefining a const is a syntax error</span></td>
+          <td><span>redefining a const is an error</span></td>
 <script data-source="
 const baz = 1;
 try {
@@ -9257,55 +9257,55 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
         <tr class="supertest">
           <td id="WeakMap"><span><a class="anchor" href="#WeakMap">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
 
-          <td class="tally tr" data-tally="0">0/5</td>
-          <td class="tally _6to5" data-tally="0">0/5</td>
-          <td class="tally ejs" data-tally="0.4">2/5</td>
-          <td class="tally closure" data-tally="0">0/5</td>
-          <td class="tally ie10" data-tally="0">0/5</td>
-          <td class="tally ie11" data-tally="0.6">3/5</td>
-          <td class="tally ie11tp" data-tally="1">5/5</td>
-          <td class="tally firefox11 obsolete" data-tally="0.4">2/5</td>
-          <td class="tally firefox13 obsolete" data-tally="0.4">2/5</td>
-          <td class="tally firefox16 obsolete" data-tally="0.4">2/5</td>
-          <td class="tally firefox17 obsolete" data-tally="0.4">2/5</td>
-          <td class="tally firefox18 obsolete" data-tally="0.4">2/5</td>
-          <td class="tally firefox23 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox24 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox25 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox27 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox28 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox29 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox30 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox31" data-tally="0.6">3/5</td>
-          <td class="tally firefox32 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally firefox33" data-tally="0.8">4/5</td>
-          <td class="tally firefox34" data-tally="0.8">4/5</td>
-          <td class="tally firefox35" data-tally="0.8">4/5</td>
-          <td class="tally chrome obsolete" data-tally="0">0/5</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/5</td>
-          <td class="tally chrome21dev obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome30 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome31 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome33 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome34 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome35 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome36 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome37 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome38" data-tally="1">5/5</td>
-          <td class="tally chrome39" data-tally="1">5/5</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/5</td>
-          <td class="tally safari6" data-tally="0">0/5</td>
-          <td class="tally safari7" data-tally="0">0/5</td>
-          <td class="tally safari71_8" data-tally="0.8">4/5</td>
-          <td class="tally webkit" data-tally="0.8">4/5</td>
-          <td class="tally opera" data-tally="0">0/5</td>
-          <td class="tally konq49" data-tally="0">0/5</td>
-          <td class="tally rhino17" data-tally="0">0/5</td>
-          <td class="tally phantom" data-tally="0">0/5</td>
-          <td class="tally node" data-tally="0">0/5</td>
-          <td class="tally nodeharmony" data-tally="0.6">3/5</td>
-          <td class="tally ios7" data-tally="0">0/5</td>
-          <td class="tally ios8" data-tally="0.8">4/5</td>
+          <td class="tally tr" data-tally="0">0/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
+          <td class="tally ejs" data-tally="0.25">1/4</td>
+          <td class="tally closure" data-tally="0">0/4</td>
+          <td class="tally ie10" data-tally="0">0/4</td>
+          <td class="tally ie11" data-tally="0.5">2/4</td>
+          <td class="tally ie11tp" data-tally="1">4/4</td>
+          <td class="tally firefox11 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox13 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox16 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox17 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox18 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox23 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox24 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox25 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox27 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox28 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox29 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox30 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox31" data-tally="0.5">2/4</td>
+          <td class="tally firefox32 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally firefox33" data-tally="0.75">3/4</td>
+          <td class="tally firefox34" data-tally="0.75">3/4</td>
+          <td class="tally firefox35" data-tally="0.75">3/4</td>
+          <td class="tally chrome obsolete" data-tally="0">0/4</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
+          <td class="tally chrome21dev obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome30 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome31 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome33 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome34 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome35 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome36 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome37 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome38" data-tally="1">4/4</td>
+          <td class="tally chrome39" data-tally="1">4/4</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/4</td>
+          <td class="tally safari6" data-tally="0">0/4</td>
+          <td class="tally safari7" data-tally="0">0/4</td>
+          <td class="tally safari71_8" data-tally="0.75">3/4</td>
+          <td class="tally webkit" data-tally="0.75">3/4</td>
+          <td class="tally opera" data-tally="0">0/4</td>
+          <td class="tally konq49" data-tally="0">0/4</td>
+          <td class="tally rhino17" data-tally="0">0/4</td>
+          <td class="tally phantom" data-tally="0">0/4</td>
+          <td class="tally node" data-tally="0">0/4</td>
+          <td class="tally nodeharmony" data-tally="0.5">2/4</td>
+          <td class="tally ios7" data-tally="0">0/4</td>
+          <td class="tally ios8" data-tally="0.75">3/4</td>
         <tr class="subtest" data-parent="WeakMap">
           <td><span>basic functionality</span></td>
 <script data-source="
@@ -9546,116 +9546,59 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
           <td class="yes nodeharmony">Yes</td>
           <td class="no ios7">No</td>
           <td class="yes ios8">Yes</td>
-        <tr class="subtest" data-parent="WeakMap">
-          <td><span>WeakMap.prototype.clear</span></td>
-<script data-source="
-return typeof WeakMap.prototype.clear === &quot;function&quot;;
-      ">
-test(function(){try{return Function("\nreturn typeof WeakMap.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
-</script>
-
-          <td class="no tr">No</td>
-          <td class="no _6to5">No</td>
-          <td class="yes ejs">Yes</td>
-          <td class="no closure">No</td>
-          <td class="no ie10">No</td>
-          <td class="yes ie11">Yes</td>
-          <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24 obsolete">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox28 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32 obsolete">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes firefox35">Yes</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome31 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35 obsolete">Yes</td>
-          <td class="yes chrome36 obsolete">Yes</td>
-          <td class="yes chrome37 obsolete">Yes</td>
-          <td class="yes chrome38">Yes</td>
-          <td class="yes chrome39">Yes</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes</td>
-          <td class="yes webkit">Yes</td>
-          <td class="no opera">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no phantom">No</td>
-          <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes</td>
-          <td class="no ios7">No</td>
-          <td class="yes ios8">Yes</td>
         </tr>
         <tr class="supertest">
           <td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
 
-          <td class="tally tr" data-tally="0">0/5</td>
-          <td class="tally _6to5" data-tally="0">0/5</td>
-          <td class="tally ejs" data-tally="0.4">2/5</td>
-          <td class="tally closure" data-tally="0">0/5</td>
-          <td class="tally ie10" data-tally="0">0/5</td>
-          <td class="tally ie11" data-tally="0">0/5</td>
-          <td class="tally ie11tp" data-tally="1">5/5</td>
-          <td class="tally firefox11 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox13 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox16 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox17 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox18 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox23 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox24 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox25 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox27 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox28 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox29 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox30 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox31" data-tally="0">0/5</td>
-          <td class="tally firefox32 obsolete" data-tally="0">0/5</td>
-          <td class="tally firefox33" data-tally="0">0/5</td>
-          <td class="tally firefox34" data-tally="1">5/5</td>
-          <td class="tally firefox35" data-tally="1">5/5</td>
-          <td class="tally chrome obsolete" data-tally="0">0/5</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/5</td>
-          <td class="tally chrome21dev obsolete" data-tally="0">0/5</td>
-          <td class="tally chrome30 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome31 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome33 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome34 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome35 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome36 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome37 obsolete" data-tally="0.6">3/5</td>
-          <td class="tally chrome38" data-tally="1">5/5</td>
-          <td class="tally chrome39" data-tally="1">5/5</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/5</td>
-          <td class="tally safari6" data-tally="0">0/5</td>
-          <td class="tally safari7" data-tally="0">0/5</td>
-          <td class="tally safari71_8" data-tally="0">0/5</td>
-          <td class="tally webkit" data-tally="0">0/5</td>
-          <td class="tally opera" data-tally="0">0/5</td>
-          <td class="tally konq49" data-tally="0">0/5</td>
-          <td class="tally rhino17" data-tally="0">0/5</td>
-          <td class="tally phantom" data-tally="0">0/5</td>
-          <td class="tally node" data-tally="0">0/5</td>
-          <td class="tally nodeharmony" data-tally="0.6">3/5</td>
-          <td class="tally ios7" data-tally="0">0/5</td>
-          <td class="tally ios8" data-tally="0">0/5</td>
+          <td class="tally tr" data-tally="0">0/4</td>
+          <td class="tally _6to5" data-tally="0">0/4</td>
+          <td class="tally ejs" data-tally="0.25">1/4</td>
+          <td class="tally closure" data-tally="0">0/4</td>
+          <td class="tally ie10" data-tally="0">0/4</td>
+          <td class="tally ie11" data-tally="0">0/4</td>
+          <td class="tally ie11tp" data-tally="1">4/4</td>
+          <td class="tally firefox11 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox13 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox16 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox17 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox18 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox23 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox24 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox25 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox27 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox28 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox29 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox30 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox31" data-tally="0">0/4</td>
+          <td class="tally firefox32 obsolete" data-tally="0">0/4</td>
+          <td class="tally firefox33" data-tally="0">0/4</td>
+          <td class="tally firefox34" data-tally="1">4/4</td>
+          <td class="tally firefox35" data-tally="1">4/4</td>
+          <td class="tally chrome obsolete" data-tally="0">0/4</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/4</td>
+          <td class="tally chrome21dev obsolete" data-tally="0">0/4</td>
+          <td class="tally chrome30 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome31 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome33 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome34 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome35 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome36 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome37 obsolete" data-tally="0.5">2/4</td>
+          <td class="tally chrome38" data-tally="1">4/4</td>
+          <td class="tally chrome39" data-tally="1">4/4</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/4</td>
+          <td class="tally safari6" data-tally="0">0/4</td>
+          <td class="tally safari7" data-tally="0">0/4</td>
+          <td class="tally safari71_8" data-tally="0">0/4</td>
+          <td class="tally webkit" data-tally="0">0/4</td>
+          <td class="tally opera" data-tally="0">0/4</td>
+          <td class="tally konq49" data-tally="0">0/4</td>
+          <td class="tally rhino17" data-tally="0">0/4</td>
+          <td class="tally phantom" data-tally="0">0/4</td>
+          <td class="tally node" data-tally="0">0/4</td>
+          <td class="tally nodeharmony" data-tally="0.5">2/4</td>
+          <td class="tally ios7" data-tally="0">0/4</td>
+          <td class="tally ios8" data-tally="0">0/4</td>
         <tr class="subtest" data-parent="WeakSet">
           <td><span>basic functionality</span></td>
 <script data-source="
@@ -9895,116 +9838,59 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
           <td class="yes nodeharmony">Yes</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
-        <tr class="subtest" data-parent="WeakSet">
-          <td><span>WeakSet.prototype.clear</span></td>
-<script data-source="
-return typeof WeakSet.prototype.clear === &quot;function&quot;;
-      ">
-test(function(){try{return Function("\nreturn typeof WeakSet.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
-</script>
-
-          <td class="no tr">No</td>
-          <td class="no _6to5">No</td>
-          <td class="yes ejs">Yes</td>
-          <td class="no closure">No</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes firefox35">Yes</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome31 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35 obsolete">Yes</td>
-          <td class="yes chrome36 obsolete">Yes</td>
-          <td class="yes chrome37 obsolete">Yes</td>
-          <td class="yes chrome38">Yes</td>
-          <td class="yes chrome39">Yes</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no safari7">No</td>
-          <td class="no safari71_8">No</td>
-          <td class="no webkit">No</td>
-          <td class="no opera">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no phantom">No</td>
-          <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes</td>
-          <td class="no ios7">No</td>
-          <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
           <td id="Proxy"><span><a class="anchor" href="#Proxy">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
 
-          <td class="tally tr" data-tally="0">0/15</td>
-          <td class="tally _6to5" data-tally="0">0/15</td>
-          <td class="tally ejs" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally closure" data-tally="0">0/15</td>
-          <td class="tally ie10" data-tally="0">0/15</td>
-          <td class="tally ie11" data-tally="0">0/15</td>
-          <td class="tally ie11tp" data-tally="0.9333333333333333">14/15</td>
-          <td class="tally firefox11 obsolete" data-tally="0">0/15</td>
-          <td class="tally firefox13 obsolete" data-tally="0">0/15</td>
-          <td class="tally firefox16 obsolete" data-tally="0">0/15</td>
-          <td class="tally firefox17 obsolete" data-tally="0">0/15</td>
-          <td class="tally firefox18 obsolete" data-tally="0.4666666666666667">7/15</td>
-          <td class="tally firefox23 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox24 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox25 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox27 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox28 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox29 obsolete" data-tally="0.5333333333333333">8/15</td>
-          <td class="tally firefox30 obsolete" data-tally="0.6">9/15</td>
-          <td class="tally firefox31" data-tally="0.6666666666666666">10/15</td>
-          <td class="tally firefox32 obsolete" data-tally="0.6666666666666666">10/15</td>
-          <td class="tally firefox33" data-tally="0.7333333333333333">11/15</td>
-          <td class="tally firefox34" data-tally="0.8">12/15</td>
-          <td class="tally firefox35" data-tally="0.8">12/15</td>
-          <td class="tally chrome obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome21dev obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome30 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome31 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome33 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome34 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome35 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome36 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome37 obsolete" data-tally="0">0/15</td>
-          <td class="tally chrome38" data-tally="0">0/15</td>
-          <td class="tally chrome39" data-tally="0">0/15</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/15</td>
-          <td class="tally safari6" data-tally="0">0/15</td>
-          <td class="tally safari7" data-tally="0">0/15</td>
-          <td class="tally safari71_8" data-tally="0">0/15</td>
-          <td class="tally webkit" data-tally="0">0/15</td>
-          <td class="tally opera" data-tally="0">0/15</td>
-          <td class="tally konq49" data-tally="0">0/15</td>
-          <td class="tally rhino17" data-tally="0">0/15</td>
-          <td class="tally phantom" data-tally="0">0/15</td>
-          <td class="tally node" data-tally="0">0/15</td>
-          <td class="tally nodeharmony" data-tally="0">0/15</td>
-          <td class="tally ios7" data-tally="0">0/15</td>
-          <td class="tally ios8" data-tally="0">0/15</td>
+          <td class="tally tr" data-tally="0">0/17</td>
+          <td class="tally _6to5" data-tally="0">0/17</td>
+          <td class="tally ejs" data-tally="0.47058823529411764">8/17</td>
+          <td class="tally closure" data-tally="0">0/17</td>
+          <td class="tally ie10" data-tally="0">0/17</td>
+          <td class="tally ie11" data-tally="0">0/17</td>
+          <td class="tally ie11tp" data-tally="0.8235294117647058">14/17</td>
+          <td class="tally firefox11 obsolete" data-tally="0">0/17</td>
+          <td class="tally firefox13 obsolete" data-tally="0">0/17</td>
+          <td class="tally firefox16 obsolete" data-tally="0">0/17</td>
+          <td class="tally firefox17 obsolete" data-tally="0">0/17</td>
+          <td class="tally firefox18 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox23 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox24 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox25 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox27 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox28 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox29 obsolete" data-tally="0.5294117647058824">9/17</td>
+          <td class="tally firefox30 obsolete" data-tally="0.5882352941176471">10/17</td>
+          <td class="tally firefox31" data-tally="0.6470588235294118">11/17</td>
+          <td class="tally firefox32 obsolete" data-tally="0.6470588235294118">11/17</td>
+          <td class="tally firefox33" data-tally="0.7058823529411765">12/17</td>
+          <td class="tally firefox34" data-tally="0.7647058823529411">13/17</td>
+          <td class="tally firefox35" data-tally="0.7647058823529411">13/17</td>
+          <td class="tally chrome obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome21dev obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome30 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome31 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome33 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome34 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome35 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome36 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome37 obsolete" data-tally="0">0/17</td>
+          <td class="tally chrome38" data-tally="0">0/17</td>
+          <td class="tally chrome39" data-tally="0">0/17</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/17</td>
+          <td class="tally safari6" data-tally="0">0/17</td>
+          <td class="tally safari7" data-tally="0">0/17</td>
+          <td class="tally safari71_8" data-tally="0">0/17</td>
+          <td class="tally webkit" data-tally="0">0/17</td>
+          <td class="tally opera" data-tally="0">0/17</td>
+          <td class="tally konq49" data-tally="0">0/17</td>
+          <td class="tally rhino17" data-tally="0">0/17</td>
+          <td class="tally phantom" data-tally="0">0/17</td>
+          <td class="tally node" data-tally="0">0/17</td>
+          <td class="tally nodeharmony" data-tally="0">0/17</td>
+          <td class="tally ios7" data-tally="0">0/17</td>
+          <td class="tally ios8" data-tally="0">0/17</td>
         <tr class="subtest" data-parent="Proxy">
           <td><span>"get" handler</span></td>
 <script data-source="
@@ -10998,6 +10884,120 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>Array.isArray support</span></td>
+<script data-source="
+return Array.isArray(new Proxy([], {}));
+      ">
+test(function(){try{return Function("\nreturn Array.isArray(new Proxy([], {}));\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>JSON.stringify support</span></td>
+<script data-source="
+return JSON.stringify(new Proxy(['foo'], {})) === '[&quot;foo&quot;]';
+      ">
+test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
           <td id="Reflect"><span><a class="anchor" href="#Reflect">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
@@ -11941,55 +11941,55 @@ test(function(){try{return Function("\n'use strict';\n{\n  function f(){}\n}\nre
         <tr class="supertest">
           <td id="destructuring"><span><a class="anchor" href="#destructuring">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
 
-          <td class="tally tr" data-tally="0.8">8/10</td>
-          <td class="tally _6to5" data-tally="0.6">6/10</td>
-          <td class="tally ejs" data-tally="0.5">5/10</td>
-          <td class="tally closure" data-tally="0.8">8/10</td>
-          <td class="tally ie10" data-tally="0">0/10</td>
-          <td class="tally ie11" data-tally="0">0/10</td>
-          <td class="tally ie11tp" data-tally="0">0/10</td>
-          <td class="tally firefox11 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox13 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox16 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox17 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox18 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox23 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox24 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox25 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox27 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox28 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox29 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox30 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox31" data-tally="0.5">5/10</td>
-          <td class="tally firefox32 obsolete" data-tally="0.5">5/10</td>
-          <td class="tally firefox33" data-tally="0.5">5/10</td>
-          <td class="tally firefox34" data-tally="0.7">7/10</td>
-          <td class="tally firefox35" data-tally="0.7">7/10</td>
-          <td class="tally chrome obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome21dev obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome30 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome31 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome33 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome34 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome35 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome36 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome37 obsolete" data-tally="0">0/10</td>
-          <td class="tally chrome38" data-tally="0">0/10</td>
-          <td class="tally chrome39" data-tally="0">0/10</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/10</td>
-          <td class="tally safari6" data-tally="0">0/10</td>
-          <td class="tally safari7" data-tally="0">0/10</td>
-          <td class="tally safari71_8" data-tally="0.5">5/10</td>
-          <td class="tally webkit" data-tally="0.5">5/10</td>
-          <td class="tally opera" data-tally="0">0/10</td>
-          <td class="tally konq49" data-tally="0">0/10</td>
-          <td class="tally rhino17" data-tally="0">0/10</td>
-          <td class="tally phantom" data-tally="0">0/10</td>
-          <td class="tally node" data-tally="0">0/10</td>
-          <td class="tally nodeharmony" data-tally="0">0/10</td>
-          <td class="tally ios7" data-tally="0">0/10</td>
-          <td class="tally ios8" data-tally="0.5">5/10</td>
+          <td class="tally tr" data-tally="0.7272727272727273">8/11</td>
+          <td class="tally _6to5" data-tally="0.5454545454545454">6/11</td>
+          <td class="tally ejs" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally closure" data-tally="0.7272727272727273">8/11</td>
+          <td class="tally ie10" data-tally="0">0/11</td>
+          <td class="tally ie11" data-tally="0">0/11</td>
+          <td class="tally ie11tp" data-tally="0">0/11</td>
+          <td class="tally firefox11 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox13 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox16 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox17 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox18 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox23 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox24 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox25 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox27 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox28 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox29 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox30 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox31" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox32 obsolete" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox33" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally firefox34" data-tally="0.6363636363636364">7/11</td>
+          <td class="tally firefox35" data-tally="0.6363636363636364">7/11</td>
+          <td class="tally chrome obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome21dev obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome30 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome31 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome33 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome34 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome35 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome36 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome37 obsolete" data-tally="0">0/11</td>
+          <td class="tally chrome38" data-tally="0">0/11</td>
+          <td class="tally chrome39" data-tally="0">0/11</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/11</td>
+          <td class="tally safari6" data-tally="0">0/11</td>
+          <td class="tally safari7" data-tally="0">0/11</td>
+          <td class="tally safari71_8" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally webkit" data-tally="0.45454545454545453">5/11</td>
+          <td class="tally opera" data-tally="0">0/11</td>
+          <td class="tally konq49" data-tally="0">0/11</td>
+          <td class="tally rhino17" data-tally="0">0/11</td>
+          <td class="tally phantom" data-tally="0">0/11</td>
+          <td class="tally node" data-tally="0">0/11</td>
+          <td class="tally nodeharmony" data-tally="0">0/11</td>
+          <td class="tally ios7" data-tally="0">0/11</td>
+          <td class="tally ios8" data-tally="0.45454545454545453">5/11</td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>with arrays</span></td>
 <script data-source="
@@ -12341,7 +12341,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no ios7">No</td>
           <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
-          <td><span>parameters</span></td>
+          <td><span>in parameters</span></td>
 <script data-source="
 return (function({a, x:b, y:e}, [c, d]) {
   return a === 1 && b === 2 && c === 3 &&
@@ -12435,6 +12435,65 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
           <td class="no firefox33">No</td>
           <td class="yes firefox34">Yes</td>
           <td class="yes firefox35">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="destructuring">
+          <td><span>nested rest</span></td>
+<script data-source="
+var a = [1, 2, 3], first, last;
+[first, ...[a[2], last]] = a;
+return first === 1 && last === 3 && (a + &quot;&quot;) === &quot;1,2,2&quot;;
+      ">
+test(function(){try{return Function("\nvar a = [1, 2, 3], first, last;\n[first, ...[a[2], last]] = a;\nreturn first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -14159,9 +14218,9 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
         <tr class="supertest">
           <td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
 
-          <td class="tally tr" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally _6to5" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally ejs" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally tr" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally _6to5" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally ejs" data-tally="0.6666666666666666">4/6</td>
           <td class="tally closure" data-tally="0">0/6</td>
           <td class="tally ie10" data-tally="0">0/6</td>
           <td class="tally ie11" data-tally="0">0/6</td>
@@ -14170,42 +14229,42 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td class="tally firefox13 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox16 obsolete" data-tally="0">0/6</td>
           <td class="tally firefox17 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox18 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox23 obsolete" data-tally="0.5">3/6</td>
-          <td class="tally firefox24 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox25 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox27 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox28 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally firefox29 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally firefox30 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally firefox31" data-tally="1">6/6</td>
-          <td class="tally firefox32 obsolete" data-tally="1">6/6</td>
-          <td class="tally firefox33" data-tally="1">6/6</td>
-          <td class="tally firefox34" data-tally="1">6/6</td>
-          <td class="tally firefox35" data-tally="1">6/6</td>
+          <td class="tally firefox18 obsolete" data-tally="0.3333333333333333">2/6</td>
+          <td class="tally firefox23 obsolete" data-tally="0.3333333333333333">2/6</td>
+          <td class="tally firefox24 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox25 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox27 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox28 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally firefox29 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox30 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally firefox31" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally firefox32 obsolete" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally firefox33" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally firefox34" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally firefox35" data-tally="0.8333333333333334">5/6</td>
           <td class="tally chrome obsolete" data-tally="0">0/6</td>
           <td class="tally chrome19dev obsolete" data-tally="0">0/6</td>
           <td class="tally chrome21dev obsolete" data-tally="0">0/6</td>
-          <td class="tally chrome30 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally chrome31 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally chrome33 obsolete" data-tally="0.6666666666666666">4/6</td>
-          <td class="tally chrome34 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally chrome35 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally chrome36 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally chrome37 obsolete" data-tally="0.8333333333333334">5/6</td>
-          <td class="tally chrome38" data-tally="1">6/6</td>
-          <td class="tally chrome39" data-tally="1">6/6</td>
+          <td class="tally chrome30 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome31 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome33 obsolete" data-tally="0.5">3/6</td>
+          <td class="tally chrome34 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally chrome35 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally chrome36 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally chrome37 obsolete" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally chrome38" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally chrome39" data-tally="0.8333333333333334">5/6</td>
           <td class="tally safari51 obsolete" data-tally="0">0/6</td>
           <td class="tally safari6" data-tally="0">0/6</td>
           <td class="tally safari7" data-tally="0">0/6</td>
           <td class="tally safari71_8" data-tally="0">0/6</td>
-          <td class="tally webkit" data-tally="0.5">3/6</td>
+          <td class="tally webkit" data-tally="0.3333333333333333">2/6</td>
           <td class="tally opera" data-tally="0">0/6</td>
           <td class="tally konq49" data-tally="0">0/6</td>
           <td class="tally rhino17" data-tally="0">0/6</td>
           <td class="tally phantom" data-tally="0">0/6</td>
           <td class="tally node" data-tally="0">0/6</td>
-          <td class="tally nodeharmony" data-tally="0.6666666666666666">4/6</td>
+          <td class="tally nodeharmony" data-tally="0.5">3/6</td>
           <td class="tally ios7" data-tally="0">0/6</td>
           <td class="tally ios8" data-tally="0">0/6</td>
         <tr class="subtest" data-parent="String.prototype_methods">
@@ -14499,17 +14558,17 @@ test(function(){try{return Function("\nreturn typeof String.prototype.endsWith =
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="String.prototype_methods">
-          <td><span>String.prototype.contains</span></td>
+          <td><span>String.prototype.includes</span></td>
 <script data-source="
-return typeof String.prototype.contains === 'function'
-  && &quot;foobar&quot;.contains(&quot;oba&quot;);
+return typeof String.prototype.includes === 'function'
+  && &quot;foobar&quot;.includes(&quot;oba&quot;);
       ">
-test(function(){try{return Function("\nreturn typeof String.prototype.contains === 'function'\n  && \"foobar\".contains(\"oba\");\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="yes tr">Yes</td>
-          <td class="yes _6to5">Yes</td>
-          <td class="yes ejs">Yes</td>
+          <td class="no tr">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no _6to5">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no ejs">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14518,42 +14577,42 @@ test(function(){try{return Function("\nreturn typeof String.prototype.contains =
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes</td>
-          <td class="yes firefox23 obsolete">Yes</td>
-          <td class="yes firefox24 obsolete">Yes</td>
-          <td class="yes firefox25 obsolete">Yes</td>
-          <td class="yes firefox27 obsolete">Yes</td>
-          <td class="yes firefox28 obsolete">Yes</td>
-          <td class="yes firefox29 obsolete">Yes</td>
-          <td class="yes firefox30 obsolete">Yes</td>
-          <td class="yes firefox31">Yes</td>
-          <td class="yes firefox32 obsolete">Yes</td>
-          <td class="yes firefox33">Yes</td>
-          <td class="yes firefox34">Yes</td>
-          <td class="yes firefox35">Yes</td>
+          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox31">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox33">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox34">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox35">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
-          <td class="yes chrome30 obsolete">Yes</td>
-          <td class="yes chrome31 obsolete">Yes</td>
-          <td class="yes chrome33 obsolete">Yes</td>
-          <td class="yes chrome34 obsolete">Yes</td>
-          <td class="yes chrome35 obsolete">Yes</td>
-          <td class="yes chrome36 obsolete">Yes</td>
-          <td class="yes chrome37 obsolete">Yes</td>
-          <td class="yes chrome38">Yes</td>
-          <td class="yes chrome39">Yes</td>
+          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome38">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome39">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
           <td class="no safari71_8">No</td>
-          <td class="yes webkit">Yes</td>
+          <td class="no webkit">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="yes nodeharmony">Yes</td>
+          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -15409,63 +15468,6 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="well-known_symbols">
-          <td><span>Symbol.isRegExp</span></td>
-<script data-source="
-return RegExp.prototype[Symbol.isRegExp] === true;
-      ">
-test(function(){try{return Function("\nreturn RegExp.prototype[Symbol.isRegExp] === true;\n      ")()}catch(e){return false;}}());
-</script>
-
-          <td class="no tr">No</td>
-          <td class="no _6to5">No</td>
-          <td class="no ejs">No</td>
-          <td class="no closure">No</td>
-          <td class="no ie10">No</td>
-          <td class="no ie11">No</td>
-          <td class="no ie11tp">No</td>
-          <td class="no firefox11 obsolete">No</td>
-          <td class="no firefox13 obsolete">No</td>
-          <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No</td>
-          <td class="no firefox23 obsolete">No</td>
-          <td class="no firefox24 obsolete">No</td>
-          <td class="no firefox25 obsolete">No</td>
-          <td class="no firefox27 obsolete">No</td>
-          <td class="no firefox28 obsolete">No</td>
-          <td class="no firefox29 obsolete">No</td>
-          <td class="no firefox30 obsolete">No</td>
-          <td class="no firefox31">No</td>
-          <td class="no firefox32 obsolete">No</td>
-          <td class="no firefox33">No</td>
-          <td class="no firefox34">No</td>
-          <td class="no firefox35">No</td>
-          <td class="no chrome obsolete">No</td>
-          <td class="no chrome19dev obsolete">No</td>
-          <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30 obsolete">No</td>
-          <td class="no chrome31 obsolete">No</td>
-          <td class="no chrome33 obsolete">No</td>
-          <td class="no chrome34 obsolete">No</td>
-          <td class="no chrome35 obsolete">No</td>
-          <td class="no chrome36 obsolete">No</td>
-          <td class="no chrome37 obsolete">No</td>
-          <td class="no chrome38">No</td>
-          <td class="no chrome39">No</td>
-          <td class="no safari51 obsolete">No</td>
-          <td class="no safari6">No</td>
-          <td class="no safari7">No</td>
-          <td class="no safari71_8">No</td>
-          <td class="no webkit">No</td>
-          <td class="no opera">No</td>
-          <td class="no konq49">No</td>
-          <td class="no rhino17">No</td>
-          <td class="no phantom">No</td>
-          <td class="no node">No</td>
-          <td class="no nodeharmony">No</td>
-          <td class="no ios7">No</td>
-          <td class="no ios8">No</td>
-        <tr class="subtest" data-parent="well-known_symbols">
           <td><span>Symbol.iterator</span></td>
 <script data-source="
 var a = 0, b = {};
@@ -15522,6 +15524,65 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
           <td class="yes chrome37 obsolete">Yes</td>
           <td class="yes chrome38">Yes</td>
           <td class="yes chrome39">Yes</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="well-known_symbols">
+          <td><span>Symbol.species</span></td>
+<script data-source="
+return RegExp[Symbol.species] === RegExp
+  && Array[Symbol.species] === Array
+  && !(Symbol.species in Object);
+      ">
+test(function(){try{return Function("\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38">No</td>
+          <td class="no chrome39">No</td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -15775,11 +15836,11 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="tally ios7" data-tally="0">0/4</td>
           <td class="tally ios8" data-tally="0">0/4</td>
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.match</span></td>
+          <td><span>RegExp.prototype[Symbol.match]</span></td>
 <script data-source="
-return typeof RegExp.prototype.match === 'function';
+return typeof RegExp.prototype[Symbol.match] === 'function';
       ">
-test(function(){try{return Function("\nreturn typeof RegExp.prototype.match === 'function';\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -15832,11 +15893,11 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.match === 
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.replace</span></td>
+          <td><span>RegExp.prototype[Symbol.replace]</span></td>
 <script data-source="
-return typeof RegExp.prototype.replace === 'function';
+return typeof RegExp.prototype[Symbol.replace] === 'function';
       ">
-test(function(){try{return Function("\nreturn typeof RegExp.prototype.replace === 'function';\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -15889,11 +15950,11 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.replace ==
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.split</span></td>
+          <td><span>RegExp.prototype[Symbol.split]</span></td>
 <script data-source="
-return typeof RegExp.prototype.split === 'function';
+return typeof RegExp.prototype[Symbol.split] === 'function';
       ">
-test(function(){try{return Function("\nreturn typeof RegExp.prototype.split === 'function';\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -15946,11 +16007,11 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.split === 
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="RegExp.prototype_methods">
-          <td><span>RegExp.prototype.search</span></td>
+          <td><span>RegExp.prototype[Symbol.search]</span></td>
 <script data-source="
-return typeof RegExp.prototype.search === 'function';
+return typeof RegExp.prototype[Symbol.search] === 'function';
       ">
-test(function(){try{return Function("\nreturn typeof RegExp.prototype.search === 'function';\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -16526,20 +16587,20 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -16550,8 +16611,8 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
+          <td class="no chrome38">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -17283,7 +17344,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox35">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[16]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[17]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -18070,7 +18131,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[17]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[18]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -18231,7 +18292,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[19]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/5</td>
@@ -18981,23 +19042,26 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
       <p id="fx-destructuring-note">
         <sup>[12]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
+      <p id="string-contains-note">
+        <sup>[13]</sup> Available as the draft standard <code>String.prototype.contains</code>
+      </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[13]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[14]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[14]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[15]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[15]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[16]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[16]</sup> Available since Chrome 28
+        <sup>[17]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[17]</sup> Available since Firefox 26
+        <sup>[18]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[19]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This adds/removes/changes the following tests:
- RegExp.prototype methods
- Symbol.species
- String.prototype.includes
- WeakMap/WeakSet.prototype.clear
- Array.isArray on proxies
- JSON.stringify on proxies

This closes some but not all of #327.

It also includes a nested destructuring rest test (as described in #336) which I think is accurate, but maybe could do with an expert opinion.
