### PR TITLE
Added ES6-Transpiler column, and updated other compilers' results.

### DIFF
--- a/build.js
+++ b/build.js
@@ -48,6 +48,7 @@ process.nextTick(function () {
   var closure    = require('closurecompiler');
   var to5        = require('6to5');
   var esnext     = require('esnext');
+  // Known bug: running require('es6-transpiler') causes 6to5 to break.
   var es6tr      = require('es6-transpiler');
   var traceur    = require('traceur');
   var reacttools = require('react-tools');
@@ -59,25 +60,6 @@ process.nextTick(function () {
       polyfills: ['node_modules/traceur/bin/traceur-runtime.js'],
       compiler: function(code) {
         return traceur.compile(code);
-      },
-    },
-    {
-      name: 'Closure Compiler',
-      url: 'https://developers.google.com/closure/compiler/',
-      target_file: 'es6/compilers/closure.html',
-      polyfills: [],
-      compiler: function(code) {
-        var fpath = os.tmpDir() + path.sep + 'temp.js';
-        var file = fs.writeFileSync(fpath, code);
-        try {
-          output = ""+child_process.execSync('node_modules/closurecompiler/bin/ccjs ' +
-            fpath +
-            ' --language_in=ECMASCRIPT6 --language_out=ECMASCRIPT5 --transpile_only'
-          );
-        } catch(e) {
-          throw new Error('\n' + e.stdout.toString().split(fpath).join(''));
-        }
-        return output;
       },
     },
     {
@@ -124,6 +106,25 @@ process.nextTick(function () {
       compiler: function(code) {
         var ret = reacttools.transform(code, { harmony:true });
         return ret.code || ret;
+      },
+    },
+    {
+      name: 'Closure Compiler',
+      url: 'https://developers.google.com/closure/compiler/',
+      target_file: 'es6/compilers/closure.html',
+      polyfills: [],
+      compiler: function(code) {
+        var fpath = os.tmpDir() + path.sep + 'temp.js';
+        var file = fs.writeFileSync(fpath, code);
+        try {
+          output = ""+child_process.execSync('node_modules/closurecompiler/bin/ccjs ' +
+            fpath +
+            ' --language_in=ECMASCRIPT6 --language_out=ECMASCRIPT5 --transpile_only'
+          );
+        } catch(e) {
+          throw new Error('\n' + e.stdout.toString().split(fpath).join(''));
+        }
+        return output;
       },
     },
     {

--- a/data-es6.js
+++ b/data-es6.js
@@ -21,6 +21,12 @@ exports.browsers = {
     obsolete: false,
     platformtype: 'compiler',
   },
+  es6tr: {
+    full: 'ES6 Transpiler',
+    short: 'ES6<br>Transpiler',
+    obsolete: false,
+    platformtype: 'compiler',
+  },
   closure: {
     full: 'Closure Compiler v20141120',
     short: 'Closure<br>Compiler',
@@ -371,6 +377,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -388,6 +395,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -405,6 +413,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -423,6 +432,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -441,6 +451,7 @@ exports.tests = [
         tr:          true,
         closure:     true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -457,6 +468,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         typescript:  true,
         ejs:         true,
@@ -471,6 +483,7 @@ exports.tests = [
         return f(6) === 5;
       */},
       res: {
+        tr:          true,
         _6to5:       true,
         closure:     true,
         ie11tp:      true,
@@ -513,6 +526,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -536,7 +550,9 @@ exports.tests = [
       */},
       res: {
         _6to5:       true,
+        es6tr:       true,
         tr:          true,
+        jsx:         true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -555,6 +571,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -581,6 +598,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -599,6 +617,7 @@ exports.tests = [
       */},
       res: {
         _6to5:       true,
+        es6tr:       true,
         tr:          true,
         ejs:         true,
         closure:     true,
@@ -621,6 +640,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -657,6 +677,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -676,6 +697,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -691,6 +713,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        es6tr:       true,
         _6to5:       true,
         closure:     true,
         ie11:        true,
@@ -744,6 +767,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -762,6 +786,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -780,6 +805,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11:        true,
@@ -840,6 +866,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         typescript:  true,
@@ -853,6 +880,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         typescript:  true,
@@ -866,6 +894,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         typescript:  true,
@@ -919,6 +948,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         jsx:         true,
@@ -934,6 +964,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         jsx:         true,
         typescript:  true,
@@ -954,7 +985,7 @@ exports.tests = [
         }("foo", "bar", "baz"));
       */},
       res: {
-        ie11tp:      true,
+        tr:          true,
       },
     },
   },
@@ -970,6 +1001,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -986,6 +1018,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1021,47 +1054,55 @@ exports.tests = [
     },
     'with generic iterables, in calls': {
       exec: function () {/*
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         return Math.max(...iterable) === 3;
       */},
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       {
+          val: true,
+          note_id: 'compiler-iterable',
+          note_html: 'This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>"@@iterator"</code> method.'
+        },
         ejs:         true,
         firefox27:   true,
       },
     },
     'with generic iterables, in arrays': {
       exec: function () {/*
-        var iterable = __createIterableObject("b", "c", "d");
+        var iterable = window.__createIterableObject("b", "c", "d");
         return ["a", ...iterable, "e"][3] === "d";
       */},
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       { val: true, note_id: 'compiler-iterable' },
         ejs:         true,
         firefox27:   true,
       },
     },
     'with instances of iterables, in calls': {
       exec: function () {/*
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         return Math.max(...Object.create(iterable)) === 3;
       */},
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       { val: true, note_id: 'compiler-iterable' },
         firefox36:   true,
       },
     },
     'with instances of iterables, in arrays': {
       exec: function () {/*
-        var iterable = __createIterableObject("b", "c", "d");
+        var iterable = window.__createIterableObject("b", "c", "d");
         return ["a", ...Object.create(iterable), "e"][3] === "d";
       */},
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       { val: true, note_id: 'compiler-iterable' },
         firefox36:   true,
       },
     },
@@ -1079,6 +1120,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         jsx:         true,
         closure:     true,
@@ -1098,6 +1140,7 @@ exports.tests = [
       */},
       res: {
         _6to5:       true,
+        jsx:         true,
         ie11tp:      true,
       },
     },
@@ -1108,6 +1151,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1126,6 +1170,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1144,6 +1189,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1161,6 +1207,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1180,6 +1227,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         ie11tp:      true,
       },
@@ -1197,6 +1245,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         ie11tp:      true,
       },
@@ -1212,6 +1261,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ie11tp:      true,
       },
@@ -1225,8 +1275,13 @@ exports.tests = [
           && Array.prototype.isPrototypeOf(C.prototype);
       */},
       res: {
-        tr:          true,
-        _6to5:       true,
+        es6tr:       {
+          val: false,
+          note_id: 'compiler-proto',
+          note_html: 'Requires native support for <code>Object.prototype.__proto__</code>',
+        },
+        _6to5:       { val: false, note_id: 'compiler-proto' },
+        tr:          { val: false, note_id: 'compiler-proto' },
         ejs:         true,
         closure:     {
           val: false,
@@ -1247,8 +1302,9 @@ exports.tests = [
           && Object.getPrototypeOf(C.prototype) === null;
       */},
       res: {
-        tr:          true,
+        tr:          { val: false, note_id: 'compiler-proto' },
         ejs:         true,
+        es6tr:       true,
         jsx:         true,
         ie11tp:      true,
       },
@@ -1271,6 +1327,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         ie11tp:      true,
         chrome40:    true,
@@ -1288,6 +1345,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         ie11tp:      true,
       },
@@ -1308,6 +1366,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         ie11tp:      true,
       },
@@ -1326,6 +1385,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1343,6 +1403,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1358,6 +1419,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1482,6 +1544,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1512,7 +1575,7 @@ exports.tests = [
     'with generic iterables': {
       exec: function () {/*
         var result = "";
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         for (var item of iterable) {
           result += item;
         }
@@ -1521,6 +1584,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       { val: true, note_id: 'compiler-iterable' },
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1532,7 +1596,7 @@ exports.tests = [
     'with instances of generic iterables': {
       exec: function () {/*
         var result = "";
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         for (var item of Object.create(iterable)) {
           result += item;
         }
@@ -1541,6 +1605,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       { val: true, note_id: 'compiler-iterable' },
         ie11tp:      true,
         firefox36:   true,
         chrome35:    true,
@@ -1743,7 +1808,7 @@ exports.tests = [
     'yield *, generic iterables': {
       exec: function () {/*
         var iterator = (function * generator() {
-          yield * __createIterableObject(5, 6, 7);
+          yield * window.__createIterableObject(5, 6, 7);
         }());
         var item = iterator.next();
         var passed = item.value === 5 && item.done === false;
@@ -1823,6 +1888,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1838,6 +1904,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -1883,6 +1950,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -1909,6 +1977,7 @@ exports.tests = [
         tr:          true,
         ejs:         true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         closure:     true,
         firefox34:   true,
@@ -3328,6 +3397,7 @@ exports.tests = [
       res: (temp.destructuringResults = {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -3345,6 +3415,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -3356,7 +3427,7 @@ exports.tests = [
     },
     'with generic iterables': {
       exec: function(){/*
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         var [a, b, c] = iterable;
         return a === 1 && b === 2 && c === 3;
       */},
@@ -3367,7 +3438,7 @@ exports.tests = [
     },
     'with instances of generic iterables': {
       exec: function(){/*
-        var iterable = __createIterableObject(1, 2, 3);
+        var iterable = window.__createIterableObject(1, 2, 3);
         var [a, b, c] = Object.create(iterable);
         return a === 1 && b === 2 && c === 3;
       */},
@@ -3390,6 +3461,8 @@ exports.tests = [
         return grault === "garply";
       */},
       res: {
+        tr:          true,
+        es6tr:       true,
         firefox35:   true,
       },
     },
@@ -3401,6 +3474,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -3425,6 +3499,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         ejs:         true,
         closure:     true,
@@ -3459,6 +3534,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         closure:     true,
         firefox13:   true,
         safari71_8:  true,
@@ -3476,6 +3552,7 @@ exports.tests = [
       res: {
         tr:          true,
         _6to5:       true,
+        es6tr:       true,
         jsx:         true,
         closure:     true,
         firefox34:   true,
@@ -3499,6 +3576,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        es6tr:       true,
         closure:     true,
       },
     },
@@ -3511,6 +3589,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        es6tr:       true,
         closure:     true,
       },
     },
@@ -3627,11 +3706,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
-        _6to5: {
-          value: true,
-          note_id: 'setprototypeof-polyfill',
-          note_html: 'Requires native support for <code>Object.prototype.__proto__</code>',
-        },
+        _6to5:       { val: false, note_id: 'compiler-proto' },
         ie11:        true,
         firefox31:   true,
         chrome34:    true,
@@ -4115,6 +4190,7 @@ exports.tests = [
   res: {
     tr:          true,
     _6to5:       true,
+    es6tr:       true,
     ejs:         true,
     closure:     true,
     ie10:        false,

--- a/es6/index.html
+++ b/es6/index.html
@@ -83,7 +83,7 @@
       <thead>
         <tr>
           <th colspan="3"  class="platformtype"></th>
-          <th colspan="5"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
+          <th colspan="6"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
           <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
           <th colspan="5"  class="platformtype" id="engine-header" style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
@@ -94,6 +94,7 @@
           <th></th>
           <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></th>
           <th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr></th>
+          <th class="platform es6tr compiler"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Transpiler</abbr></th>
           <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141120">Closure<br>Compiler</abbr></th>
           <th class="platform jsx compiler"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[1]</sup></a></th>
           <th class="platform typescript compiler"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.3">TypeScript</abbr></th>
@@ -164,6 +165,7 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -219,8 +221,9 @@ test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n
         <tr class="supertest">
           <td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 
-          <td class="tally tr" data-tally="0.6666666666666666">6/9</td>
+          <td class="tally tr" data-tally="0.7777777777777778">7/9</td>
           <td class="tally _6to5" data-tally="0.7777777777777778">7/9</td>
+          <td class="tally es6tr" data-tally="0.6666666666666666">6/9</td>
           <td class="tally closure" data-tally="0.7777777777777778">7/9</td>
           <td class="tally jsx" data-tally="0.6666666666666666">6/9</td>
           <td class="tally typescript" data-tally="0.6666666666666666">6/9</td>
@@ -282,6 +285,7 @@ test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}cat
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -344,6 +348,7 @@ test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fe
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -406,6 +411,7 @@ test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w +
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -469,6 +475,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -532,6 +539,7 @@ test(function(){try{return Function("\nvar d = { x : \"foo\", y : function() { r
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -595,6 +603,7 @@ test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { r
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -655,8 +664,9 @@ return f(6) === 5;
 test(function(){try{return Function("\nvar f = (function() { return z => arguments[0]; }(5));\nreturn f(6) === 5;\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="no tr">No</td>
+          <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -720,6 +730,7 @@ test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -782,6 +793,7 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -839,8 +851,9 @@ test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnPropert
 
           <td class="tally tr" data-tally="0.75">6/8</td>
           <td class="tally _6to5" data-tally="0.75">6/8</td>
+          <td class="tally es6tr" data-tally="0.75">6/8</td>
           <td class="tally closure" data-tally="0.75">6/8</td>
-          <td class="tally jsx" data-tally="0">0/8</td>
+          <td class="tally jsx" data-tally="0.125">1/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
           <td class="tally ie10" data-tally="0">0/8</td>
           <td class="tally ie11" data-tally="1">8/8</td>
@@ -901,6 +914,7 @@ test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -964,8 +978,9 @@ test(function(){try{return Function("\nconst bar = 123;\n{ const bar = 456; }\nr
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
-          <td class="no jsx">No</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="yes ie11">Yes</td>
@@ -1030,6 +1045,7 @@ test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1093,6 +1109,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try { qux; } ca
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1156,6 +1173,7 @@ test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1220,6 +1238,7 @@ test(function(){try{return Function("\n'use strict';\nconst bar = 123;\n{ const 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1287,6 +1306,7 @@ test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  F
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1351,6 +1371,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1408,6 +1429,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
 
           <td class="tally tr" data-tally="0.8">8/10</td>
           <td class="tally _6to5" data-tally="0.8">8/10</td>
+          <td class="tally es6tr" data-tally="0.6">6/10</td>
           <td class="tally closure" data-tally="0.8">8/10</td>
           <td class="tally jsx" data-tally="0">0/10</td>
           <td class="tally typescript" data-tally="0">0/10</td>
@@ -1470,6 +1492,7 @@ test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n  
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1533,6 +1556,7 @@ test(function(){try{return Function("\nlet bar = 123;\n{ let bar = 456; }\nretur
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1596,6 +1620,7 @@ test(function(){try{return Function("\nlet baz = 1;\nfor(let baz = 0; false; fal
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1659,6 +1684,7 @@ test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } c
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1731,6 +1757,7 @@ test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1794,6 +1821,7 @@ test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (fo
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1858,6 +1886,7 @@ test(function(){try{return Function("\n'use strict';\nlet bar = 123;\n{ let bar 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1922,6 +1951,7 @@ test(function(){try{return Function("\n'use strict';\nlet baz = 1;\nfor(let baz 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -1986,6 +2016,7 @@ test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2059,6 +2090,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2116,6 +2148,7 @@ test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let 
 
           <td class="tally tr" data-tally="0.6">3/5</td>
           <td class="tally _6to5" data-tally="1">5/5</td>
+          <td class="tally es6tr" data-tally="0.6">3/5</td>
           <td class="tally closure" data-tally="0.8">4/5</td>
           <td class="tally jsx" data-tally="0">0/5</td>
           <td class="tally typescript" data-tally="0.6">3/5</td>
@@ -2177,6 +2210,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
@@ -2238,6 +2272,7 @@ test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
@@ -2299,6 +2334,7 @@ test(function(){try{return Function("\nreturn (function (a, b = a) { return b ==
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="yes typescript">Yes</td>
@@ -2370,6 +2406,7 @@ test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    e
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2436,6 +2473,7 @@ test(function(){try{return Function("\nreturn (function(a=function(){\n  return 
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2491,14 +2529,15 @@ test(function(){try{return Function("\nreturn (function(a=function(){\n  return 
         <tr class="supertest">
           <td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 
-          <td class="tally tr" data-tally="0.6666666666666666">2/3</td>
+          <td class="tally tr" data-tally="1">3/3</td>
           <td class="tally _6to5" data-tally="0.6666666666666666">2/3</td>
+          <td class="tally es6tr" data-tally="0.6666666666666666">2/3</td>
           <td class="tally closure" data-tally="0.3333333333333333">1/3</td>
           <td class="tally jsx" data-tally="0.6666666666666666">2/3</td>
           <td class="tally typescript" data-tally="0.6666666666666666">2/3</td>
           <td class="tally ie10" data-tally="0">0/3</td>
           <td class="tally ie11" data-tally="0">0/3</td>
-          <td class="tally ie11tp" data-tally="1">3/3</td>
+          <td class="tally ie11tp" data-tally="0.6666666666666666">2/3</td>
           <td class="tally firefox11 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox13 obsolete" data-tally="0">0/3</td>
           <td class="tally firefox16 obsolete" data-tally="0.6666666666666666">2/3</td>
@@ -2556,6 +2595,7 @@ test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  retu
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -2617,6 +2657,7 @@ test(function(){try{return Function("\nreturn function(a, ...b){}.length === 1 &
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -2684,14 +2725,15 @@ return (function (foo, ...args) {
 test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  foo = \"qux\";\n  // The arguments object is not mapped to the\n  // parameters, even outside of strict mode.\n  return arguments.length === 3\n    && arguments[0] === \"foo\"\n    && arguments[1] === \"bar\"\n    && arguments[2] === \"baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="no tr">No</td>
+          <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
-          <td class="yes ie11tp">Yes</td>
+          <td class="no ie11tp">No</td>
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
@@ -2743,6 +2785,7 @@ test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  foo 
 
           <td class="tally tr" data-tally="1">8/8</td>
           <td class="tally _6to5" data-tally="1">8/8</td>
+          <td class="tally es6tr" data-tally="0.75">6/8</td>
           <td class="tally closure" data-tally="0.25">2/8</td>
           <td class="tally jsx" data-tally="0">0/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
@@ -2804,6 +2847,7 @@ test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n    
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2865,6 +2909,7 @@ test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2926,6 +2971,7 @@ test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n    
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -2987,6 +3033,7 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3041,14 +3088,15 @@ test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in calls</span></td>
 <script data-source="
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...iterable) === 3;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3103,14 +3151,15 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with generic iterables, in arrays</span></td>
 <script data-source="
-var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
+var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3165,14 +3214,15 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in calls</span></td>
 <script data-source="
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...Object.create(iterable)) === 3;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3227,14 +3277,15 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
         <tr class="subtest" data-parent="spread_(...)_operator">
           <td><span>with instances of iterables, in arrays</span></td>
 <script data-source="
-var iterable = __createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
+var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d&quot;;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3290,10 +3341,11 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(\"b
         <tr class="supertest">
           <td id="class"><span><a class="anchor" href="#class">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
 
-          <td class="tally tr" data-tally="0.9090909090909091">10/11</td>
-          <td class="tally _6to5" data-tally="0.9090909090909091">10/11</td>
+          <td class="tally tr" data-tally="0.7272727272727273">8/11</td>
+          <td class="tally _6to5" data-tally="0.8181818181818182">9/11</td>
+          <td class="tally es6tr" data-tally="0.8181818181818182">9/11</td>
           <td class="tally closure" data-tally="0.45454545454545453">5/11</td>
-          <td class="tally jsx" data-tally="0.6363636363636364">7/11</td>
+          <td class="tally jsx" data-tally="0.7272727272727273">8/11</td>
           <td class="tally typescript" data-tally="0">0/11</td>
           <td class="tally ie10" data-tally="0">0/11</td>
           <td class="tally ie11" data-tally="0">0/11</td>
@@ -3354,6 +3406,7 @@ test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"functio
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3421,8 +3474,9 @@ test(function(){try{return Function("\nclass C {}\nvar c1 = C;\n{\n  class C {}\
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
-          <td class="no jsx">No</td>
+          <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -3482,6 +3536,7 @@ test(function(){try{return Function("\nreturn typeof class C {} === \"function\"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3547,6 +3602,7 @@ test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3612,6 +3668,7 @@ test(function(){try{return Function("\nclass C {\n  method() { return 2; }\n}\nr
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3677,6 +3734,7 @@ test(function(){try{return Function("\nclass C {\n  static method() { return 3; 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3744,6 +3802,7 @@ test(function(){try{return Function("\nvar baz = false;\nclass C {\n  get foo() 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3811,6 +3870,7 @@ test(function(){try{return Function("\nvar baz = false;\nclass C {\n  static get
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -3876,6 +3936,7 @@ test(function(){try{return Function("\nvar c = class C {\n  static method() { re
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -3939,10 +4000,11 @@ return c instanceof Array
 test(function(){try{return Function("\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof Array\n  && Array.isPrototypeOf(C)\n  && Array.prototype.isPrototypeOf(C.prototype);\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="yes tr">Yes</td>
-          <td class="yes _6to5">Yes</td>
-          <td class="no closure">No<a href="#compiled-extends-note"><sup>[8]</sup></a></td>
-          <td class="no jsx">No<a href="#compiled-extends-note"><sup>[8]</sup></a></td>
+          <td class="no tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+          <td class="no _6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+          <td class="no es6tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+          <td class="no closure">No<a href="#compiled-extends-note"><sup>[10]</sup></a></td>
+          <td class="no jsx">No<a href="#compiled-extends-note"><sup>[10]</sup></a></td>
           <td class="no typescript">No</td>
           <td class="no ie10">No</td>
           <td class="no ie11">No</td>
@@ -4004,8 +4066,9 @@ return !(c instanceof Object)
 test(function(){try{return Function("\nclass C extends null {}\nvar c = new C();\nreturn !(c instanceof Object)\n  && Function.prototype.isPrototypeOf(C)\n  && Object.getPrototypeOf(C.prototype) === null;\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="yes tr">Yes</td>
+          <td class="no tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
           <td class="no _6to5">No</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -4063,6 +4126,7 @@ test(function(){try{return Function("\nclass C extends null {}\nvar c = new C();
 
           <td class="tally tr" data-tally="1">3/3</td>
           <td class="tally _6to5" data-tally="1">3/3</td>
+          <td class="tally es6tr" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="0">0/3</td>
           <td class="tally jsx" data-tally="0">0/3</td>
           <td class="tally typescript" data-tally="0">0/3</td>
@@ -4129,6 +4193,7 @@ test(function(){try{return Function("\nclass B extends class {\n  constructor(a)
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4195,6 +4260,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux(a) { retur
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4265,6 +4331,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4322,6 +4389,7 @@ test(function(){try{return Function("\nclass B extends class {\n  qux() { return
 
           <td class="tally tr" data-tally="1">3/3</td>
           <td class="tally _6to5" data-tally="1">3/3</td>
+          <td class="tally es6tr" data-tally="1">3/3</td>
           <td class="tally closure" data-tally="1">3/3</td>
           <td class="tally jsx" data-tally="0.6666666666666666">2/3</td>
           <td class="tally typescript" data-tally="0.3333333333333333">1/3</td>
@@ -4384,6 +4452,7 @@ test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4446,6 +4515,7 @@ test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -4507,6 +4577,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="yes typescript">Yes</td>
@@ -4564,6 +4635,7 @@ test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;
 
           <td class="tally tr" data-tally="1">4/4</td>
           <td class="tally _6to5" data-tally="1">4/4</td>
+          <td class="tally es6tr" data-tally="0.75">3/4</td>
           <td class="tally closure" data-tally="0.75">3/4</td>
           <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
@@ -4627,6 +4699,7 @@ test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4691,6 +4764,7 @@ test(function(){try{return Function("\nvar str = \"\";\nfor (var item of \"foo\"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4746,17 +4820,18 @@ test(function(){try{return Function("\nvar str = \"\";\nfor (var item of \"foo\"
           <td><span>with generic iterables</span></td>
 <script data-source="
 var result = &quot;&quot;;
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 for (var item of iterable) {
   result += item;
 }
 return result === &quot;123&quot;;
       ">
-test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4812,17 +4887,18 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
           <td><span>with instances of generic iterables</span></td>
 <script data-source="
 var result = &quot;&quot;;
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 for (var item of Object.create(iterable)) {
   result += item;
 }
 return result === &quot;123&quot;;
       ">
-test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -4880,6 +4956,7 @@ test(function(){try{return Function("\nvar result = \"\";\nvar iterable = __crea
 
           <td class="tally tr" data-tally="0.9166666666666666">11/12</td>
           <td class="tally _6to5" data-tally="0.9166666666666666">11/12</td>
+          <td class="tally es6tr" data-tally="0">0/12</td>
           <td class="tally closure" data-tally="0.5">6/12</td>
           <td class="tally jsx" data-tally="0">0/12</td>
           <td class="tally typescript" data-tally="0">0/12</td>
@@ -4951,6 +5028,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5022,6 +5100,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield this.x; 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5091,6 +5170,7 @@ test(function(){try{return Function("\nvar sent;\nfunction * generator(){\n  sen
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5161,6 +5241,7 @@ test(function(){try{return Function("\nfunction * generatorFn(){}\nvar ownProto 
 
           <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5233,6 +5314,7 @@ test(function(){try{return Function("\nvar passed = false;\nfunction * generator
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5304,6 +5386,7 @@ test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5372,6 +5455,7 @@ test(function(){try{return Function("\nvar passed;\nfunction * generator(){\n  p
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5442,6 +5526,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5512,6 +5597,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5567,7 +5653,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
           <td><span>yield *, generic iterables</span></td>
 <script data-source="
 var iterator = (function * generator() {
-  yield * __createIterableObject(5, 6, 7);
+  yield * window.__createIterableObject(5, 6, 7);
 }());
 var item = iterator.next();
 var passed = item.value === 5 && item.done === false;
@@ -5579,11 +5665,12 @@ item = iterator.next();
 passed    &= item.value === undefined && item.done === true;
 return passed;
       ">
-test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * __createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * window.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5656,6 +5743,7 @@ test(function(){try{return Function("\nvar iterator = (function * generator() {\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5729,6 +5817,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5786,6 +5875,7 @@ test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5
 
           <td class="tally tr" data-tally="0.5">2/4</td>
           <td class="tally _6to5" data-tally="0.5">2/4</td>
+          <td class="tally es6tr" data-tally="0.5">2/4</td>
           <td class="tally closure" data-tally="0.5">2/4</td>
           <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
@@ -5847,6 +5937,7 @@ test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      "
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5908,6 +5999,7 @@ test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      "
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -5969,6 +6061,7 @@ test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}c
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6030,6 +6123,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6087,6 +6181,7 @@ test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}c
 
           <td class="tally tr" data-tally="1">2/2</td>
           <td class="tally _6to5" data-tally="1">2/2</td>
+          <td class="tally es6tr" data-tally="1">2/2</td>
           <td class="tally closure" data-tally="1">2/2</td>
           <td class="tally jsx" data-tally="1">2/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
@@ -6150,6 +6245,7 @@ test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -6222,6 +6318,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -6279,6 +6376,7 @@ test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a
 
           <td class="tally tr" data-tally="0.5">1/2</td>
           <td class="tally _6to5" data-tally="0.5">1/2</td>
+          <td class="tally es6tr" data-tally="0">0/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
@@ -6344,6 +6442,7 @@ test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6405,6 +6504,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6462,6 +6562,7 @@ test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length ===
 
           <td class="tally tr" data-tally="0">0/40</td>
           <td class="tally _6to5" data-tally="0">0/40</td>
+          <td class="tally es6tr" data-tally="0">0/40</td>
           <td class="tally closure" data-tally="0">0/40</td>
           <td class="tally jsx" data-tally="0">0/40</td>
           <td class="tally typescript" data-tally="0">0/40</td>
@@ -6525,6 +6626,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6588,6 +6690,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6651,6 +6754,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6714,6 +6818,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6777,6 +6882,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6840,6 +6946,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6903,6 +7010,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -6966,6 +7074,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7029,6 +7138,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7093,6 +7203,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7157,6 +7268,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7221,6 +7333,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7285,6 +7398,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7349,6 +7463,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7413,6 +7528,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7477,6 +7593,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7541,6 +7658,7 @@ test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar vi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7610,6 +7728,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.from === \"functi
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7679,6 +7798,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7748,6 +7868,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarra
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7817,6 +7938,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7886,6 +8008,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -7955,6 +8078,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastInd
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8024,6 +8148,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8093,6 +8218,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8162,6 +8288,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8231,6 +8358,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8300,6 +8428,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map ===
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8369,6 +8498,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8438,6 +8568,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceR
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8507,6 +8638,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8576,6 +8708,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8645,6 +8778,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8714,6 +8848,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWit
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8783,6 +8918,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8852,6 +8988,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findInd
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8921,6 +9058,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -8990,6 +9128,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9059,6 +9198,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9128,6 +9268,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9185,6 +9326,7 @@ test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries
 
           <td class="tally tr" data-tally="0.9090909090909091">10/11</td>
           <td class="tally _6to5" data-tally="1">11/11</td>
+          <td class="tally es6tr" data-tally="0">0/11</td>
           <td class="tally closure" data-tally="0">0/11</td>
           <td class="tally jsx" data-tally="0">0/11</td>
           <td class="tally typescript" data-tally="0">0/11</td>
@@ -9251,6 +9393,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9317,6 +9460,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar map =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9379,6 +9523,7 @@ test(function(){try{return Function("\nvar map = new Map();\nreturn map.set(0, 0
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9446,6 +9591,7 @@ test(function(){try{return Function("\nvar map = new Map();\nmap.set(-0, \"foo\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9512,6 +9658,7 @@ test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nma
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9573,6 +9720,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.delete === \"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9634,6 +9782,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.clear === \"f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9695,6 +9844,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.forEach === \
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9756,6 +9906,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.keys === \"fu
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9817,6 +9968,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.values === \"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9878,6 +10030,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -9935,6 +10088,7 @@ test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \
 
           <td class="tally tr" data-tally="0.9090909090909091">10/11</td>
           <td class="tally _6to5" data-tally="1">11/11</td>
+          <td class="tally es6tr" data-tally="0">0/11</td>
           <td class="tally closure" data-tally="0">0/11</td>
           <td class="tally jsx" data-tally="0">0/11</td>
           <td class="tally typescript" data-tally="0">0/11</td>
@@ -10002,6 +10156,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10067,6 +10222,7 @@ test(function(){try{return Function("\nvar obj1 = {};\nvar obj2 = {};\nvar set =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10129,6 +10285,7 @@ test(function(){try{return Function("\nvar set = new Set();\nreturn set.add(0) =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10196,6 +10353,7 @@ test(function(){try{return Function("\nvar set = new Set();\nset.add(-0);\nvar k
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10264,6 +10422,7 @@ test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nse
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10325,6 +10484,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.delete === \"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10386,6 +10546,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.clear === \"f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10447,6 +10608,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.forEach === \
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10508,6 +10670,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.keys === \"fu
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10569,6 +10732,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.values === \"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10630,6 +10794,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10687,6 +10852,7 @@ test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \
 
           <td class="tally tr" data-tally="0">0/4</td>
           <td class="tally _6to5" data-tally="0">0/4</td>
+          <td class="tally es6tr" data-tally="0">0/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
@@ -10753,6 +10919,7 @@ test(function(){try{return Function("\nvar key = {};\nvar weakmap = new WeakMap(
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10819,6 +10986,7 @@ test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar weakm
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10882,6 +11050,7 @@ test(function(){try{return Function("\nvar weakmap = new WeakMap();\nvar key = {
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -10943,6 +11112,7 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11000,6 +11170,7 @@ test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete ==
 
           <td class="tally tr" data-tally="0">0/4</td>
           <td class="tally _6to5" data-tally="0">0/4</td>
+          <td class="tally es6tr" data-tally="0">0/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
@@ -11067,6 +11238,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11131,6 +11303,7 @@ test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11194,6 +11367,7 @@ test(function(){try{return Function("\nvar weakset = new WeakSet();\nvar obj = {
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11255,6 +11429,7 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11312,6 +11487,7 @@ test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete ==
 
           <td class="tally tr" data-tally="0">0/20</td>
           <td class="tally _6to5" data-tally="0">0/20</td>
+          <td class="tally es6tr" data-tally="0">0/20</td>
           <td class="tally closure" data-tally="0">0/20</td>
           <td class="tally jsx" data-tally="0">0/20</td>
           <td class="tally typescript" data-tally="0">0/20</td>
@@ -11379,6 +11555,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11446,6 +11623,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.cr
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11456,20 +11634,20 @@ test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.cr
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
-          <td class="no firefox36">No<a href="#fx-proxy-get-note"><sup>[9]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
+          <td class="no firefox36">No<a href="#fx-proxy-get-note"><sup>[11]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -11515,6 +11693,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11584,6 +11763,7 @@ test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\n
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11652,6 +11832,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11720,6 +11901,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11788,6 +11970,7 @@ test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11862,6 +12045,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -11872,13 +12056,13 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[10]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-getown-note"><sup>[12]</sup></a></td>
           <td class="yes firefox30 obsolete">Yes</td>
           <td class="yes firefox31">Yes</td>
           <td class="yes firefox32 obsolete">Yes</td>
@@ -11935,6 +12119,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12003,6 +12188,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nv
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12076,6 +12262,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nva
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12146,6 +12333,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12217,6 +12405,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12290,6 +12479,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nf
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12360,6 +12550,7 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12370,16 +12561,16 @@ test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nO
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[11]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-proxy-ownkeys-note"><sup>[13]</sup></a></td>
           <td class="yes firefox33 obsolete">Yes</td>
           <td class="yes firefox34">Yes</td>
           <td class="yes firefox35">Yes</td>
@@ -12431,6 +12622,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12500,6 +12692,7 @@ test(function(){try{return Function("\nvar proxied = function(){};\nvar passed =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12569,6 +12762,7 @@ test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: func
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12630,6 +12824,7 @@ test(function(){try{return Function("\nreturn Array.isArray(new Proxy([], {}));\
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12691,6 +12886,7 @@ test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12748,6 +12944,7 @@ test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], 
 
           <td class="tally tr" data-tally="0">0/14</td>
           <td class="tally _6to5" data-tally="0">0/14</td>
+          <td class="tally es6tr" data-tally="0">0/14</td>
           <td class="tally closure" data-tally="0">0/14</td>
           <td class="tally jsx" data-tally="0">0/14</td>
           <td class="tally typescript" data-tally="0">0/14</td>
@@ -12809,6 +13006,7 @@ test(function(){try{return Function("\nreturn Reflect.get({ qux: 987 }, \"qux\")
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12872,6 +13070,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.set(obj, \"quux\",
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12933,6 +13132,7 @@ test(function(){try{return Function("\nreturn Reflect.has({ qux: 987 }, \"qux\")
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -12996,6 +13196,7 @@ test(function(){try{return Function("\nvar obj = { bar: 456 };\nReflect.deletePr
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13060,6 +13261,7 @@ test(function(){try{return Function("\nvar obj = { baz: 789 };\nvar desc = Refle
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13123,6 +13325,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.defineProperty(obj
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13184,6 +13387,7 @@ test(function(){try{return Function("\nreturn Reflect.getPrototypeOf([]) === Arr
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13247,6 +13451,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.setPrototypeOf(obj
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13309,6 +13514,7 @@ test(function(){try{return Function("\nreturn Reflect.isExtensible({}) &&\n  !Re
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13372,6 +13578,7 @@ test(function(){try{return Function("\nvar obj = {};\nReflect.preventExtensions(
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13442,6 +13649,7 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nvar iterat
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13504,6 +13712,7 @@ test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nreturn Ref
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13565,6 +13774,7 @@ test(function(){try{return Function("\nreturn Reflect.apply(Array.prototype.push
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13628,6 +13838,7 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13681,7 +13892,7 @@ test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[12]</sup></a></span></td>
+          <td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[14]</sup></a></span></td>
 <script data-source="
 'use strict';
 function f() { return 1; }
@@ -13695,6 +13906,7 @@ test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13750,8 +13962,9 @@ test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }
         <tr class="supertest">
           <td id="destructuring"><span><a class="anchor" href="#destructuring">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
 
-          <td class="tally tr" data-tally="0.8">12/15</td>
+          <td class="tally tr" data-tally="0.8666666666666667">13/15</td>
           <td class="tally _6to5" data-tally="0.8">12/15</td>
+          <td class="tally es6tr" data-tally="0.7333333333333333">11/15</td>
           <td class="tally closure" data-tally="0.7333333333333333">11/15</td>
           <td class="tally jsx" data-tally="0.4666666666666667">7/15</td>
           <td class="tally typescript" data-tally="0">0/15</td>
@@ -13814,6 +14027,7 @@ test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nretu
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -13876,6 +14090,7 @@ test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -13930,15 +14145,16 @@ test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"
         <tr class="subtest" data-parent="destructuring">
           <td><span>with generic iterables</span></td>
 <script data-source="
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 var [a, b, c] = iterable;
 return a === 1 && b === 2 && c === 3;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -13993,15 +14209,16 @@ test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 
         <tr class="subtest" data-parent="destructuring">
           <td><span>with instances of generic iterables</span></td>
 <script data-source="
-var iterable = __createIterableObject(1, 2, 3);
+var iterable = window.__createIterableObject(1, 2, 3);
 var [a, b, c] = Object.create(iterable);
 return a === 1 && b === 2 && c === 3;
       ">
-test(function(){try{return Function("\nvar iterable = __createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
+test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
 </script>
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14064,6 +14281,7 @@ test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -14125,8 +14343,9 @@ return grault === &quot;garply&quot;;
 test(function(){try{return Function("\nvar qux = \"corge\";\nvar { [qux]: grault } = { corge: \"garply\" };\nreturn grault === \"garply\";\n      ")()}catch(e){return false;}}());
 </script>
 
-          <td class="no tr">No</td>
+          <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="yes es6tr">Yes</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14189,6 +14408,7 @@ test(function(){try{return Function("\nvar [a,b] = [5,6], {c,d} = {c:7,d:8};\nre
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -14251,6 +14471,7 @@ test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -14315,6 +14536,7 @@ test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -14378,6 +14600,7 @@ test(function(){try{return Function("\nfor(var [i, j, k] in { qux: 1 }) {\n  ret
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14441,6 +14664,7 @@ test(function(){try{return Function("\nfor(var [i, j, k] of [[1,2,3]]) {\n  retu
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14505,6 +14729,7 @@ test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d]
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="yes jsx">Yes</td>
           <td class="no typescript">No</td>
@@ -14568,6 +14793,7 @@ test(function(){try{return Function("\nvar a = [1, 2, 3], first, last;\n[first, 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14630,6 +14856,7 @@ test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undef
 
           <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14694,6 +14921,7 @@ test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:
 
           <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14757,6 +14985,7 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14814,6 +15043,7 @@ test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\
 
           <td class="tally tr" data-tally="0.75">3/4</td>
           <td class="tally _6to5" data-tally="0.5">2/4</td>
+          <td class="tally es6tr" data-tally="0">0/4</td>
           <td class="tally closure" data-tally="0">0/4</td>
           <td class="tally jsx" data-tally="0">0/4</td>
           <td class="tally typescript" data-tally="0">0/4</td>
@@ -14876,6 +15106,7 @@ test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true},
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -14939,6 +15170,7 @@ test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15003,6 +15235,7 @@ test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] 
 
           <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15063,7 +15296,8 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
 </script>
 
           <td class="no tr">No</td>
-          <td class="no _6to5">No<a href="#setprototypeof-polyfill-note"><sup>[13]</sup></a></td>
+          <td class="no _6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15121,6 +15355,7 @@ test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.pr
 
           <td class="tally tr" data-tally="0">0/16</td>
           <td class="tally _6to5" data-tally="0">0/16</td>
+          <td class="tally es6tr" data-tally="0">0/16</td>
           <td class="tally closure" data-tally="0">0/16</td>
           <td class="tally jsx" data-tally="0">0/16</td>
           <td class="tally typescript" data-tally="0">0/16</td>
@@ -15184,6 +15419,7 @@ test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'f
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15246,6 +15482,7 @@ test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15307,6 +15544,7 @@ test(function(){try{return Function("\nreturn (new Function).name === \"anonymou
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15370,6 +15608,7 @@ test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).n
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15433,6 +15672,7 @@ test(function(){try{return Function("\nvar foo = function() {};\nvar bar = funct
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15498,6 +15738,7 @@ test(function(){try{return Function("\nvar o = { foo: function(){}, bar: functio
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15562,6 +15803,7 @@ test(function(){try{return Function("\nvar o = { get foo(){}, set foo(x){} };\nv
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15624,6 +15866,7 @@ test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15693,6 +15936,7 @@ test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = S
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15757,6 +16001,7 @@ test(function(){try{return Function("\nclass foo {};\nclass bar { static name() 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15819,6 +16064,7 @@ test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15885,6 +16131,7 @@ test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -15950,6 +16197,7 @@ test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16012,6 +16260,7 @@ test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16074,6 +16323,7 @@ test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16138,6 +16388,7 @@ test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDes
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16200,6 +16451,7 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16257,6 +16509,7 @@ test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod
 
           <td class="tally tr" data-tally="1">2/2</td>
           <td class="tally _6to5" data-tally="1">2/2</td>
+          <td class="tally es6tr" data-tally="0">0/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
@@ -16318,6 +16571,7 @@ test(function(){try{return Function("\nreturn typeof String.raw === 'function';\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16379,6 +16633,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16436,6 +16691,7 @@ test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'f
 
           <td class="tally tr" data-tally="0.8333333333333334">5/6</td>
           <td class="tally _6to5" data-tally="0.8333333333333334">5/6</td>
+          <td class="tally es6tr" data-tally="0">0/6</td>
           <td class="tally closure" data-tally="0">0/6</td>
           <td class="tally jsx" data-tally="0">0/6</td>
           <td class="tally typescript" data-tally="0">0/6</td>
@@ -16497,6 +16753,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.codePointA
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16560,6 +16817,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.normalize 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16622,6 +16880,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.repeat ===
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16684,6 +16943,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.startsWith
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16746,6 +17006,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.endsWith =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16808,6 +17069,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16818,33 +17080,33 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
           <td class="no firefox17 obsolete">No</td>
-          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox31">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox34">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox35">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no firefox36">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox31">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox34">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox35">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no firefox36">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
-          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome39">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
-          <td class="no chrome40">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no chrome30 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome31 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome33 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome34 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome35 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome36 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome37 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome39">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
+          <td class="no chrome40">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -16855,7 +17117,7 @@ test(function(){try{return Function("\nreturn typeof String.prototype.includes =
           <td class="no rhino17">No</td>
           <td class="no phantom">No</td>
           <td class="no node">No</td>
-          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[14]</sup></a></td>
+          <td class="no nodeharmony">No<a href="#string-contains-note"><sup>[15]</sup></a></td>
           <td class="yes ejs">Yes</td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
@@ -16870,6 +17132,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="yes es6tr">Yes</td>
           <td class="yes closure">Yes</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -16927,6 +17190,7 @@ test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\
 
           <td class="tally tr" data-tally="0.4444444444444444">4/9</td>
           <td class="tally _6to5" data-tally="0.5555555555555556">5/9</td>
+          <td class="tally es6tr" data-tally="0">0/9</td>
           <td class="tally closure" data-tally="0">0/9</td>
           <td class="tally jsx" data-tally="0">0/9</td>
           <td class="tally typescript" data-tally="0">0/9</td>
@@ -16992,6 +17256,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17053,6 +17318,7 @@ test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n 
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17126,6 +17392,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 
           <td class="yes tr">Yes</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17196,6 +17463,7 @@ test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17270,6 +17538,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17331,6 +17600,7 @@ test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symb
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17397,6 +17667,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symb
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17463,6 +17734,7 @@ test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject 
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17526,6 +17798,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17583,6 +17856,7 @@ test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn S
 
           <td class="tally tr" data-tally="0.14285714285714285">1/7</td>
           <td class="tally _6to5" data-tally="0.2857142857142857">2/7</td>
+          <td class="tally es6tr" data-tally="0">0/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
           <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
@@ -17651,6 +17925,7 @@ test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: tru
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17715,6 +17990,7 @@ test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpr
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17789,6 +18065,7 @@ test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17852,6 +18129,7 @@ test(function(){try{return Function("\nreturn RegExp[Symbol.species] === RegExp\
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17922,6 +18200,7 @@ test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed =
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -17985,6 +18264,7 @@ test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"fo
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18050,6 +18330,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18098,7 +18379,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
           <td class="no phantom">No</td>
           <td class="no node">No</td>
           <td class="no nodeharmony">No</td>
-          <td class="no ejs">No<a href="#ejs-no-with-note"><sup>[15]</sup></a></td>
+          <td class="no ejs">No<a href="#ejs-no-with-note"><sup>[16]</sup></a></td>
           <td class="no ios7">No</td>
           <td class="no ios8">No</td>
         </tr>
@@ -18107,6 +18388,7 @@ test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.uns
 
           <td class="tally tr" data-tally="0">0/5</td>
           <td class="tally _6to5" data-tally="0">0/5</td>
+          <td class="tally es6tr" data-tally="0">0/5</td>
           <td class="tally closure" data-tally="0">0/5</td>
           <td class="tally jsx" data-tally="0">0/5</td>
           <td class="tally typescript" data-tally="0">0/5</td>
@@ -18168,6 +18450,7 @@ test(function(){try{return Function("\nreturn /./igm.flags === \"gim\" && /./.fl
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18229,6 +18512,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.mat
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18290,6 +18574,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.rep
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18351,6 +18636,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.spl
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18412,6 +18698,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.sea
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18469,6 +18756,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.sea
 
           <td class="tally tr" data-tally="1">2/2</td>
           <td class="tally _6to5" data-tally="1">2/2</td>
+          <td class="tally es6tr" data-tally="0">0/2</td>
           <td class="tally closure" data-tally="0">0/2</td>
           <td class="tally jsx" data-tally="0">0/2</td>
           <td class="tally typescript" data-tally="0">0/2</td>
@@ -18530,6 +18818,7 @@ test(function(){try{return Function("\nreturn typeof Array.from === 'function';\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18592,6 +18881,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18649,6 +18939,7 @@ test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\
 
           <td class="tally tr" data-tally="0.75">6/8</td>
           <td class="tally _6to5" data-tally="0.875">7/8</td>
+          <td class="tally es6tr" data-tally="0">0/8</td>
           <td class="tally closure" data-tally="0">0/8</td>
           <td class="tally jsx" data-tally="0">0/8</td>
           <td class="tally typescript" data-tally="0">0/8</td>
@@ -18710,6 +19001,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin 
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18771,6 +19063,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18832,6 +19125,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex =
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18893,6 +19187,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -18954,6 +19249,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19015,6 +19311,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19024,21 +19321,21 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="no firefox11 obsolete">No</td>
           <td class="no firefox13 obsolete">No</td>
           <td class="no firefox16 obsolete">No</td>
-          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[16]</sup></a></td>
-          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[16]</sup></a></td>
-          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[16]</sup></a></td>
-          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[16]</sup></a></td>
-          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[16]</sup></a></td>
-          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[17]</sup></a></td>
-          <td class="no firefox36">No<a href="#array-prototype-iterator-note"><sup>[18]</sup></a></td>
+          <td class="no firefox17 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
+          <td class="no firefox18 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
+          <td class="no firefox23 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
+          <td class="no firefox24 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
+          <td class="no firefox25 obsolete">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
+          <td class="no firefox27 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox28 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox29 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox30 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox32 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox33 obsolete">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
+          <td class="no firefox36">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
           <td class="no chrome21dev obsolete">No</td>
@@ -19049,9 +19346,9 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.values === 
           <td class="yes chrome35 obsolete">Yes</td>
           <td class="yes chrome36 obsolete">Yes</td>
           <td class="yes chrome37 obsolete">Yes</td>
-          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[18]</sup></a></td>
-          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[18]</sup></a></td>
-          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[18]</sup></a></td>
+          <td class="no chrome38 obsolete">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
+          <td class="no chrome39">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
+          <td class="no chrome40">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
           <td class="no safari51 obsolete">No</td>
           <td class="no safari6">No</td>
           <td class="no safari7">No</td>
@@ -19076,6 +19373,7 @@ test(function(){try{return Function("\nreturn typeof Array.prototype.entries ===
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19145,6 +19443,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19202,6 +19501,7 @@ test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.
 
           <td class="tally tr" data-tally="1">7/7</td>
           <td class="tally _6to5" data-tally="1">7/7</td>
+          <td class="tally es6tr" data-tally="0">0/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
           <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
@@ -19263,6 +19563,7 @@ test(function(){try{return Function("\nreturn typeof Number.isFinite === 'functi
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19324,6 +19625,7 @@ test(function(){try{return Function("\nreturn typeof Number.isInteger === 'funct
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19385,6 +19687,7 @@ test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'f
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19446,6 +19749,7 @@ test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function'
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19507,6 +19811,7 @@ test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number'
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19568,6 +19873,7 @@ test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER ===
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19629,6 +19935,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
 
           <td class="yes tr">Yes</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19686,6 +19993,7 @@ test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER ===
 
           <td class="tally tr" data-tally="0">0/17</td>
           <td class="tally _6to5" data-tally="1">17/17</td>
+          <td class="tally es6tr" data-tally="0">0/17</td>
           <td class="tally closure" data-tally="0">0/17</td>
           <td class="tally jsx" data-tally="0">0/17</td>
           <td class="tally typescript" data-tally="0">0/17</td>
@@ -19747,6 +20055,7 @@ test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19808,6 +20117,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19834,7 +20144,7 @@ test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";
           <td class="yes firefox36">Yes</td>
           <td class="no chrome obsolete">No</td>
           <td class="no chrome19dev obsolete">No</td>
-          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[19]</sup></a></td>
+          <td class="yes chrome21dev obsolete">Yes<a href="#chromu-imul-note"><sup>[20]</sup></a></td>
           <td class="yes chrome30 obsolete">Yes</td>
           <td class="yes chrome31 obsolete">Yes</td>
           <td class="yes chrome33 obsolete">Yes</td>
@@ -19869,6 +20179,7 @@ test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19930,6 +20241,7 @@ test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -19991,6 +20303,7 @@ test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20052,6 +20365,7 @@ test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20113,6 +20427,7 @@ test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20174,6 +20489,7 @@ test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20235,6 +20551,7 @@ test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20296,6 +20613,7 @@ test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20357,6 +20675,7 @@ test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20418,6 +20737,7 @@ test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20479,6 +20799,7 @@ test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20540,6 +20861,7 @@ test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20601,6 +20923,7 @@ test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\"
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20662,6 +20985,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20676,7 +21000,7 @@ test(function(){try{return Function("\nreturn typeof Math.fround === \"function\
           <td class="no firefox23 obsolete">No</td>
           <td class="no firefox24 obsolete">No</td>
           <td class="no firefox25 obsolete">No</td>
-          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[20]</sup></a></td>
+          <td class="yes firefox27 obsolete">Yes<a href="#fx-fround-note"><sup>[21]</sup></a></td>
           <td class="yes firefox28 obsolete">Yes</td>
           <td class="yes firefox29 obsolete">Yes</td>
           <td class="yes firefox30 obsolete">Yes</td>
@@ -20723,6 +21047,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20780,6 +21105,7 @@ test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";
 
           <td class="tally tr" data-tally="0">0/7</td>
           <td class="tally _6to5" data-tally="0.42857142857142855">3/7</td>
+          <td class="tally es6tr" data-tally="0">0/7</td>
           <td class="tally closure" data-tally="0">0/7</td>
           <td class="tally jsx" data-tally="0">0/7</td>
           <td class="tally typescript" data-tally="0">0/7</td>
@@ -20842,6 +21168,7 @@ test(function(){try{return Function("\n'use strict';\nreturn this === undefined 
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20903,6 +21230,7 @@ test(function(){try{return Function("\ndo {} while (false) return true;\n      "
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -20969,6 +21297,7 @@ test(function(){try{return Function("\ntry {\n  eval('for (var i = 0 in {}) {}')
 
           <td class="no tr">No</td>
           <td class="yes _6to5">Yes</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -21034,6 +21363,7 @@ test(function(){try{return Function("\ntry {\n  new (Object.getOwnPropertyDescri
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -21102,6 +21432,7 @@ test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'prevent
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -21163,6 +21494,7 @@ test(function(){try{return Function("\nreturn new Date(NaN) + \"\" === \"Invalid
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -21224,6 +21556,7 @@ test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global ==
 
           <td class="no tr">No</td>
           <td class="no _6to5">No</td>
+          <td class="no es6tr">No</td>
           <td class="no closure">No</td>
           <td class="no jsx">No</td>
           <td class="no typescript">No</td>
@@ -21277,7 +21610,7 @@ test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global ==
           <td class="no ios8">No</td>
         </tr>
         <tr>
-          <th colspan="56" class="separator"></th>
+          <th colspan="57" class="separator"></th>
         </tr>
         <tr>
           <td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span></td>
@@ -21296,6 +21629,7 @@ test(function(){try{return Function("\n// Note: only available outside of strict
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21349,10 +21683,11 @@ test(function(){try{return Function("\n// Note: only available outside of strict
           <td class="no ios8">No</td>
         </tr>
         <tr class="supertest">
-          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[21]</sup></a></span></td>
+          <td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[22]</sup></a></span></td>
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/5</td>
+          <td title="This feature is optional on non-browser platforms." class="tally es6tr not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally jsx not-applicable " data-tally="0">0/5</td>
           <td title="This feature is optional on non-browser platforms." class="tally typescript not-applicable " data-tally="0">0/5</td>
@@ -21415,6 +21750,7 @@ test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Arra
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21481,6 +21817,7 @@ test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __prot
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21546,6 +21883,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21611,6 +21949,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21675,6 +22014,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21732,6 +22072,7 @@ test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array
 
           <td title="This feature is optional on non-browser platforms." class="tally tr not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally _6to5 not-applicable " data-tally="0">0/3</td>
+          <td title="This feature is optional on non-browser platforms." class="tally es6tr not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally closure not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally jsx not-applicable " data-tally="0">0/3</td>
           <td title="This feature is optional on non-browser platforms." class="tally typescript not-applicable " data-tally="0">0/3</td>
@@ -21794,6 +22135,7 @@ test(function(){try{return Function("\nvar A = function(){};\nreturn (new A())._
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21857,6 +22199,7 @@ test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototyp
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21925,6 +22268,7 @@ test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescripto
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -21994,6 +22338,7 @@ test(function(){try{return Function("\nvar i, names = [\"anchor\", \"big\", \"bo
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -22056,6 +22401,7 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
 
           <td title="This feature is optional on non-browser platforms." class="no tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no _6to5 not-applicable ">No</td>
+          <td title="This feature is optional on non-browser platforms." class="no es6tr not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no closure not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no jsx not-applicable ">No</td>
           <td title="This feature is optional on non-browser platforms." class="no typescript not-applicable ">No</td>
@@ -22136,47 +22482,50 @@ test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile ==
       <p id="fx-let-tdz-note">
         <sup>[7]</sup> Available from Firefox 35 for code in a <code>&lt;script type="application/javascript;version=1.7"></code> (or <code>version=1.8</code>) tag.
       </p>
+      <p id="compiler-iterable-note">
+        <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>"@@iterator"</code> method.
+      </p>
+      <p id="compiler-proto-note">
+        <sup>[9]</sup> Requires native support for <code>Object.prototype.__proto__</code>
+      </p>
       <p id="compiled-extends-note">
-        <sup>[8]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.
+        <sup>[10]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.
       </p>
       <p id="fx-proxy-get-note">
-        <sup>[9]</sup> Firefox doesn't allow a proxy's "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy's "has" handler reports it as present).
+        <sup>[11]</sup> Firefox doesn't allow a proxy's "get" handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy's "has" handler reports it as present).
       </p>
       <p id="fx-proxy-getown-note">
-        <sup>[10]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
+        <sup>[12]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible
       </p>
       <p id="fx-proxy-ownkeys-note">
-        <sup>[11]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
+        <sup>[13]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler
       </p>
       <p id="block-level-function-note">
-        <sup>[12]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
-      </p>
-      <p id="setprototypeof-polyfill-note">
-        <sup>[13]</sup> Requires native support for <code>Object.prototype.__proto__</code>
+        <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.
       </p>
       <p id="string-contains-note">
-        <sup>[14]</sup> Available as the draft standard <code>String.prototype.contains</code>
+        <sup>[15]</sup> Available as the draft standard <code>String.prototype.contains</code>
       </p>
       <p id="ejs-no-with-note">
-        <sup>[15]</sup> <code>with</code> is not supported in ejs
+        <sup>[16]</sup> <code>with</code> is not supported in ejs
       </p>
       <p id="fx-array-prototype-values-note">
-        <sup>[16]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
+        <sup>[17]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code>
       </p>
       <p id="fx-array-prototype-values-2-note">
-        <sup>[17]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>
+        <sup>[18]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype["@@iterator"]</code>
       </p>
       <p id="array-prototype-iterator-note">
-        <sup>[18]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
+        <sup>[19]</sup> Available as <code>Array.prototype[Symbol.iterator]</code>
       </p>
       <p id="chromu-imul-note">
-        <sup>[19]</sup> Available since Chrome 28
+        <sup>[20]</sup> Available since Chrome 28
       </p>
       <p id="fx-fround-note">
-        <sup>[20]</sup> Available since Firefox 26
+        <sup>[21]</sup> Available since Firefox 26
       </p>
       <p id="proto-in-object-literals-note">
-        <sup>[21]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
+        <sup>[22]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.
       </p>
     </div>
   </div>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -83,7 +83,7 @@
       <thead>
         <tr>
           <th colspan="3"  class="platformtype"></th>
-          <th colspan="5"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
+          <th colspan="6"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers</th>
           <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
           <th colspan="5"  class="platformtype" id="engine-header" style="background: #f8e8a0">Server-ish</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>


### PR DESCRIPTION
This adds a column for [ES6 Transpiler](https://github.com/termi/es6-transpiler), and updates the results for Traceur and JSX, as well as correcting a result for IETP.

One thing I'm not too sure of is whether compiler features that require native `__proto__` should be listed as "Yes" or "No". Currently I'm using "No" because they don't work in IE10 (which is arguably a mandatory feature for a compiler).
