### PR TITLE
Several misc. fixes.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -478,7 +478,6 @@ exports.tests = [
         return !a.hasOwnProperty("prototype");
       */},
       res: {
-        tr:          true,
         ejs:         true,
         ie11tp:      true,
         firefox23:   true,
@@ -2581,12 +2580,27 @@ exports.tests = [
       res: {
         ejs:         true,
         ie11tp:      true,
+        firefox18:   true,
+      },
+    },
+    '"get" handler, instances of proxies': {
+      exec: function () {/*
+        var proxied = { };
+        var proxy = Object.create(new Proxy(proxied, {
+          get: function (t, k, r) {
+            return t === proxied && k === "foo" && r === proxy && 5;
+          }
+        }));
+        return proxy.foo === 5;
+      */},
+      res: {
+        ejs:         true,
+        ie11tp:      true,
         firefox18:   {
-          val: true,
+          val: false,
           note_id: 'fx-proxy-get',
-          note_html: 'Firefox doesn\'t allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy\'s "get" handler via the prototype chain, unless the proxied object actually does possess the named property.'
+          note_html: 'Firefox doesn\'t allow a proxy\'s "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy\'s "has" handler reports it as present).'
         },
-        firefox23:   { val: true, note_id: 'fx-proxy-get' },
       },
     },
     '"set" handler': {
@@ -2604,12 +2618,24 @@ exports.tests = [
       res: {
         ejs:         true,
         ie11tp:      true,
-        firefox18:   {
-          val: true,
-          note_id: 'fx-proxy-set',
-          note_html: 'Firefox doesn\'t allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy\'s "set" handler via the prototype chain.'
-        },
-        firefox23:   { val: true, note_id: 'fx-proxy-set' },
+        firefox18:   true,
+      },
+    },
+    '"set" handler, instances of proxies': {
+      exec: function () {/*
+        var proxied = { };
+        var passed = false;
+        var proxy = Object.create(new Proxy(proxied, {
+          set: function (t, k, v, r) {
+            passed = t === proxied && k + v === "foobar" && r === proxy;
+          }
+        }));
+        proxy.foo = "bar";
+        return passed;
+      */},
+      res: {
+        ejs:         true,
+        ie11tp:      true,
       },
     },
     '"has" handler': {
@@ -2621,6 +2647,23 @@ exports.tests = [
             passed = t === proxied && k === "foo";
           }
         });
+        return passed;
+      */},
+      res: {
+        ejs:         true,
+        ie11tp:      true,
+        firefox18:   true,
+      },
+    },
+    '"has" handler, instances of proxies': {
+      exec: function () {/*
+        var proxied = {};
+        var passed = false;
+        "foo" in Object.create(new Proxy(proxied, {
+          has: function (t, k) {
+            passed = t === proxied && k === "foo";
+          }
+        }));
         return passed;
       */},
       res: {
@@ -4382,14 +4425,15 @@ exports.tests = [
         firefox27:   {
           val: false,
           note_id: 'fx-array-prototype-values-2',
-          note_html: 'Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>'
+          note_html: 'Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>'
         },
-        chrome30:    true,
-        chrome38:    {
+        firefox36:   {
           val: false,
           note_id: 'array-prototype-iterator',
           note_html: 'Available as <code>Array.prototype[Symbol.iterator]</code>'
         },
+        chrome30:    true,
+        chrome38:    { val: false, note_id: 'array-prototype-iterator' },
         nodeharmony: true,
       },
     },
@@ -4816,18 +4860,30 @@ exports.tests = [
       res: {
       },
     },
+    'accessors aren\'t constructors': {
+      exec: function(){/*
+        try {
+          new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;
+        } catch(e) {
+          return true;
+        }
+      */},
+      res: {
+      },
+    },
     'Object static methods accept primitives': {
       exec: function(){/*
-        var methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptors',
-          'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys'];
+        var methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',
+          'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];
         for (var i = 0; i < methods.length; i++) {
-          Object[methods[i]](2);
-          Object[methods[i]]("foo");
-          Object[methods[i]](false);
+          Object[methods[i]](20000, "foo");
+          Object[methods[i]]("foo", "foo");
+          Object[methods[i]](false, "foo");
         }
         return true;
       */},
       res: {
+        firefox35:   true,
       },
     },
     'Invalid Date': {

--- a/es6/index.html
+++ b/es6/index.html
@@ -217,7 +217,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
         <tr class="supertest">
           <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 
-          <td class="tally tr" data-tally="0.7777777777777778">7/9</td>
+          <td class="tally tr" data-tally="0.6666666666666666">6/9</td>
           <td class="tally _6to5" data-tally="0.7777777777777778">7/9</td>
           <td class="tally ejs" data-tally="0.7777777777777778">7/9</td>
           <td class="tally closure" data-tally="0.6666666666666666">6/9</td>
@@ -769,7 +769,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnProperty(\"prototype\");\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="yes tr">Yes</td>
+          <td class="no tr">No</td>
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
@@ -10474,58 +10474,58 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
         <tr class="supertest">
           <td id="Proxy"><span><a class="anchor" href="#Proxy">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
 
-          <td class="tally tr" data-tally="0">0/17</td>
-          <td class="tally _6to5" data-tally="0">0/17</td>
-          <td class="tally ejs" data-tally="0.47058823529411764">8/17</td>
-          <td class="tally closure" data-tally="0">0/17</td>
-          <td class="tally typescript" data-tally="0">0/17</td>
-          <td class="tally ie10" data-tally="0">0/17</td>
-          <td class="tally ie11" data-tally="0">0/17</td>
-          <td class="tally ie11tp" data-tally="0.8235294117647058">14/17</td>
-          <td class="tally firefox11 obsolete" data-tally="0">0/17</td>
-          <td class="tally firefox13 obsolete" data-tally="0">0/17</td>
-          <td class="tally firefox16 obsolete" data-tally="0">0/17</td>
-          <td class="tally firefox17 obsolete" data-tally="0">0/17</td>
-          <td class="tally firefox18 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox23 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox24 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox25 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox27 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox28 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox29 obsolete" data-tally="0.5294117647058824">9/17</td>
-          <td class="tally firefox30 obsolete" data-tally="0.5882352941176471">10/17</td>
-          <td class="tally firefox31" data-tally="0.6470588235294118">11/17</td>
-          <td class="tally firefox32 obsolete" data-tally="0.6470588235294118">11/17</td>
-          <td class="tally firefox33 obsolete" data-tally="0.7058823529411765">12/17</td>
-          <td class="tally firefox34" data-tally="0.7647058823529411">13/17</td>
-          <td class="tally firefox35" data-tally="0.7647058823529411">13/17</td>
-          <td class="tally firefox36" data-tally="0.7647058823529411">13/17</td>
-          <td class="tally chrome obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome19dev obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome21dev obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome30 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome31 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome33 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome34 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome35 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome36 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome37 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome38 obsolete" data-tally="0">0/17</td>
-          <td class="tally chrome39" data-tally="0">0/17</td>
-          <td class="tally chrome40" data-tally="0">0/17</td>
-          <td class="tally safari51 obsolete" data-tally="0">0/17</td>
-          <td class="tally safari6" data-tally="0">0/17</td>
-          <td class="tally safari7" data-tally="0">0/17</td>
-          <td class="tally safari71_8" data-tally="0">0/17</td>
-          <td class="tally webkit" data-tally="0">0/17</td>
-          <td class="tally opera" data-tally="0">0/17</td>
-          <td class="tally konq49" data-tally="0">0/17</td>
-          <td class="tally rhino17" data-tally="0">0/17</td>
-          <td class="tally phantom" data-tally="0">0/17</td>
-          <td class="tally node" data-tally="0">0/17</td>
-          <td class="tally nodeharmony" data-tally="0">0/17</td>
-          <td class="tally ios7" data-tally="0">0/17</td>
-          <td class="tally ios8" data-tally="0">0/17</td>
+          <td class="tally tr" data-tally="0">0/20</td>
+          <td class="tally _6to5" data-tally="0">0/20</td>
+          <td class="tally ejs" data-tally="0.55">11/20</td>
+          <td class="tally closure" data-tally="0">0/20</td>
+          <td class="tally typescript" data-tally="0">0/20</td>
+          <td class="tally ie10" data-tally="0">0/20</td>
+          <td class="tally ie11" data-tally="0">0/20</td>
+          <td class="tally ie11tp" data-tally="0.85">17/20</td>
+          <td class="tally firefox11 obsolete" data-tally="0">0/20</td>
+          <td class="tally firefox13 obsolete" data-tally="0">0/20</td>
+          <td class="tally firefox16 obsolete" data-tally="0">0/20</td>
+          <td class="tally firefox17 obsolete" data-tally="0">0/20</td>
+          <td class="tally firefox18 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox23 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox24 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox25 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox27 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox28 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox29 obsolete" data-tally="0.5">10/20</td>
+          <td class="tally firefox30 obsolete" data-tally="0.55">11/20</td>
+          <td class="tally firefox31" data-tally="0.6">12/20</td>
+          <td class="tally firefox32 obsolete" data-tally="0.6">12/20</td>
+          <td class="tally firefox33 obsolete" data-tally="0.65">13/20</td>
+          <td class="tally firefox34" data-tally="0.7">14/20</td>
+          <td class="tally firefox35" data-tally="0.7">14/20</td>
+          <td class="tally firefox36" data-tally="0.7">14/20</td>
+          <td class="tally chrome obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome19dev obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome21dev obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome30 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome31 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome33 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome34 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome35 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome36 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome37 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome38 obsolete" data-tally="0">0/20</td>
+          <td class="tally chrome39" data-tally="0">0/20</td>
+          <td class="tally chrome40" data-tally="0">0/20</td>
+          <td class="tally safari51 obsolete" data-tally="0">0/20</td>
+          <td class="tally safari6" data-tally="0">0/20</td>
+          <td class="tally safari7" data-tally="0">0/20</td>
+          <td class="tally safari71_8" data-tally="0">0/20</td>
+          <td class="tally webkit" data-tally="0">0/20</td>
+          <td class="tally opera" data-tally="0">0/20</td>
+          <td class="tally konq49" data-tally="0">0/20</td>
+          <td class="tally rhino17" data-tally="0">0/20</td>
+          <td class="tally phantom" data-tally="0">0/20</td>
+          <td class="tally node" data-tally="0">0/20</td>
+          <td class="tally nodeharmony" data-tally="0">0/20</td>
+          <td class="tally ios7" data-tally="0">0/20</td>
+          <td class="tally ios8" data-tally="0">0/20</td>
         <tr class="subtest" data-parent="Proxy">
           <td><span>"get" handler</span></td>
 <script data-source="
@@ -10552,20 +10552,86 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox33 obsolete">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox35">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="yes firefox36">Yes<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33 obsolete">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="yes firefox36">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38 obsolete">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no chrome40">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>"get" handler, instances of proxies</span></td>
+<script data-source="
+var proxied = { };
+var proxy = Object.create(new Proxy(proxied, {
+  get: function (t, k, r) {
+    return t === proxied && k === &quot;foo&quot; && r === proxy && 5;
+  }
+}));
+return proxy.foo === 5;
+      ">
+test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
+          <td class="no typescript">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10620,20 +10686,88 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="yes firefox18 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox23 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox24 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox25 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox28 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox29 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox30 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox31">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox32 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox33 obsolete">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox34">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox35">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
-          <td class="yes firefox36">Yes<a href="#fx-proxy-set-note"><sup>[8]</sup></a></td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33 obsolete">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="yes firefox36">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38 obsolete">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no chrome40">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>"set" handler, instances of proxies</span></td>
+<script data-source="
+var proxied = { };
+var passed = false;
+var proxy = Object.create(new Proxy(proxied, {
+  set: function (t, k, v, r) {
+    passed = t === proxied && k + v === &quot;foobar&quot; && r === proxy;
+  }
+}));
+proxy.foo = &quot;bar&quot;;
+return passed;
+      ">
+test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
+          <td class="no typescript">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33 obsolete">No</td>
+          <td class="no firefox34">No</td>
+          <td class="no firefox35">No</td>
+          <td class="no firefox36">No</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10673,6 +10807,73 @@ var passed = false;
 return passed;
       ">
 test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="yes ejs">Yes</td>
+          <td class="no closure">No</td>
+          <td class="no typescript">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="yes ie11tp">Yes</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="yes firefox18 obsolete">Yes</td>
+          <td class="yes firefox23 obsolete">Yes</td>
+          <td class="yes firefox24 obsolete">Yes</td>
+          <td class="yes firefox25 obsolete">Yes</td>
+          <td class="yes firefox27 obsolete">Yes</td>
+          <td class="yes firefox28 obsolete">Yes</td>
+          <td class="yes firefox29 obsolete">Yes</td>
+          <td class="yes firefox30 obsolete">Yes</td>
+          <td class="yes firefox31">Yes</td>
+          <td class="yes firefox32 obsolete">Yes</td>
+          <td class="yes firefox33 obsolete">Yes</td>
+          <td class="yes firefox34">Yes</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="yes firefox36">Yes</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38 obsolete">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no chrome40">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="Proxy">
+          <td><span>"has" handler, instances of proxies</span></td>
+<script data-source="
+var proxied = {};
+var passed = false;
+&quot;foo&quot; in Object.create(new Proxy(proxied, {
+  has: function (t, k) {
+    passed = t === proxied && k === &quot;foo&quot;;
+  }
+}));
+return passed;
+      ">
+test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -10827,13 +11028,13 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32 obsolete">Yes</td>
@@ -11318,16 +11519,16 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
           <td class="yes firefox33 obsolete">Yes</td>
           <td class="yes firefox34">Yes</td>
           <td class="yes firefox35">Yes</td>
@@ -12608,7 +12809,7 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[10]</sup></a></span></td>
 <script data-source="
 'use strict';
 function f() { return 1; }
@@ -12779,7 +12980,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -12788,7 +12989,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>with strings</span></td>
 <script data-source="
@@ -12840,7 +13041,7 @@ test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -12849,7 +13050,7 @@ test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>with generic iterables</span></td>
 <script data-source="
@@ -13025,7 +13226,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -13034,7 +13235,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>nested</span></td>
 <script data-source="
@@ -13086,7 +13287,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
-          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes safari71_8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
           <td class="yes webkit">Yes</td>
           <td class="no opera">No</td>
           <td class="no konq49">No</td>
@@ -13095,7 +13296,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
           <td class="no ios7">No</td>
-          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[12]</sup></a></td>
+          <td class="yes ios8">Yes<a href="#fx-destructuring-note"><sup>[11]</sup></a></td>
         <tr class="subtest" data-parent="destructuring">
           <td><span>in parameters</span></td>
 <script data-source="
@@ -13721,7 +13922,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
 </script>
 
           <td class="no tr">No</td>
-          <td class="no _6to5">No<a href="#setprototypeof-polyfill-note"><sup>[13]</sup></a></td>
+          <td class="no _6to5">No<a href="#setprototypeof-polyfill-note"><sup>[12]</sup></a></td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
           <td class="no typescript">No</td>
@@ -15437,8 +15638,8 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
 </script>
 
           <td class="yes tr">Yes</td>
-          <td class="no _6to5">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no ejs">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no _6to5">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no ejs">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
@@ -15448,33 +15649,33 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox31">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox34">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox35">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox36">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox31">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox34">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox35">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox36">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome39">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome40">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome39">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome40">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -15485,7 +15686,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -17619,21 +17820,21 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[15]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[15]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[15]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[15]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[15]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-array-prototype-values-2-note"><sup>[16]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox36">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -17644,9 +17845,9 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[17]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[17]</sup></a></td>
-          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[17]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -18416,7 +18617,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox36">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[18]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[17]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -19244,7 +19445,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[19]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[18]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -19344,58 +19545,58 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
         <tr class="supertest">
           <td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
 
-          <td class="tally tr" data-tally="0">0/6</td>
-          <td class="tally _6to5" data-tally="0">0/6</td>
-          <td class="tally ejs" data-tally="0">0/6</td>
-          <td class="tally closure" data-tally="0">0/6</td>
-          <td class="tally typescript" data-tally="0">0/6</td>
-          <td class="tally ie10" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally ie11" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally ie11tp" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox11 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox13 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox16 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox17 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox18 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox23 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox24 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox25 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox27 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox28 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox29 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox30 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox31" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox32 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox33 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox34" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally firefox35" data-tally="0.5">3/6</td>
-          <td class="tally firefox36" data-tally="0.5">3/6</td>
-          <td class="tally chrome obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome19dev obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome21dev obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome30 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome31 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome33 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome34 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome35 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome36 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome37 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome38 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome39" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally chrome40" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally safari51 obsolete" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally safari6" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally safari7" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally safari71_8" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally webkit" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally opera" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally konq49" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally rhino17" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally phantom" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally node" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally nodeharmony" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally ios7" data-tally="0.3333333333333333">2/6</td>
-          <td class="tally ios8" data-tally="0.3333333333333333">2/6</td>
+          <td class="tally tr" data-tally="0">0/7</td>
+          <td class="tally _6to5" data-tally="0">0/7</td>
+          <td class="tally ejs" data-tally="0">0/7</td>
+          <td class="tally closure" data-tally="0">0/7</td>
+          <td class="tally typescript" data-tally="0">0/7</td>
+          <td class="tally ie10" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally ie11" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally ie11tp" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox11 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox13 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox16 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox17 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox18 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox23 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox24 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox25 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox27 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox28 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox29 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox30 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox31" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox32 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox33 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox34" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally firefox35" data-tally="0.5714285714285714">4/7</td>
+          <td class="tally firefox36" data-tally="0.5714285714285714">4/7</td>
+          <td class="tally chrome obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome19dev obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome21dev obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome30 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome31 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome33 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome34 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome35 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome36 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome37 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome38 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome39" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally chrome40" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally safari51 obsolete" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally safari6" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally safari7" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally safari71_8" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally webkit" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally opera" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally konq49" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally rhino17" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally phantom" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally node" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally nodeharmony" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally ios7" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally ios8" data-tally="0.2857142857142857">2/7</td>
         <tr class="subtest" data-parent="miscellaneous">
           <td><span>duplicate property names in strict mode</span></td>
 <script data-source="
@@ -19583,18 +19784,15 @@ test(function(){try{return Function("\ntry {\n  eval('for (var i = 0 in {}) {}')
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         <tr class="subtest" data-parent="miscellaneous">
-          <td><span>Object static methods accept primitives</span></td>
+          <td><span>accessors aren't constructors</span></td>
 <script data-source="
-var methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptors',
-  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys'];
-for (var i = 0; i < methods.length; i++) {
-  Object[methods[i]](2);
-  Object[methods[i]](&quot;foo&quot;);
-  Object[methods[i]](false);
+try {
+  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;
+} catch(e) {
+  return true;
 }
-return true;
       ">
-test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptors',\n  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys'];\nfor (var i = 0; i < methods.length; i++) {\n  Object[methods[i]](2);\n  Object[methods[i]](\"foo\");\n  Object[methods[i]](false);\n}\nreturn true;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
@@ -19623,6 +19821,73 @@ test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'prevent
           <td class="no firefox34">No</td>
           <td class="no firefox35">No</td>
           <td class="no firefox36">No</td>
+          <td class="no chrome obsolete">No</td>
+          <td class="no chrome19dev obsolete">No</td>
+          <td class="no chrome21dev obsolete">No</td>
+          <td class="no chrome30 obsolete">No</td>
+          <td class="no chrome31 obsolete">No</td>
+          <td class="no chrome33 obsolete">No</td>
+          <td class="no chrome34 obsolete">No</td>
+          <td class="no chrome35 obsolete">No</td>
+          <td class="no chrome36 obsolete">No</td>
+          <td class="no chrome37 obsolete">No</td>
+          <td class="no chrome38 obsolete">No</td>
+          <td class="no chrome39">No</td>
+          <td class="no chrome40">No</td>
+          <td class="no safari51 obsolete">No</td>
+          <td class="no safari6">No</td>
+          <td class="no safari7">No</td>
+          <td class="no safari71_8">No</td>
+          <td class="no webkit">No</td>
+          <td class="no opera">No</td>
+          <td class="no konq49">No</td>
+          <td class="no rhino17">No</td>
+          <td class="no phantom">No</td>
+          <td class="no node">No</td>
+          <td class="no nodeharmony">No</td>
+          <td class="no ios7">No</td>
+          <td class="no ios8">No</td>
+        <tr class="subtest" data-parent="miscellaneous">
+          <td><span>Object static methods accept primitives</span></td>
+<script data-source="
+var methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',
+  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];
+for (var i = 0; i < methods.length; i++) {
+  Object[methods[i]](20000, &quot;foo&quot;);
+  Object[methods[i]](&quot;foo&quot;, &quot;foo&quot;);
+  Object[methods[i]](false, &quot;foo&quot;);
+}
+return true;
+      ">
+test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',\n  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];\nfor (var i = 0; i < methods.length; i++) {\n  Object[methods[i]](20000, \"foo\");\n  Object[methods[i]](\"foo\", \"foo\");\n  Object[methods[i]](false, \"foo\");\n}\nreturn true;\n      ")()}catch(e){return false;}}());
+</script>
+
+          <td class="no tr">No</td>
+          <td class="no _6to5">No</td>
+          <td class="no ejs">No</td>
+          <td class="no closure">No</td>
+          <td class="no typescript">No</td>
+          <td class="no ie10">No</td>
+          <td class="no ie11">No</td>
+          <td class="no ie11tp">No</td>
+          <td class="no firefox11 obsolete">No</td>
+          <td class="no firefox13 obsolete">No</td>
+          <td class="no firefox16 obsolete">No</td>
+          <td class="no firefox17 obsolete">No</td>
+          <td class="no firefox18 obsolete">No</td>
+          <td class="no firefox23 obsolete">No</td>
+          <td class="no firefox24 obsolete">No</td>
+          <td class="no firefox25 obsolete">No</td>
+          <td class="no firefox27 obsolete">No</td>
+          <td class="no firefox28 obsolete">No</td>
+          <td class="no firefox29 obsolete">No</td>
+          <td class="no firefox30 obsolete">No</td>
+          <td class="no firefox31">No</td>
+          <td class="no firefox32 obsolete">No</td>
+          <td class="no firefox33 obsolete">No</td>
+          <td class="no firefox34">No</td>
+          <td class="yes firefox35">Yes</td>
+          <td class="yes firefox36">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -19842,7 +20107,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[20]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[19]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/5</td>
@@ -20592,6 +20857,10 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
       </tbody>
     </table>
     <div id="footnotes">
+      <div id="create-iterable-object">
+        <code>__createIterableObject()</code>, used in the numerous "generic iterables" tests, is defined as:
+        <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
+      </div>
       <p id="ie-experimental-flag-note">
         <sup>[1]</sup> Have to be enabled via "Experimental Web Platform Features" flag
       </p>
@@ -20611,46 +20880,43 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
         <sup>[6]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
       <p id="fx-proxy-get-note">
-        <sup>[7]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "get" handler via the prototype chain, unless the proxied object actually does possess the named property.
-      </p>
-      <p id="fx-proxy-set-note">
-        <sup>[8]</sup> Firefox doesn't allow inheritors of a proxy (such as objects created by <code>Object.create(proxy)</code>) to trigger the proxy's "set" handler via the prototype chain.
+        <sup>[7]</sup> Firefox doesn't allow a proxy's "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy's "has" handler reports it as present).
       </p>
       <p id="fx-proxy-getown-note">
-        <sup>[9]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+        <sup>[8]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
       </p>
       <p id="fx-proxy-ownkeys-note">
-        <sup>[10]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+        <sup>[9]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
       </p>
       <p id="block-level-function-note">
-        <sup>[11]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[10]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="fx-destructuring-note">
-        <sup>[12]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
+        <sup>[11]</sup> Safari 7.1, Safari 8 and iOS 8 fail to support multiple destructurings in a single <code>var</code> or <code>let</code> statement - for example, <code>var [a,b] = [5,6], {c,d} = {c:7,d:8};</code>
       </p>
       <p id="setprototypeof-polyfill-note">
-        <sup>[13]</sup> Requires native support for <code>Object.prototype.__proto__</code>
+        <sup>[12]</sup> Requires native support for <code>Object.prototype.__proto__</code>
       </p>
       <p id="string-contains-note">
-        <sup>[14]</sup> Available as the draft standard <code>String.prototype.contains</code>
+        <sup>[13]</sup> Available as the draft standard <code>String.prototype.contains</code>
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[15]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[14]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[16]</sup> Available since Firefox 27 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[15]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[17]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[16]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[18]</sup> Available since Chrome 28
+        <sup>[17]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[19]</sup> Available since Firefox 26
+        <sup>[18]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[20]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[19]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
     </div>
   </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -100,6 +100,10 @@
       </tbody>
     </table>
     <div id="footnotes">
+      <div id="create-iterable-object">
+        <code>__createIterableObject()</code>, used in the numerous "generic iterables" tests, is defined as:
+        <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
+      </div>
       <!-- FOOTNOTES -->
     </div>
   </div>


### PR DESCRIPTION
- Fixed the 'Object static methods accept primitives' misc. test (closes #347).
- Added an 'accessors aren't constructors' misc. test.
- Fixed the Traceur result for the 'no "prototype" property' arrow test.
- Added a footnote explaining `__createIterableObject()`.
- Fixed a Firefox footnote for Array.prototype.values.
- Added two more Proxy tests involving the prototype chain, partially replacing the two Firefox notes about 'get' and 'set'.
