### PR TITLE
Added React JSX results

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,6 +32,7 @@ var to5        = require('6to5');
 var esnext     = require('esnext');
 var es6tr      = require('es6-transpiler');
 var traceur    = require('traceur');
+var reacttools = require('react-tools');
 
 var useCompilers = String(process.argv[2]).toLowerCase() === "compilers";
 
@@ -94,6 +95,16 @@ process.nextTick(function () {
       polyfills: [],
       compiler: function(code) {
         return es6tr.run({src:code}).src;
+      },
+    },
+    {
+      name: 'JSX',
+      url: 'https://github.com/facebook/react',
+      target_file: 'es6/compilers/jsx.html',
+      polyfills: [],
+      compiler: function(code) {
+        var ret = reacttools.transform(code, { harmony:true });
+        return ret.code || ret;
       },
     },
     {

--- a/data-es6.js
+++ b/data-es6.js
@@ -33,6 +33,14 @@ exports.browsers = {
     obsolete: false,
     platformtype: 'compiler',
   },
+  jsx: {
+    full: 'JSX',
+    short: 'JSX',
+    obsolete: false,
+    platformtype: 'compiler',
+    note_id: 'jsx-flag',
+    note_html: 'Have to be enabled via <code>harmony</code> option'
+  },
   typescript: {
     full: 'TypeScript 1.3',
     short: 'TypeScript',
@@ -363,6 +371,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         closure:     true,
@@ -379,6 +388,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         closure:     true,
@@ -395,6 +405,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         closure:     true,
@@ -412,6 +423,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         closure:     true,
@@ -428,6 +440,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         ie11tp:      true,
@@ -443,6 +456,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         typescript:  true,
         ejs:         true,
         closure:     true,
@@ -900,6 +914,7 @@ exports.tests = [
     _6to5:       true,
     ejs:         true,
     closure:     true,
+    jsx:         true,
     typescript:  true,
     ie10:        false,
     ie11:        false,
@@ -1065,6 +1080,7 @@ exports.tests = [
         tr:          true,
         _6to5:       true,
         ejs:         true,
+        jsx:         true,
         closure:     true,
         ie11tp:      true,
         chrome40:    true,
@@ -1092,6 +1108,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1109,6 +1126,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1127,6 +1145,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1144,6 +1163,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1160,6 +1180,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ie11tp:      true,
       },
     },
@@ -1268,6 +1289,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1282,6 +1304,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         typescript:  true,
@@ -1806,6 +1829,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1831,6 +1855,7 @@ exports.tests = [
         tr:          true,
         ejs:         true,
         _6to5:       true,
+        jsx:         true,
         closure:     true,
         firefox34:   true,
       },
@@ -3240,6 +3265,7 @@ exports.tests = [
       res: (temp.destructuringResults = {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
@@ -3253,16 +3279,17 @@ exports.tests = [
         var [a, b, c] = "bar";
         return a === "b" && b === "a" && c === "r";
       */},
-      res: (temp.destructuringResults = {
+      res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
         safari71_8:  true,
         webkit:      true,
         ios8:        true,
-      }),
+      },
     },
     'with generic iterables': {
       exec: function(){/*
@@ -3301,6 +3328,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
@@ -3324,6 +3352,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         firefox11:   true,
@@ -3374,6 +3403,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        jsx:         true,
         closure:     true,
         firefox34:   true,
       },
@@ -3693,7 +3723,7 @@ exports.tests = [
           [sym2]: function(){}
         };
 
-        return o[sym].name === "[foo]" &&
+        return o[sym1].name === "[foo]" &&
                o[sym2].name === "";
       */},
       res: {},

--- a/es6/index.html
+++ b/es6/index.html
@@ -96,10 +96,11 @@
           <th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr></th>
           <th class="platform ejs compiler"><a href="#ejs" class="browser-name"><abbr title="Echo JS">EJS</abbr></th>
           <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141023">Closure<br>Compiler</abbr></th>
+          <th class="platform jsx compiler"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[1]</sup></a></th>
           <th class="platform typescript compiler"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.3">TypeScript</abbr></th>
           <th class="platform ie10 desktop"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></th>
           <th class="platform ie11 desktop"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></th>
-          <th class="platform ie11tp desktop"><a href="#ie11tp" class="browser-name"><abbr title="Internet Explorer">IE<br>Technical<br>Preview</abbr><a href="#ie-experimental-flag-note"><sup>[1]</sup></a></th>
+          <th class="platform ie11tp desktop"><a href="#ie11tp" class="browser-name"><abbr title="Internet Explorer">IE<br>Technical<br>Preview</abbr><a href="#ie-experimental-flag-note"><sup>[2]</sup></a></th>
           <th class="platform firefox11 obsolete desktop"><a href="#firefox11" class="browser-name"><abbr title="Firefox">FF 11-12</abbr></th>
           <th class="platform firefox13 obsolete desktop"><a href="#firefox13" class="browser-name"><abbr title="Firefox">FF 13</abbr></th>
           <th class="platform firefox16 obsolete desktop"><a href="#firefox16" class="browser-name"><abbr title="Firefox">FF 16</abbr></th>
@@ -119,29 +120,29 @@
           <th class="platform firefox35 desktop"><a href="#firefox35" class="browser-name"><abbr title="Firefox">FF 35</abbr></th>
           <th class="platform firefox36 desktop"><a href="#firefox36" class="browser-name"><abbr title="Firefox">FF 36</abbr></th>
           <th class="platform chrome obsolete desktop"><a href="#chrome" class="browser-name"><abbr title="Chrome">CH &lt;19</abbr></th>
-          <th class="platform chrome19dev obsolete desktop"><a href="#chrome19dev" class="browser-name"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome21dev obsolete desktop"><a href="#chrome21dev" class="browser-name"><abbr title="Chrome">CH 21-29</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome30 obsolete desktop"><a href="#chrome30" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;30,<br>OP&nbsp;17</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome31 obsolete desktop"><a href="#chrome31" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;31,<br>OP&nbsp;18</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome33 obsolete desktop"><a href="#chrome33" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;32-33,<br>OP&nbsp;19-20</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome34 obsolete desktop"><a href="#chrome34" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;34,<br>OP&nbsp;21</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome35 obsolete desktop"><a href="#chrome35" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;35,<br>OP&nbsp;22</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome36 obsolete desktop"><a href="#chrome36" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;36,<br>OP&nbsp;23</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome37 obsolete desktop"><a href="#chrome37" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;37,<br>OP&nbsp;24</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome38 obsolete desktop"><a href="#chrome38" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;38,<br>OP&nbsp;25</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome39 desktop"><a href="#chrome39" class="browser-name"><abbr title="Chrome, Opera">CH 39,<br>OP&nbsp;26</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
-          <th class="platform chrome40 desktop"><a href="#chrome40" class="browser-name"><abbr title="Chrome, Opera">CH 40,<br>OP&nbsp;27</abbr><a href="#experimental-flag-note"><sup>[2]</sup></a></th>
+          <th class="platform chrome19dev obsolete desktop"><a href="#chrome19dev" class="browser-name"><abbr title="Chrome">CH 19</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome21dev obsolete desktop"><a href="#chrome21dev" class="browser-name"><abbr title="Chrome">CH 21-29</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome30 obsolete desktop"><a href="#chrome30" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;30,<br>OP&nbsp;17</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome31 obsolete desktop"><a href="#chrome31" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;31,<br>OP&nbsp;18</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome33 obsolete desktop"><a href="#chrome33" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;32-33,<br>OP&nbsp;19-20</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome34 obsolete desktop"><a href="#chrome34" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;34,<br>OP&nbsp;21</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome35 obsolete desktop"><a href="#chrome35" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;35,<br>OP&nbsp;22</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome36 obsolete desktop"><a href="#chrome36" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;36,<br>OP&nbsp;23</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome37 obsolete desktop"><a href="#chrome37" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;37,<br>OP&nbsp;24</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome38 obsolete desktop"><a href="#chrome38" class="browser-name"><abbr title="Chrome, Opera">CH&nbsp;38,<br>OP&nbsp;25</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome39 desktop"><a href="#chrome39" class="browser-name"><abbr title="Chrome, Opera">CH 39,<br>OP&nbsp;26</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
+          <th class="platform chrome40 desktop"><a href="#chrome40" class="browser-name"><abbr title="Chrome, Opera">CH 40,<br>OP&nbsp;27</abbr><a href="#experimental-flag-note"><sup>[3]</sup></a></th>
           <th class="platform safari51 obsolete desktop"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></th>
           <th class="platform safari6 desktop"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></th>
           <th class="platform safari7 desktop"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 7.0</abbr></th>
           <th class="platform safari71_8 desktop"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></th>
           <th class="platform webkit desktop"><a href="#webkit" class="browser-name"><abbr title="WebKit r176637">WK</abbr></th>
           <th class="platform opera desktop"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></th>
-          <th class="platform konq49 desktop"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[3]</sup></a></th>
+          <th class="platform konq49 desktop"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[4]</sup></a></th>
           <th class="platform rhino17 engine"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></th>
           <th class="platform phantom engine"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></th>
           <th class="platform node engine"><a href="#node" class="browser-name"><abbr title="Node 0.10">Node</abbr></th>
-          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node<br>harmony</abbr><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+          <th class="platform nodeharmony engine"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.14 harmony">Node<br>harmony</abbr><a href="#harmony-flag-note"><sup>[5]</sup></a></th>
           <th class="platform ios7 mobile"><a href="#ios7" class="browser-name"><abbr title="iOS Safari">iOS7</abbr></th>
           <th class="platform ios8 mobile"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS8</abbr></th>
         </tr>
@@ -165,6 +166,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -221,6 +223,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
           <td class="tally _6to5" data-tally="0.7777777777777778">7/9</td>
           <td class="tally ejs" data-tally="0.7777777777777778">7/9</td>
           <td class="tally closure" data-tally="0.6666666666666666">6/9</td>
+          <td class="tally jsx" data-tally="0.6666666666666666">6/9</td>
           <td class="tally typescript" data-tally="0.6666666666666666">6/9</td>
           <td class="tally ie10" data-tally="0">0/9</td>
           <td class="tally ie11" data-tally="0">0/9</td>
@@ -281,6 +284,7 @@ test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}cat
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -342,6 +346,7 @@ test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fe
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -403,6 +408,7 @@ test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w +
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -465,6 +471,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -527,6 +534,7 @@ test(function(){try{return Function("\nvar d = { x : \"foo\", y : function() { r
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -589,6 +597,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -650,6 +659,7 @@ test(function(){try{return Function("\nvar f = (function() { return z => argumen
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -712,6 +722,7 @@ test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -773,6 +784,7 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -829,6 +841,7 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
           <td class="tally _6to5" data-tally="0.5">4/8</td>
           <td class="tally ejs" data-tally="1">8/8</td>
           <td class="tally closure" data-tally="0.75">6/8</td>
+          <td class="tally jsx" data-tally="0">0/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="1">8/8</td>
@@ -890,6 +903,7 @@ test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -952,6 +966,7 @@ test(function(){try{return Function("\nconst bar = 123;\n{ const bar = 456; }\nr
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1017,6 +1032,7 @@ test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1079,6 +1095,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try { qux; } ca
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1141,6 +1158,7 @@ test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1204,6 +1222,7 @@ test(function(){try{return Function("\n'use strict';\nconst bar = 123;\n{ const 
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1270,6 +1289,7 @@ test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  F
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1333,6 +1353,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1389,6 +1410,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="tally _6to5" data-tally="0.8">8/10</td>
           <td class="tally ejs" data-tally="1">10/10</td>
           <td class="tally closure" data-tally="0.8">8/10</td>
+          <td class="tally jsx" data-tally="0">0/10</td>
           <td class="tally typescript" data-tally="0">0/10</td>
           <td class="tally ie10" data-tally="0">0/10</td>
           <td class="tally ie11" data-tally="0.8">8/10</td>
@@ -1450,28 +1472,29 @@ test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n  
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1512,28 +1535,29 @@ test(function(){try{return Function("\nlet bar = 123;\n{ let bar = 456; }\nretur
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1574,28 +1598,29 @@ test(function(){try{return Function("\nlet baz = 1;\nfor(let baz = 0; false; fal
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1636,6 +1661,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1656,8 +1682,8 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33 obsolete">No</td>
           <td class="no firefox34">No</td>
-          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[7]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-tdz-note"><sup>[7]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -1707,6 +1733,7 @@ test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -1769,28 +1796,29 @@ test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (fo
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1832,28 +1860,29 @@ test(function(){try{return Function("\n'use strict';\nlet bar = 123;\n{ let bar 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1895,28 +1924,29 @@ test(function(){try{return Function("\n'use strict';\nlet baz = 1;\nfor(let baz 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
           <td class="yes ie11tp">Yes</td>
-          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-note"><sup>[5]</sup></a></td>
+          <td class="no firefox11 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox13 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox16 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-note"><sup>[6]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -1958,6 +1988,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1978,8 +2009,8 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
           <td class="no firefox32 obsolete">No</td>
           <td class="no firefox33 obsolete">No</td>
           <td class="no firefox34">No</td>
-          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-let-tdz-note"><sup>[6]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-let-tdz-note"><sup>[7]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-let-tdz-note"><sup>[7]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="yes chrome19dev obsolete">Yes</td>
           <td class="yes chrome21dev obsolete">Yes</td>
@@ -2030,6 +2061,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2086,6 +2118,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
           <td class="tally _6to5" data-tally="0.8">4/5</td>
           <td class="tally ejs" data-tally="0.6">3/5</td>
           <td class="tally closure" data-tally="0.6">3/5</td>
+          <td class="tally jsx" data-tally="0">0/5</td>
           <td class="tally typescript" data-tally="0.6">3/5</td>
           <td class="tally ie10" data-tally="0">0/5</td>
           <td class="tally ie11" data-tally="0">0/5</td>
@@ -2146,6 +2179,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2206,6 +2240,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2266,6 +2301,7 @@ test(function(){try{return Function("\nreturn (function (a, b = a) { return b ==
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2336,6 +2372,7 @@ test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    e
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2401,6 +2438,7 @@ test(function(){try{return Function("\nreturn (function(a=function(){\n  return 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2462,6 +2500,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2518,6 +2557,7 @@ test(function(){try{return Function("\nreturn (function (...args) { return typeo
           <td class="tally _6to5" data-tally="1">8/8</td>
           <td class="tally ejs" data-tally="0.75">6/8</td>
           <td class="tally closure" data-tally="0.25">2/8</td>
+          <td class="tally jsx" data-tally="0">0/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
@@ -2578,6 +2618,7 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n    
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2638,6 +2679,7 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2698,6 +2740,7 @@ test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n    
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2758,6 +2801,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2819,6 +2863,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2880,6 +2925,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -2941,6 +2987,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3002,6 +3049,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3058,6 +3106,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b
           <td class="tally _6to5" data-tally="1">8/8</td>
           <td class="tally ejs" data-tally="0.75">6/8</td>
           <td class="tally closure" data-tally="0.75">6/8</td>
+          <td class="tally jsx" data-tally="0.75">6/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
@@ -3119,6 +3168,7 @@ test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"functio
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3185,6 +3235,7 @@ test(function(){try{return Function("\nclass C {}\nvar c1 = C;\n{\n  class C {}\
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3245,6 +3296,7 @@ test(function(){try{return Function("\nreturn typeof class C {} === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3309,6 +3361,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3374,6 +3427,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  method()
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3439,6 +3493,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() {}\n  static m
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3503,6 +3558,7 @@ test(function(){try{return Function("\nvar c = class C {\n  static method() { re
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3565,6 +3621,7 @@ test(function(){try{return Function("\nclass C extends Array {}\nreturn Array.is
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3621,6 +3678,7 @@ test(function(){try{return Function("\nclass C extends Array {}\nreturn Array.is
           <td class="tally _6to5" data-tally="1">3/3</td>
           <td class="tally ejs" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="0">0/3</td>
+          <td class="tally jsx" data-tally="0">0/3</td>
           <td class="tally typescript" data-tally="0">0/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
@@ -3686,6 +3744,7 @@ test(function(){try{return Function("\nclass B extends class {\n  constructor(a)
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3751,6 +3810,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux(a) { retur
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3820,6 +3880,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3876,6 +3937,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
           <td class="tally _6to5" data-tally="1">3/3</td>
           <td class="tally ejs" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="1">3/3</td>
+          <td class="tally jsx" data-tally="0.6666666666666666">2/3</td>
           <td class="tally typescript" data-tally="0.3333333333333333">1/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
@@ -3937,6 +3999,7 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3998,6 +4061,7 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4058,6 +4122,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4114,6 +4179,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
           <td class="tally _6to5" data-tally="1">4/4</td>
           <td class="tally ejs" data-tally="0.75">3/4</td>
           <td class="tally closure" data-tally="0.75">3/4</td>
+          <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
@@ -4176,6 +4242,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4239,6 +4306,7 @@ test(function(){try{return Function("\nvar str = \"\";\nfor (var item of \"foo\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4304,6 +4372,7 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4369,6 +4438,7 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4425,6 +4495,7 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td class="tally _6to5" data-tally="0.75">9/12</td>
           <td class="tally ejs" data-tally="0">0/12</td>
           <td class="tally closure" data-tally="0.5">6/12</td>
+          <td class="tally jsx" data-tally="0">0/12</td>
           <td class="tally typescript" data-tally="0">0/12</td>
           <td class="tally ie10" data-tally="0">0/12</td>
           <td class="tally ie11" data-tally="0">0/12</td>
@@ -4495,6 +4566,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4565,6 +4637,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield this.x; 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4633,6 +4706,7 @@ test(function(){try{return Function("\nvar sent;\nfunction * generator(){\n  sen
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4702,6 +4776,7 @@ test(function(){try{return Function("\nfunction * generatorFn(){}\nvar ownProto 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4773,6 +4848,7 @@ test(function(){try{return Function("\nvar passed = false;\nfunction * generator
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4843,6 +4919,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4910,6 +4987,7 @@ test(function(){try{return Function("\nvar passed;\nfunction * generator(){\n  p
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4979,6 +5057,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5048,6 +5127,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5119,6 +5199,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5190,6 +5271,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5262,6 +5344,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5318,6 +5401,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
           <td class="tally _6to5" data-tally="0.5">2/4</td>
           <td class="tally ejs" data-tally="1">4/4</td>
           <td class="tally closure" data-tally="1">4/4</td>
+          <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
@@ -5378,6 +5462,7 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      "
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5438,6 +5523,7 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      "
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5498,6 +5584,7 @@ test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}c
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5558,6 +5645,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5614,6 +5702,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
           <td class="tally _6to5" data-tally="1">2/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="1">2/2</td>
+          <td class="tally jsx" data-tally="1">2/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
@@ -5676,6 +5765,7 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5747,6 +5837,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5803,6 +5894,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
           <td class="tally _6to5" data-tally="0.5">1/2</td>
           <td class="tally ejs" data-tally="0">0/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
+          <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
@@ -5867,6 +5959,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5927,6 +6020,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -5983,6 +6077,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
           <td class="tally _6to5" data-tally="0">0/40</td>
           <td class="tally ejs" data-tally="0.45">18/40</td>
           <td class="tally closure" data-tally="0">0/40</td>
+          <td class="tally jsx" data-tally="0">0/40</td>
           <td class="tally typescript" data-tally="0">0/40</td>
           <td class="tally ie10" data-tally="0.4">16/40</td>
           <td class="tally ie11" data-tally="0.4">16/40</td>
@@ -6045,6 +6140,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6107,6 +6203,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6169,6 +6266,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -6231,6 +6329,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6293,6 +6392,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6355,6 +6455,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6417,6 +6518,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6479,6 +6581,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6541,6 +6644,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6604,6 +6708,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6667,6 +6772,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6730,6 +6836,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6793,6 +6900,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6856,6 +6964,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6919,6 +7028,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -6982,6 +7092,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -7045,6 +7156,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -7113,6 +7225,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.from === \"functi
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7181,6 +7294,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7249,6 +7363,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarra
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7317,6 +7432,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7385,6 +7501,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7453,6 +7570,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastInd
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7521,6 +7639,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7589,6 +7708,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7657,6 +7777,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7725,6 +7846,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7793,6 +7915,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map ===
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7861,6 +7984,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7929,6 +8053,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceR
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -7997,6 +8122,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8065,6 +8191,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8133,6 +8260,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8201,6 +8329,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWit
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8269,6 +8398,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8337,6 +8467,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findInd
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8405,6 +8536,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8473,6 +8605,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8541,6 +8674,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8609,6 +8743,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8665,6 +8800,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
           <td class="tally _6to5" data-tally="1">11/11</td>
           <td class="tally ejs" data-tally="0.8181818181818182">9/11</td>
           <td class="tally closure" data-tally="0">0/11</td>
+          <td class="tally jsx" data-tally="0">0/11</td>
           <td class="tally typescript" data-tally="0">0/11</td>
           <td class="tally ie10" data-tally="0">0/11</td>
           <td class="tally ie11" data-tally="0.45454545454545453">5/11</td>
@@ -8730,6 +8866,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -8795,6 +8932,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar map =
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8856,6 +8994,7 @@ test(function(){try{return Function("\nvar map = new Map();\nreturn map.set(0, 0
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8922,6 +9061,7 @@ test(function(){try{return Function("\nvar map = new Map();\nmap.set(-0, \"foo\"
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -8987,6 +9127,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9047,6 +9188,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.delete === \"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9107,6 +9249,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.clear === \"f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9167,6 +9310,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.forEach === \
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9227,6 +9371,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.keys === \"fu
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9287,6 +9432,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.values === \"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9347,6 +9493,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9403,6 +9550,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
           <td class="tally _6to5" data-tally="1">11/11</td>
           <td class="tally ejs" data-tally="0.8181818181818182">9/11</td>
           <td class="tally closure" data-tally="0">0/11</td>
+          <td class="tally jsx" data-tally="0">0/11</td>
           <td class="tally typescript" data-tally="0">0/11</td>
           <td class="tally ie10" data-tally="0">0/11</td>
           <td class="tally ie11" data-tally="0.45454545454545453">5/11</td>
@@ -9469,6 +9617,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9533,6 +9682,7 @@ test(function(){try{return Function("\nvar obj1 = {};\nvar obj2 = {};\nvar set =
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9594,6 +9744,7 @@ test(function(){try{return Function("\nvar set = new Set();\nreturn set.add(0) =
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9660,6 +9811,7 @@ test(function(){try{return Function("\nvar set = new Set();\nset.add(-0);\nvar k
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -9727,6 +9879,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9787,6 +9940,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.delete === \"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9847,6 +10001,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.clear === \"f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9907,6 +10062,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.forEach === \
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -9967,6 +10123,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.keys === \"fu
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10027,6 +10184,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.values === \"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10087,6 +10245,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10143,6 +10302,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
           <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="0.25">1/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
+          <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0.5">2/4</td>
@@ -10208,6 +10368,7 @@ test(function(){try{return Function("\nvar key = {};\nvar weakmap = new WeakMap(
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -10273,6 +10434,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar weakm
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10335,6 +10497,7 @@ test(function(){try{return Function("\nvar weakmap = new WeakMap();\nvar key = {
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10395,6 +10558,7 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -10451,6 +10615,7 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
           <td class="tally _6to5" data-tally="0">0/4</td>
           <td class="tally ejs" data-tally="0.25">1/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
+          <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0">0/4</td>
@@ -10517,6 +10682,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10580,6 +10746,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10642,6 +10809,7 @@ test(function(){try{return Function("\nvar weakset = new WeakSet();\nvar obj = {
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10702,6 +10870,7 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10758,6 +10927,7 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
           <td class="tally _6to5" data-tally="0">0/20</td>
           <td class="tally ejs" data-tally="0.55">11/20</td>
           <td class="tally closure" data-tally="0">0/20</td>
+          <td class="tally jsx" data-tally="0">0/20</td>
           <td class="tally typescript" data-tally="0">0/20</td>
           <td class="tally ie10" data-tally="0">0/20</td>
           <td class="tally ie11" data-tally="0">0/20</td>
@@ -10824,6 +10994,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10890,6 +11061,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.cr
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -10898,20 +11070,20 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.cr
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-proxy-get-note"><sup>[7]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-proxy-get-note"><sup>[8]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -10958,6 +11130,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11026,6 +11199,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11093,6 +11267,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11160,6 +11335,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11227,6 +11403,7 @@ test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11300,6 +11477,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11308,13 +11486,13 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[8]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[9]</sup></a></td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32 obsolete">Yes</td>
@@ -11372,6 +11550,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11439,6 +11618,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nv
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11511,6 +11691,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nva
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11580,6 +11761,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11650,6 +11832,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11722,6 +11905,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nf
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11791,6 +11975,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11799,16 +11984,16 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[9]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[10]</sup></a></td>
           <td class="yes firefox33 obsolete">Yes</td>
           <td class="yes firefox34">Yes</td>
           <td class="yes firefox35">Yes</td>
@@ -11861,6 +12046,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11929,6 +12115,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -11997,6 +12184,7 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12057,6 +12245,7 @@ test(function(){try{return Function("\nreturn Array.isArray(new Proxy([], {}));\
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12117,6 +12306,7 @@ test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12173,6 +12363,7 @@ test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], 
           <td class="tally _6to5" data-tally="0">0/14</td>
           <td class="tally ejs" data-tally="1">14/14</td>
           <td class="tally closure" data-tally="0">0/14</td>
+          <td class="tally jsx" data-tally="0">0/14</td>
           <td class="tally typescript" data-tally="0">0/14</td>
           <td class="tally ie10" data-tally="0">0/14</td>
           <td class="tally ie11" data-tally="0">0/14</td>
@@ -12233,6 +12424,7 @@ test(function(){try{return Function("\nreturn Reflect.get({ qux: 987 }, \"qux\")
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12295,6 +12487,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.set(obj, \"quux\",
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12355,6 +12548,7 @@ test(function(){try{return Function("\nreturn Reflect.has({ qux: 987 }, \"qux\")
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12417,6 +12611,7 @@ test(function(){try{return Function("\nvar obj = { bar: 456 };\nReflect.deletePr
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12480,6 +12675,7 @@ test(function(){try{return Function("\nvar obj = { baz: 789 };\nvar desc = Refle
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12542,6 +12738,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.defineProperty(obj
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12602,6 +12799,7 @@ test(function(){try{return Function("\nreturn Reflect.getPrototypeOf([]) === Arr
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12664,6 +12862,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.setPrototypeOf(obj
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12725,6 +12924,7 @@ test(function(){try{return Function("\nreturn Reflect.isExtensible({}) &&\n  !Re
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12787,6 +12987,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.preventExtensions(
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12856,6 +13057,7 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nvar iterat
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12917,6 +13119,7 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nreturn Ref
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -12977,6 +13180,7 @@ test(function(){try{return Function("\nreturn Reflect.apply(Array.prototype.push
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13039,6 +13243,7 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13089,7 +13294,7 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[10]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span></td>
 <script data-source="
 'use strict';
 function f() { return 1; }
@@ -13105,6 +13310,7 @@ test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -13161,6 +13367,7 @@ test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }
           <td class="tally _6to5" data-tally="0.8571428571428571">12/14</td>
           <td class="tally ejs" data-tally="0.42857142857142855">6/14</td>
           <td class="tally closure" data-tally="0.7857142857142857">11/14</td>
+          <td class="tally jsx" data-tally="0.5">7/14</td>
           <td class="tally typescript" data-tally="0">0/14</td>
           <td class="tally ie10" data-tally="0">0/14</td>
           <td class="tally ie11" data-tally="0">0/14</td>
@@ -13222,6 +13429,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13283,6 +13491,7 @@ test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13345,6 +13554,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13407,6 +13617,7 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13468,6 +13679,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13529,6 +13741,7 @@ test(function(){try{return Function("\nvar [a,b] = [5,6], {c,d} = {c:7,d:8};\nre
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13590,6 +13803,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13653,6 +13867,7 @@ test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13715,6 +13930,7 @@ test(function(){try{return Function("\nfor(var [i, j, k] in { qux: 1 }) {\n  ret
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13777,6 +13993,7 @@ test(function(){try{return Function("\nfor(var [i, j, k] of [[1,2,3]]) {\n  retu
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13840,6 +14057,7 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13902,6 +14120,7 @@ test(function(){try{return Function("\nvar a = [1, 2, 3], first, last;\n[first, 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -13963,6 +14182,7 @@ test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undef
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14026,6 +14246,7 @@ test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14088,6 +14309,7 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14144,6 +14366,7 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
           <td class="tally _6to5" data-tally="0.5">2/4</td>
           <td class="tally ejs" data-tally="1">4/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
+          <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
           <td class="tally ie10" data-tally="0">0/4</td>
           <td class="tally ie11" data-tally="0.25">1/4</td>
@@ -14205,6 +14428,7 @@ test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true},
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14267,6 +14491,7 @@ test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14330,6 +14555,7 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] 
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14387,9 +14613,10 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
 </script>
 
           <td class="no tr">No</td>
-          <td class="no _6to5">No<a href="#setprototypeof-polyfill-note"><sup>[11]</sup></a></td>
+          <td class="no _6to5">No<a href="#setprototypeof-polyfill-note"><sup>[12]</sup></a></td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -14446,6 +14673,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
           <td class="tally _6to5" data-tally="0">0/16</td>
           <td class="tally ejs" data-tally="0">0/16</td>
           <td class="tally closure" data-tally="0">0/16</td>
+          <td class="tally jsx" data-tally="0">0/16</td>
           <td class="tally typescript" data-tally="0">0/16</td>
           <td class="tally ie10" data-tally="0">0/16</td>
           <td class="tally ie11" data-tally="0">0/16</td>
@@ -14508,6 +14736,7 @@ test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'f
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14569,6 +14798,7 @@ test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14629,6 +14859,7 @@ test(function(){try{return Function("\nreturn (new Function).name === \"anonymou
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14691,6 +14922,7 @@ test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).n
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14753,6 +14985,7 @@ test(function(){try{return Function("\nvar foo = function() {};\nvar bar = funct
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14817,6 +15050,7 @@ test(function(){try{return Function("\nvar o = { foo: function(){}, bar: functio
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14880,6 +15114,7 @@ test(function(){try{return Function("\nvar o = { get foo(){}, set foo(x){} };\nv
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14941,6 +15176,7 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -14999,16 +15235,17 @@ var o = {
   [sym2]: function(){}
 };
 
-return o[sym].name === &quot;[foo]&quot; &&
+return o[sym1].name === &quot;[foo]&quot; &&
        o[sym2].name === &quot;&quot;;
       ">
-test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15072,6 +15309,7 @@ test(function(){try{return Function("\nclass foo {};\nclass bar { static name() 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15133,6 +15371,7 @@ test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15198,6 +15437,7 @@ test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15262,6 +15502,7 @@ test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15323,6 +15564,7 @@ test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15384,6 +15626,7 @@ test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15447,6 +15690,7 @@ test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDes
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15508,6 +15752,7 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15564,6 +15809,7 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
           <td class="tally _6to5" data-tally="1">2/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
+          <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
@@ -15624,6 +15870,7 @@ test(function(){try{return Function("\nreturn typeof String.raw === 'function';\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15684,6 +15931,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15740,6 +15988,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
           <td class="tally _6to5" data-tally="0.6666666666666666">4/6</td>
           <td class="tally ejs" data-tally="0.6666666666666666">4/6</td>
           <td class="tally closure" data-tally="0">0/6</td>
+          <td class="tally jsx" data-tally="0">0/6</td>
           <td class="tally typescript" data-tally="0">0/6</td>
           <td class="tally ie10" data-tally="0">0/6</td>
           <td class="tally ie11" data-tally="0">0/6</td>
@@ -15800,6 +16049,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.codePointA
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15862,6 +16112,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.normalize 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15923,6 +16174,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.repeat ===
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -15984,6 +16236,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.startsWith
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16045,6 +16298,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.endsWith =
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16103,9 +16357,10 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
 </script>
 
           <td class="yes tr">Yes</td>
-          <td class="no _6to5">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no ejs">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
+          <td class="no _6to5">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no ejs">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16114,33 +16369,33 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox31">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox34">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox35">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no firefox36">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox31">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox34">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox35">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no firefox36">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome39">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
-          <td class="no chrome40">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
+          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome39">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
+          <td class="no chrome40">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -16151,7 +16406,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[12]</sup></a></td>
+          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[13]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -16167,6 +16422,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="yes closure">Yes</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16223,6 +16479,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
           <td class="tally _6to5" data-tally="0.4444444444444444">4/9</td>
           <td class="tally ejs" data-tally="0.6666666666666666">6/9</td>
           <td class="tally closure" data-tally="0">0/9</td>
+          <td class="tally jsx" data-tally="0">0/9</td>
           <td class="tally typescript" data-tally="0">0/9</td>
           <td class="tally ie10" data-tally="0">0/9</td>
           <td class="tally ie11" data-tally="0">0/9</td>
@@ -16287,6 +16544,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16347,6 +16605,7 @@ test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n 
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16419,6 +16678,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16488,6 +16748,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16561,6 +16822,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16621,6 +16883,7 @@ test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symb
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16686,6 +16949,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symb
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16751,6 +17015,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject 
           <td class="yes _6to5">Yes</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16813,6 +17078,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16869,6 +17135,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
           <td class="tally _6to5" data-tally="0.14285714285714285">1/7</td>
           <td class="tally ejs" data-tally="0.5714285714285714">4/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
+          <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
           <td class="tally ie10" data-tally="0">0/7</td>
           <td class="tally ie11" data-tally="0">0/7</td>
@@ -16936,6 +17203,7 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -16999,6 +17267,7 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17072,6 +17341,7 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17134,6 +17404,7 @@ test(function(){try{return Function("\nreturn RegExp[Symbol.species] === RegExp\
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17203,6 +17474,7 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17265,6 +17537,7 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
           <td class="no _6to5">No</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17329,6 +17602,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17385,6 +17659,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="tally _6to5" data-tally="0">0/5</td>
           <td class="tally ejs" data-tally="0">0/5</td>
           <td class="tally closure" data-tally="0">0/5</td>
+          <td class="tally jsx" data-tally="0">0/5</td>
           <td class="tally typescript" data-tally="0">0/5</td>
           <td class="tally ie10" data-tally="0">0/5</td>
           <td class="tally ie11" data-tally="0">0/5</td>
@@ -17445,6 +17720,7 @@ test(function(){try{return Function("\nreturn /./igm.flags === \"gim\" && /./.fl
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17505,6 +17781,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.mat
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17565,6 +17842,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.rep
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17625,6 +17903,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.spl
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17685,6 +17964,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.sea
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17741,6 +18021,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.sea
           <td class="tally _6to5" data-tally="1">2/2</td>
           <td class="tally ejs" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
+          <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
           <td class="tally ie10" data-tally="0">0/2</td>
           <td class="tally ie11" data-tally="0">0/2</td>
@@ -17801,6 +18082,7 @@ test(function(){try{return Function("\nreturn typeof Array.from === 'function';\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17862,6 +18144,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -17918,6 +18201,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
           <td class="tally _6to5" data-tally="0.875">7/8</td>
           <td class="tally ejs" data-tally="0.875">7/8</td>
           <td class="tally closure" data-tally="0">0/8</td>
+          <td class="tally jsx" data-tally="0">0/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="0">0/8</td>
@@ -17978,6 +18262,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18038,6 +18323,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18098,6 +18384,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex =
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18158,6 +18445,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18218,6 +18506,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18278,6 +18567,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18285,21 +18575,21 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[13]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[14]</sup></a></td>
-          <td class="no firefox36">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[14]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[15]</sup></a></td>
+          <td class="no firefox36">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -18310,9 +18600,9 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
-          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[15]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
+          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[16]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -18338,6 +18628,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.entries ===
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18406,6 +18697,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18462,6 +18754,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
           <td class="tally _6to5" data-tally="1">7/7</td>
           <td class="tally ejs" data-tally="1">7/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
+          <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
           <td class="tally ie10" data-tally="0">0/7</td>
           <td class="tally ie11" data-tally="0">0/7</td>
@@ -18522,6 +18815,7 @@ test(function(){try{return Function("\nreturn typeof Number.isFinite === 'functi
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18582,6 +18876,7 @@ test(function(){try{return Function("\nreturn typeof Number.isInteger === 'funct
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18642,6 +18937,7 @@ test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'f
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18702,6 +18998,7 @@ test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function'
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18762,6 +19059,7 @@ test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number'
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18822,6 +19120,7 @@ test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER ===
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18882,6 +19181,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -18938,6 +19238,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
           <td class="tally _6to5" data-tally="1">17/17</td>
           <td class="tally ejs" data-tally="1">17/17</td>
           <td class="tally closure" data-tally="0">0/17</td>
+          <td class="tally jsx" data-tally="0">0/17</td>
           <td class="tally typescript" data-tally="0">0/17</td>
           <td class="tally ie10" data-tally="0">0/17</td>
           <td class="tally ie11" data-tally="0">0/17</td>
@@ -18998,6 +19299,7 @@ test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19058,6 +19360,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19082,7 +19385,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox36">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[16]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[17]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -19118,6 +19421,7 @@ test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19178,6 +19482,7 @@ test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19238,6 +19543,7 @@ test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19298,6 +19604,7 @@ test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19358,6 +19665,7 @@ test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19418,6 +19726,7 @@ test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19478,6 +19787,7 @@ test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19538,6 +19848,7 @@ test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19598,6 +19909,7 @@ test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19658,6 +19970,7 @@ test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19718,6 +20031,7 @@ test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19778,6 +20092,7 @@ test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19838,6 +20153,7 @@ test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\"
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19898,6 +20214,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -19910,7 +20227,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[17]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[18]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -19958,6 +20275,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="yes _6to5">Yes</td>
           <td class="yes ejs">Yes</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20014,6 +20332,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
           <td class="tally _6to5" data-tally="0">0/7</td>
           <td class="tally ejs" data-tally="0">0/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
+          <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
           <td class="tally ie10" data-tally="0.2857142857142857">2/7</td>
           <td class="tally ie11" data-tally="0.2857142857142857">2/7</td>
@@ -20075,6 +20394,7 @@ test(function(){try{return Function("\n'use strict';\nreturn this === undefined 
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20135,6 +20455,7 @@ test(function(){try{return Function("\ndo {} while (false) return true;\n      "
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -20200,6 +20521,7 @@ test(function(){try{return Function("\ntry {\n  eval('for (var i = 0 in {}) {}')
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20264,6 +20586,7 @@ test(function(){try{return Function("\ntry {\n  new (Object.getOwnPropertyDescri
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20331,6 +20654,7 @@ test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'prevent
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20391,6 +20715,7 @@ test(function(){try{return Function("\nreturn new Date(NaN) + \"\" === \"Invalid
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -20451,6 +20776,7 @@ test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global ==
           <td class="no _6to5">No</td>
           <td class="no ejs">No</td>
           <td class="no closure">No</td>
+          <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20501,7 +20827,7 @@ test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global ==
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <th colspan="55" class="separator"></th>
+          <th colspan="56" class="separator"></th>
         </tr>
         <tr>
           <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
@@ -20522,6 +20848,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -20572,12 +20899,13 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[18]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[19]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally ejs not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/5</td>
+          <td title="This feature is optional on non-browser platforms." class="tally jsx not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally typescript not-applicable " data-tally="0">0/5</td>
           <td class="tally ie10" data-tally="0">0/5</td>
           <td class="tally ie11" data-tally="0.2">1/5</td>
@@ -20639,6 +20967,7 @@ test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Arra
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -20704,6 +21033,7 @@ test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __prot
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20768,6 +21098,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20832,6 +21163,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20895,6 +21227,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -20951,6 +21284,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally ejs not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/3</td>
+          <td title="This feature is optional on non-browser platforms." class="tally jsx not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally typescript not-applicable " data-tally="0">0/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="1">3/3</td>
@@ -21012,6 +21346,7 @@ test(function(){try{return Function("\nvar A = function(){};\nreturn (new A())._
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -21074,6 +21409,7 @@ test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototyp
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -21141,6 +21477,7 @@ test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescripto
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -21209,6 +21546,7 @@ test(function(){try{return Function("\nvar i, names = [\"anchor\", \"big\", \"bo
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -21270,6 +21608,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no ejs not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
           <td class="yes ie10">Yes</td>
           <td class="yes ie11">Yes</td>
@@ -21326,59 +21665,62 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
         <code>__createIterableObject()</code>, used in the numerous "generic iterables" tests, is defined as:
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
+      <p id="jsx-flag-note">
+        <sup>[1]</sup> Have to be enabled via <code>harmony</code> option
+      </p>
       <p id="ie-experimental-flag-note">
-        <sup>[1]</sup> Have to be enabled via "Experimental Web Platform Features" flag
+        <sup>[2]</sup> Have to be enabled via "Experimental Web Platform Features" flag
       </p>
       <p id="experimental-flag-note">
-        <sup>[2]</sup> Have to be enabled via "Experimental Javascript features" flag
+        <sup>[3]</sup> Have to be enabled via "Experimental Javascript features" flag
       </p>
       <p id="khtml-note">
-        <sup>[3]</sup> Results are only applicable for the KHTML rendering engine.
+        <sup>[4]</sup> Results are only applicable for the KHTML rendering engine.
       </p>
       <p id="harmony-flag-note">
-        <sup>[4]</sup> Have to be enabled via --harmony flag
+        <sup>[5]</sup> Have to be enabled via --harmony flag
       </p>
       <p id="fx-let-note">
-        <sup>[5]</sup> Available from Firefox 2 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
+        <sup>[6]</sup> Available from Firefox 2 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
       <p id="fx-let-tdz-note">
-        <sup>[6]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
+        <sup>[7]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
       <p id="fx-proxy-get-note">
-        <sup>[7]</sup> Firefox doesn't allow a proxy's "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy's "has" handler reports it as present).
+        <sup>[8]</sup> Firefox doesn't allow a proxy's "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy's "has" handler reports it as present).
       </p>
       <p id="fx-proxy-getown-note">
-        <sup>[8]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+        <sup>[9]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
       </p>
       <p id="fx-proxy-ownkeys-note">
-        <sup>[9]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+        <sup>[10]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
       </p>
       <p id="block-level-function-note">
-        <sup>[10]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
+        <sup>[11]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="setprototypeof-polyfill-note">
-        <sup>[11]</sup> Requires native support for <code>Object.prototype.__proto__</code>
+        <sup>[12]</sup> Requires native support for <code>Object.prototype.__proto__</code>
       </p>
       <p id="string-contains-note">
-        <sup>[12]</sup> Available as the draft standard <code>String.prototype.contains</code>
+        <sup>[13]</sup> Available as the draft standard <code>String.prototype.contains</code>
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[13]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[14]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[14]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[15]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[15]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[16]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[16]</sup> Available since Chrome 28
+        <sup>[17]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[17]</sup> Available since Firefox 26
+        <sup>[18]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[18]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[19]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
     </div>
   </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -83,7 +83,7 @@
       <thead>
         <tr>
           <th colspan="3"  class="platformtype"></th>
-          <th colspan="5"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
+          <th colspan="6"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
           <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
           <th colspan="4"  class="platformtype" id="engine-header" style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "esnext":         "*",
     "es6-transpiler": "*",
     "traceur":        "*",
-    "typescript":     "*"
+    "typescript":     "*",
+    "react-tools":    "*"
   }
 }


### PR DESCRIPTION
This closes #356, but also includes a fix to close #357 as well.

Note: JSX technically supports `extends`, but its compiled output fails the current test (that the prototype chain is correct) which I think is fair.
