### PR TITLE
Sort compilers by most ES6/7 support

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -10,15 +10,15 @@ exports.target_file = 'es6/index.html';
 exports.skeleton_file = 'es6/skeleton.html';
 
 exports.browsers = {
-  tr: {
-    full: 'Traceur',
-    short: 'Traceur',
-    obsolete: false,
-    platformtype: 'compiler',
-  },
   _6to5: {
     full: '6to5',
     short: '6to5 +<br>polyfill',
+    obsolete: false,
+    platformtype: 'compiler',
+  },
+  tr: {
+    full: 'Traceur',
+    short: 'Traceur',
     obsolete: false,
     platformtype: 'compiler',
   },
@@ -1685,12 +1685,12 @@ exports.tests = [
         function * generatorFn(){}
         var ownProto = Object.getPrototypeOf(generatorFn());
         var passed = ownProto === generatorFn.prototype;
-        
+
         var sharedProto = Object.getPrototypeOf(ownProto);
         passed &= sharedProto !== Object.prototype &&
           sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&
           sharedProto.hasOwnProperty('next');
-        
+
         return passed;
       */},
       res: {

--- a/data-es7.js
+++ b/data-es7.js
@@ -5,12 +5,6 @@ exports.target_file = 'es7/index.html';
 exports.skeleton_file = 'es7/skeleton.html';
 
 exports.browsers = {
-  tr: {
-    full: 'Traceur compiler',
-    short: 'Traceur',
-    obsolete: false, // always up-to-date version
-    platformtype: 'compiler',
-  },
   _6to5: {
     full: '6to5',
     short: '6to5 +<br>polyfill',
@@ -18,6 +12,12 @@ exports.browsers = {
     platformtype: 'compiler',
     note_id: 'experimental-flag',
     note_html: 'Have to be enabled via --experimental flag'
+  },
+  tr: {
+    full: 'Traceur compiler',
+    short: 'Traceur',
+    obsolete: false, // always up-to-date version
+    platformtype: 'compiler',
   },
   ie11: {
     full: 'Internet Explorer',

--- a/es6/index.html
+++ b/es6/index.html
@@ -102,8 +102,8 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
-<th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr></a></th>
+        <th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr></a></th>
+<th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
 <th class="platform es6tr compiler"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Transpiler</abbr></a></th>
 <th class="platform closure compiler"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141120">Closure<br>Compiler</abbr></a></th>
 <th class="platform jsx compiler"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[1]</sup></a></a></th>
@@ -170,8 +170,8 @@ return (function f(n){
 }(1e6)) === &quot;foo&quot;;
   ">test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -225,8 +225,8 @@ return (function f(n){
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.7777777777777778">7/9</td>
 <td data-browser="_6to5" class="tally" data-tally="0.7777777777777778">7/9</td>
+<td data-browser="tr" class="tally" data-tally="0.7777777777777778">7/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6666666666666666">6/9</td>
 <td data-browser="closure" class="tally" data-tally="0.7777777777777778">7/9</td>
 <td data-browser="jsx" class="tally" data-tally="0.6666666666666666">6/9</td>
@@ -283,8 +283,8 @@ return (function f(n){
 return (() =&gt; 5)() === 5;
       ">test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -342,8 +342,8 @@ var b = x =&gt; x + &quot;foo&quot;;
 return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
       ">test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fee fie foe \") === \"fee fie foe foo\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -401,8 +401,8 @@ var c = (v, w, x, y, z) =&gt; &quot;&quot; + v + w + x + y + z;
 return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
       ">test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w + x + y + z;\nreturn (c(6, 5, 4, 3, 2) === \"65432\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -461,8 +461,8 @@ var e = { x : &quot;baz&quot;, y : d };
 return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;) === &quot;barley&quot;;
       ">test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }}.y();\nvar e = { x : \"baz\", y : d };\nreturn d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -521,8 +521,8 @@ var e = { x : &quot;bar&quot; };
 return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo&quot;;
       ">test(function(){try{return Function("\nvar d = { x : \"foo\", y : function() { return () => this.x; }};\nvar e = { x : \"bar\" };\nreturn d.y().call(e) === \"foo\" && d.y().apply(e) === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -581,8 +581,8 @@ var e = { x : &quot;baz&quot; };
 return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
       ">test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }};\nvar e = { x : \"baz\" };\nreturn d.y().bind(e, \"ley\")() === \"barley\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -640,8 +640,8 @@ var f = (function() { return z =&gt; arguments[0]; }(5));
 return f(6) === 5;
       ">test(function(){try{return Function("\nvar f = (function() { return z => arguments[0]; }(5));\nreturn f(6) === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -700,8 +700,8 @@ return (() =&gt; {
 })();
       ">test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n})();\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -759,8 +759,8 @@ var a = () =&gt; 5;
 return !a.hasOwnProperty(&quot;prototype&quot;);
       ">test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnProperty(\"prototype\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -814,8 +814,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="const"><span><a class="anchor" href="#const">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">const</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="_6to5" class="tally" data-tally="0.75">6/8</td>
+<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="closure" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="jsx" class="tally" data-tally="0.125">1/8</td>
@@ -873,8 +873,8 @@ const foo = 123;
 return (foo === 123);
       ">test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -933,8 +933,8 @@ const bar = 123;
 return bar === 123;
       ">test(function(){try{return Function("\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -996,8 +996,8 @@ try {
 }
       ">test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1056,8 +1056,8 @@ const qux = 456;
 return passed;
       ">test(function(){try{return Function("\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1116,8 +1116,8 @@ const foo = 123;
 return (foo === 123);
       ">test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1177,8 +1177,8 @@ const bar = 123;
 return bar === 123;
       ">test(function(){try{return Function("\n'use strict';\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1241,8 +1241,8 @@ try {
 }
       ">test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  Function(\"'use strict'; const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1302,8 +1302,8 @@ const qux = 456;
 return passed;
       ">test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1357,8 +1357,8 @@ return passed;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="let"><span><a class="anchor" href="#let">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">let</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8">8/10</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8">8/10</td>
+<td data-browser="tr" class="tally" data-tally="0.8">8/10</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">6/10</td>
 <td data-browser="closure" class="tally" data-tally="0.8">8/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
@@ -1416,8 +1416,8 @@ let foo = 123;
 return (foo === 123);
       ">test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1476,8 +1476,8 @@ let bar = 123;
 return bar === 123;
       ">test(function(){try{return Function("\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1536,8 +1536,8 @@ for(let baz = 0; false; false) {}
 return baz === 1;
       ">test(function(){try{return Function("\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1596,8 +1596,8 @@ let qux = 456;
 return passed;
       ">test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1665,8 +1665,8 @@ passed &amp;= (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&
 return passed;
       ">test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1725,8 +1725,8 @@ let foo = 123;
 return (foo === 123);
       ">test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1786,8 +1786,8 @@ let bar = 123;
 return bar === 123;
       ">test(function(){try{return Function("\n'use strict';\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1847,8 +1847,8 @@ for(let baz = 0; false; false) {}
 return baz === 1;
       ">test(function(){try{return Function("\n'use strict';\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1908,8 +1908,8 @@ let qux = 456;
 return passed;
       ">test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -1978,8 +1978,8 @@ passed &amp;= (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&
 return passed;
       ">test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2033,8 +2033,8 @@ return passed;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.6">3/5</td>
 <td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
+<td data-browser="tr" class="tally" data-tally="0.6">3/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">3/5</td>
 <td data-browser="closure" class="tally" data-tally="0.8">4/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -2091,8 +2091,8 @@ return passed;
 return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
       ">test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2149,8 +2149,8 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined, 3));
       ">test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2207,8 +2207,8 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 return (function (a, b = a) { return b === 5; }(5));
       ">test(function(){try{return Function("\nreturn (function (a, b = a) { return b === 5; }(5));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2275,8 +2275,8 @@ return (function(x = 1) {
 }());
       ">test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    eval(\"(function(a=a){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=b,b){}())\");\n    return false;\n  } catch(e) {}\n  return true;\n}());\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2338,8 +2338,8 @@ return (function(a=function(){
 }());
       ">test(function(){try{return Function("\nreturn (function(a=function(){\n  return typeof b === 'undefined';\n}){\n  var b = 1;\n  return a();\n}());\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2393,8 +2393,8 @@ return (function(a=function(){
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6666666666666666">2/3</td>
 <td data-browser="closure" class="tally" data-tally="0.3333333333333333">1/3</td>
 <td data-browser="jsx" class="tally" data-tally="0.6666666666666666">2/3</td>
@@ -2453,8 +2453,8 @@ return (function (foo, ...args) {
 }(&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;));
       ">test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  return args instanceof Array && args + \"\" === \"bar,baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -2511,8 +2511,8 @@ return (function (foo, ...args) {
 return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0;
       ">test(function(){try{return Function("\nreturn function(a, ...b){}.length === 1 && function(...c){}.length === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -2577,8 +2577,8 @@ return (function (foo, ...args) {
 }(&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;));
       ">test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  foo = \"qux\";\n  // The arguments object is not mapped to the\n  // parameters, even outside of strict mode.\n  return arguments.length === 3\n    && arguments[0] === \"foo\"\n    && arguments[1] === \"bar\"\n    && arguments[2] === \"baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2632,8 +2632,8 @@ return (function (foo, ...args) {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">8/8</td>
 <td data-browser="_6to5" class="tally" data-tally="1">8/8</td>
+<td data-browser="tr" class="tally" data-tally="1">8/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="closure" class="tally" data-tally="0.25">2/8</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/8</td>
@@ -2690,8 +2690,8 @@ return (function (foo, ...args) {
 return Math.max(...[1, 2, 3]) === 3
       ">test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2748,8 +2748,8 @@ return Math.max(...[1, 2, 3]) === 3
 return [...[1, 2, 3]][2] === 3;
       ">test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2806,8 +2806,8 @@ return [...[1, 2, 3]][2] === 3;
 return Math.max(...&quot;1234&quot;) === 4;
       ">test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2864,8 +2864,8 @@ return Math.max(...&quot;1234&quot;) === 4;
 return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
       ">test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2923,8 +2923,8 @@ var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...iterable) === 3;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2982,8 +2982,8 @@ var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot
 return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -3041,8 +3041,8 @@ var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...Object.create(iterable)) === 3;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -3100,8 +3100,8 @@ var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot
 return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d&quot;;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -3155,8 +3155,8 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="class"><span><a class="anchor" href="#class">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.7272727272727273">8/11</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8181818181818182">9/11</td>
+<td data-browser="tr" class="tally" data-tally="0.7272727272727273">8/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="closure" class="tally" data-tally="0.45454545454545453">5/11</td>
 <td data-browser="jsx" class="tally" data-tally="0.7272727272727273">8/11</td>
@@ -3214,8 +3214,8 @@ class C {}
 return typeof C === &quot;function&quot;;
       ">test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3278,8 +3278,8 @@ var c1 = C;
 return C === c1;
       ">test(function(){try{return Function("\nclass C {}\nvar c1 = C;\n{\n  class C {}\n  var c2 = C;\n}\nreturn C === c1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3336,8 +3336,8 @@ return C === c1;
 return typeof class C {} === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof class C {} === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3398,8 +3398,8 @@ return C.prototype.constructor === C
   &amp;&amp; new C().x === 1;
       ">test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; }\n}\nreturn C.prototype.constructor === C\n  && new C().x === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3460,8 +3460,8 @@ return typeof C.prototype.method === &quot;function&quot;
   &amp;&amp; new C().method() === 2;
       ">test(function(){try{return Function("\nclass C {\n  method() { return 2; }\n}\nreturn typeof C.prototype.method === \"function\"\n  && new C().method() === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3522,8 +3522,8 @@ return typeof C.method === &quot;function&quot;
   &amp;&amp; C.method() === 3;
       ">test(function(){try{return Function("\nclass C {\n  static method() { return 3; }\n}\nreturn typeof C.method === \"function\"\n  && C.method() === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3586,8 +3586,8 @@ new C().bar = true;
 return new C().foo === &quot;foo&quot; &amp;&amp; baz;
       ">test(function(){try{return Function("\nvar baz = false;\nclass C {\n  get foo() { return \"foo\"; }\n  set bar(x) { baz = x; }\n}\nnew C().bar = true;\nreturn new C().foo === \"foo\" && baz;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -3650,8 +3650,8 @@ C.bar = true;
 return C.foo === &quot;foo&quot; &amp;&amp; baz;
       ">test(function(){try{return Function("\nvar baz = false;\nclass C {\n  static get foo() { return \"foo\"; }\n  static set bar(x) { baz = x; }\n}\nC.bar = true;\nreturn C.foo === \"foo\" && baz;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -3712,8 +3712,8 @@ var c = class C {
 return c();
       ">test(function(){try{return Function("\nvar c = class C {\n  static method() { return this === undefined; }\n}.method;\n\nreturn c();\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3774,8 +3774,8 @@ return c instanceof Array
   &amp;&amp; Array.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{return Function("\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof Array\n  && Array.isPrototypeOf(C)\n  && Array.prototype.isPrototypeOf(C.prototype);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[10]</sup></a></td>
@@ -3836,8 +3836,8 @@ return !(c instanceof Object)
   &amp;&amp; Object.getPrototypeOf(C.prototype) === null;
       ">test(function(){try{return Function("\nclass C extends null {}\nvar c = new C();\nreturn !(c instanceof Object)\n  && Function.prototype.isPrototypeOf(C)\n  && Object.getPrototypeOf(C.prototype) === null;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3891,8 +3891,8 @@ return !(c instanceof Object)
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="super"><span><a class="anchor" href="#super">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword">super</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
+<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="closure" class="tally" data-tally="0">0/3</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/3</td>
@@ -3954,8 +3954,8 @@ class B extends class {
 return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
       ">test(function(){try{return Function("\nclass B extends class {\n  constructor(a) { return [\"foo\" + a]; }\n} {\n  constructor(a) { return super(\"bar\" + a); }\n}\nreturn new B(\"baz\")[0] === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4017,8 +4017,8 @@ class B extends class {
 return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
       ">test(function(){try{return Function("\nclass B extends class {\n  qux(a) { return \"foo\" + a; }\n} {\n  qux(a) { return super.qux(\"bar\" + a); }\n}\nreturn new B().qux(\"baz\") === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4084,8 +4084,8 @@ var obj = {
 return obj.qux() === &quot;barley&quot;;
       ">test(function(){try{return Function("\nclass B extends class {\n  qux() { return \"bar\"; }\n} {\n  qux() { return super.qux() + this.corge; }\n}\nvar obj = {\n  qux: B.prototype.qux,\n  corge: \"ley\"\n};\nreturn obj.qux() === \"barley\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4139,8 +4139,8 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser">object literal extensions</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
+<td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="closure" class="tally" data-tally="1">3/3</td>
 <td data-browser="jsx" class="tally" data-tally="0.6666666666666666">2/3</td>
@@ -4198,8 +4198,8 @@ var x = &apos;y&apos;;
 return ({ [x]: 1 }).y === 1;
       ">test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4257,8 +4257,8 @@ var a = 7, b = 8, c = {a,b};
 return c.a === 7 &amp;&amp; c.b === 8;
       ">test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a === 7 && c.b === 8;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -4315,8 +4315,8 @@ return c.a === 7 &amp;&amp; c.b === 8;
 return ({ y() { return 2; } }).y() === 2;
       ">test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -4370,8 +4370,8 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="for..of_loops"><span><a class="anchor" href="#for..of_loops">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">4/4</td>
 <td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
+<td data-browser="tr" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="closure" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -4430,8 +4430,8 @@ for (var item of arr)
   return item === 5;
       ">test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  return item === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4491,8 +4491,8 @@ for (var item of &quot;foo&quot;)
 return str === &quot;foo&quot;;
       ">test(function(){try{return Function("\nvar str = \"\";\nfor (var item of \"foo\")\n  str += item;\nreturn str === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4554,8 +4554,8 @@ for (var item of iterable) {
 return result === &quot;123&quot;;
       ">test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4617,8 +4617,8 @@ for (var item of Object.create(iterable)) {
 return result === &quot;123&quot;;
       ">test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4672,8 +4672,8 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="generators"><span><a class="anchor" href="#generators">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9166666666666666">11/12</td>
 <td data-browser="_6to5" class="tally" data-tally="0.9166666666666666">11/12</td>
+<td data-browser="tr" class="tally" data-tally="0.9166666666666666">11/12</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/12</td>
 <td data-browser="closure" class="tally" data-tally="0.5">6/12</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/12</td>
@@ -4740,8 +4740,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4808,8 +4808,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nfunction * generator(){\n  yield this.x; yield this.y;\n};\nvar iterator = { g: generator, x: 5, y: 6 }.g();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4874,8 +4874,8 @@ iterator.next(&quot;bar&quot;);
 return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
       ">test(function(){try{return Function("\nvar sent;\nfunction * generator(){\n  sent = [yield 5, yield 6];\n};\nvar iterator = generator();\niterator.next();\niterator.next(\"foo\");\niterator.next(\"bar\");\nreturn sent[0] === \"foo\" && sent[1] === \"bar\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4941,8 +4941,8 @@ passed &amp;= sharedProto !== Object.prototype &amp;&amp;
 return passed;
       ">test(function(){try{return Function("\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5010,8 +5010,8 @@ iterator.throw(&quot;foo&quot;);
 return passed;
       ">test(function(){try{return Function("\nvar passed = false;\nfunction * generator(){\n  try {\n    yield 5; yield 6;\n  } catch(e) {\n    passed = (e === \"foo\");\n  }\n};\nvar iterator = generator();\niterator.next();\niterator.throw(\"foo\");\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5078,8 +5078,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.return(\"quxquux\");\npassed    &= item.value === \"quxquux\" && item.done === true;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5143,8 +5143,8 @@ iterator.next(true);
 return passed;
       ">test(function(){try{return Function("\nvar passed;\nfunction * generator(){\n  passed = yield 0 ? true : false;\n};\nvar iterator = generator();\niterator.next();\niterator.next(true);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5210,8 +5210,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5277,8 +5277,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5346,8 +5346,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * window.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5415,8 +5415,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5485,8 +5485,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5540,8 +5540,8 @@ return passed;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="tr" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="closure" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -5598,8 +5598,8 @@ return passed;
 return 0o10 === 8 &amp;&amp; 0O10 === 8;
       ">test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5656,8 +5656,8 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 return 0b10 === 2 &amp;&amp; 0B10 === 2;
       ">test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5714,8 +5714,8 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 return Number(&apos;0o1&apos;) === 1;
       ">test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5772,8 +5772,8 @@ return Number(&apos;0o1&apos;) === 1;
 return Number(&apos;0b1&apos;) === 1;
       ">test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -5827,8 +5827,8 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="template_strings"><span><a class="anchor" href="#template_strings">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">template strings</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="1">2/2</td>
+<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="closure" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="1">2/2</td>
@@ -5887,8 +5887,8 @@ return `foo bar
 ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
       ">test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo bar\n${a + \"z\"} ${b.toLowerCase()}` === \"foo bar\\nbaz qux\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -5956,8 +5956,8 @@ function fn(parts, a, b) {
 return fn `foo${123}bar\n${456}` &amp;&amp; called;
       ">test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a, b) {\n  called = true;\n  return parts instanceof Array &&\n    parts[0]     === \"foo\"      &&\n    parts[1]     === \"bar\\n\"    &&\n    parts.raw[0] === \"foo\"      &&\n    parts.raw[1] === \"bar\\\\n\"   &&\n    a === 123                   &&\n    b === 456;\n}\nreturn fn `foo${123}bar\\n${456}` && called;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -6011,8 +6011,8 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky">RegExp "y" and "u" flags</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.5">1/2</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="tr" class="tally" data-tally="0.5">1/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="closure" class="tally" data-tally="0">0/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -6073,8 +6073,8 @@ re2.exec(&apos;xy&apos;);
 return (re.exec(&apos;xy&apos;)[0] === &apos;x&apos; &amp;&amp; re2.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
       ">test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = new RegExp('\\\\w', 'y');\nre.exec('xy');\nre2.exec('xy');\nreturn (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6131,8 +6131,8 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;x&apos; &amp;&amp; re2.exec(&apos;x
 return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
       ">test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6186,8 +6186,8 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="typed_arrays"><span><a class="anchor" href="#typed_arrays">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects">typed arrays</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/40</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/40</td>
+<td data-browser="tr" class="tally" data-tally="0">0/40</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/40</td>
 <td data-browser="closure" class="tally" data-tally="0">0/40</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/40</td>
@@ -6246,8 +6246,8 @@ var view = new Int8Array(buffer);         view[0] = 0x80;
 return view[0] === -0x80;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6306,8 +6306,8 @@ var view = new Uint8Array(buffer);        view[0] = 0x100;
 return view[0] === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6366,8 +6366,8 @@ var view = new Uint8ClampedArray(buffer); view[0] = 0x100;
 return view[0] === 0xFF;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6426,8 +6426,8 @@ var view = new Int16Array(buffer);        view[0] = 0x8000;
 return view[0] === -0x8000;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6486,8 +6486,8 @@ var view = new Uint16Array(buffer);       view[0] = 0x10000;
 return view[0] === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6546,8 +6546,8 @@ var view = new Int32Array(buffer);        view[0] = 0x80000000;
 return view[0] === -0x80000000;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6606,8 +6606,8 @@ var view = new Uint32Array(buffer);       view[0] = 0x100000000;
 return view[0] === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6666,8 +6666,8 @@ var view = new Float32Array(buffer);       view[0] = 0.1;
 return view[0] === 0.10000000149011612;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6726,8 +6726,8 @@ var view = new Float64Array(buffer);       view[0] = 0.1;
 return view[0] === 0.1;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6787,8 +6787,8 @@ view.setInt8 (0, 0x80);
 return view.getInt8(0) === -0x80;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6848,8 +6848,8 @@ view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6909,8 +6909,8 @@ view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -6970,8 +6970,8 @@ view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7031,8 +7031,8 @@ view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7092,8 +7092,8 @@ view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7153,8 +7153,8 @@ view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7214,8 +7214,8 @@ view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
       ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7280,8 +7280,8 @@ return typeof Int8Array.from === &quot;function&quot; &amp;&amp;
   typeof Float64Array.from === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7346,8 +7346,8 @@ return typeof Int8Array.of === &quot;function&quot; &amp;&amp;
   typeof Float64Array.of === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7412,8 +7412,8 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.subarray === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7478,8 +7478,8 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.join === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7544,8 +7544,8 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7610,8 +7610,8 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp
   typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7676,8 +7676,8 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.slice === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7742,8 +7742,8 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.every === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7808,8 +7808,8 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.filter === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7874,8 +7874,8 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.forEach === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -7940,8 +7940,8 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.map === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8006,8 +8006,8 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reduce === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8072,8 +8072,8 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &amp;&amp
   typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8138,8 +8138,8 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reverse === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8204,8 +8204,8 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.some === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8270,8 +8270,8 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.sort === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8336,8 +8336,8 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8402,8 +8402,8 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.find === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8468,8 +8468,8 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8534,8 +8534,8 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.fill === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8600,8 +8600,8 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.keys === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8666,8 +8666,8 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.values === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8732,8 +8732,8 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.entries === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8787,8 +8787,8 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Map"><span><a class="anchor" href="#Map">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="_6to5" class="tally" data-tally="1">11/11</td>
+<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="closure" class="tally" data-tally="0">0/11</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/11</td>
@@ -8850,8 +8850,8 @@ map.set(key, 123);
 return map.has(key) &amp;&amp; map.get(key) === 123;
       ">test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8913,8 +8913,8 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
        map.has(key2) &amp;&amp; map.get(key2) === 456;
       ">test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -8972,8 +8972,8 @@ var map = new Map();
 return map.set(0, 0) === map;
       ">test(function(){try{return Function("\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9036,8 +9036,8 @@ map.forEach(function (value, key) {
 return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
       ">test(function(){try{return Function("\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9099,8 +9099,8 @@ map.set(key, 123);
 return map.size === 1;
       ">test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9157,8 +9157,8 @@ return map.size === 1;
 return typeof Map.prototype.delete === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9215,8 +9215,8 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 return typeof Map.prototype.clear === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9273,8 +9273,8 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 return typeof Map.prototype.forEach === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.forEach === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9331,8 +9331,8 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 return typeof Map.prototype.keys === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.keys === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9389,8 +9389,8 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 return typeof Map.prototype.values === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.values === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9447,8 +9447,8 @@ return typeof Map.prototype.values === &quot;function&quot;;
 return typeof Map.prototype.entries === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9502,8 +9502,8 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="Set"><span><a class="anchor" href="#Set">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="_6to5" class="tally" data-tally="1">11/11</td>
+<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="closure" class="tally" data-tally="0">0/11</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/11</td>
@@ -9566,8 +9566,8 @@ set.add(123);
 return set.has(123);
       ">test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9628,8 +9628,8 @@ var set = new Set([obj1, obj2]);
 return set.has(obj1) &amp;&amp; set.has(obj2);
       ">test(function(){try{return Function("\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9687,8 +9687,8 @@ var set = new Set();
 return set.add(0) === set;
       ">test(function(){try{return Function("\nvar set = new Set();\nreturn set.add(0) === set;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9751,8 +9751,8 @@ set.forEach(function (value) {
 return k === Infinity &amp;&amp; set.has(+0);
       ">test(function(){try{return Function("\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9816,8 +9816,8 @@ set.add(456);
 return set.size === 2;
       ">test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9874,8 +9874,8 @@ return set.size === 2;
 return typeof Set.prototype.delete === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9932,8 +9932,8 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 return typeof Set.prototype.clear === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -9990,8 +9990,8 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 return typeof Set.prototype.forEach === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.forEach === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10048,8 +10048,8 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 return typeof Set.prototype.keys === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.keys === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10106,8 +10106,8 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 return typeof Set.prototype.values === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.values === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10164,8 +10164,8 @@ return typeof Set.prototype.values === &quot;function&quot;;
 return typeof Set.prototype.entries === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10219,8 +10219,8 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/4</td>
+<td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -10282,8 +10282,8 @@ weakmap.set(key, 123);
 return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
       ">test(function(){try{return Function("\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10345,8 +10345,8 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
        weakmap.has(key2) &amp;&amp; weakmap.get(key2) === 456;
       ">test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10405,8 +10405,8 @@ var key = {};
 return weakmap.set(key, 0) === weakmap;
       ">test(function(){try{return Function("\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10463,8 +10463,8 @@ return weakmap.set(key, 0) === weakmap;
 return typeof WeakMap.prototype.delete === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10518,8 +10518,8 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/4</td>
+<td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -10582,8 +10582,8 @@ weakset.add(obj1);
 return weakset.has(obj1);
       ">test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10643,8 +10643,8 @@ var weakset = new WeakSet([obj1, obj2]);
 return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
       ">test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10703,8 +10703,8 @@ var obj = {};
 return weakset.add(obj) === weakset;
       ">test(function(){try{return Function("\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10761,8 +10761,8 @@ return weakset.add(obj) === weakset;
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10816,8 +10816,8 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Proxy"><span><a class="anchor" href="#Proxy">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/20</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/20</td>
+<td data-browser="tr" class="tally" data-tally="0">0/20</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/20</td>
 <td data-browser="closure" class="tally" data-tally="0">0/20</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/20</td>
@@ -10880,8 +10880,8 @@ var proxy = new Proxy(proxied, {
 return proxy.foo === 5;
       ">test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -10944,8 +10944,8 @@ var proxy = Object.create(new Proxy(proxied, {
 return proxy.foo === 5;
       ">test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11010,8 +11010,8 @@ proxy.foo = &quot;bar&quot;;
 return passed;
       ">test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11076,8 +11076,8 @@ proxy.foo = &quot;bar&quot;;
 return passed;
       ">test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11141,8 +11141,8 @@ var passed = false;
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11206,8 +11206,8 @@ var passed = false;
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11271,8 +11271,8 @@ var proxied = {};
   return passed;
 ">test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11342,8 +11342,8 @@ return (returnedDesc.value     === fakeDesc.value
   &amp;&amp; returnedDesc.enumerable   === false);
       ">test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11412,8 +11412,8 @@ Object.defineProperty(
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11477,8 +11477,8 @@ var proxy = new Proxy(proxied, {
 return Object.getPrototypeOf(proxy) === fakeProto;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11547,8 +11547,8 @@ Object.setPrototypeOf(
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11614,8 +11614,8 @@ Object.isExtensible(
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11682,8 +11682,8 @@ Object.preventExtensions(
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11752,8 +11752,8 @@ for (var i in
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11819,8 +11819,8 @@ Object.keys(
 return passed;
       ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11887,8 +11887,8 @@ host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
       ">test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11953,8 +11953,8 @@ new new Proxy(proxied, {
 return passed;
       ">test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12019,8 +12019,8 @@ try {
 return passed;
       ">test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12077,8 +12077,8 @@ return passed;
 return Array.isArray(new Proxy([], {}));
       ">test(function(){try{return Function("\nreturn Array.isArray(new Proxy([], {}));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12135,8 +12135,8 @@ return Array.isArray(new Proxy([], {}));
 return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quot;]&apos;;
       ">test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12190,8 +12190,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Reflect"><span><a class="anchor" href="#Reflect">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/14</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/14</td>
+<td data-browser="tr" class="tally" data-tally="0">0/14</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/14</td>
 <td data-browser="closure" class="tally" data-tally="0">0/14</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/14</td>
@@ -12248,8 +12248,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
       ">test(function(){try{return Function("\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12308,8 +12308,8 @@ Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
       ">test(function(){try{return Function("\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12366,8 +12366,8 @@ return obj.quux === 654;
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
       ">test(function(){try{return Function("\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12426,8 +12426,8 @@ Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
       ">test(function(){try{return Function("\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12487,8 +12487,8 @@ return desc.value === 789 &amp;&amp;
   desc.configurable &amp;&amp; desc.writable &amp;&amp; desc.enumerable;
       ">test(function(){try{return Function("\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12547,8 +12547,8 @@ Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
       ">test(function(){try{return Function("\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12605,8 +12605,8 @@ return obj.foo === 123;
 return Reflect.getPrototypeOf([]) === Array.prototype;
       ">test(function(){try{return Function("\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12665,8 +12665,8 @@ Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
       ">test(function(){try{return Function("\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12724,8 +12724,8 @@ return Reflect.isExtensible({}) &amp;&amp;
   !Reflect.isExtensible(Object.preventExtensions({}));
       ">test(function(){try{return Function("\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12784,8 +12784,8 @@ Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
       ">test(function(){try{return Function("\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12851,8 +12851,8 @@ passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
       ">test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12910,8 +12910,8 @@ var obj = { foo: 1, bar: 2 };
 return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
       ">test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -12968,8 +12968,8 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
       ">test(function(){try{return Function("\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13028,8 +13028,8 @@ return Reflect.construct(function(a, b, c) {
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
       ">test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13091,8 +13091,8 @@ function f() { return 1; }
 return f() === 1;
   ">test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13146,8 +13146,8 @@ return f() === 1;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="destructuring"><span><a class="anchor" href="#destructuring">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8666666666666667">13/15</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8">12/15</td>
+<td data-browser="tr" class="tally" data-tally="0.8666666666666667">13/15</td>
 <td data-browser="es6tr" class="tally" data-tally="0.7333333333333333">11/15</td>
 <td data-browser="closure" class="tally" data-tally="0.7333333333333333">11/15</td>
 <td data-browser="jsx" class="tally" data-tally="0.4666666666666667">7/15</td>
@@ -13205,8 +13205,8 @@ var [a, , [b], c] = [5, null, [6]];
 return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
       ">test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nreturn a === 5 && b === 6 && c === undefined;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13264,8 +13264,8 @@ var [a, b, c] = &quot;bar&quot;;
 return a === &quot;b&quot; &amp;&amp; b === &quot;a&quot; &amp;&amp; c === &quot;r&quot;;
       ">test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"b\" && b === \"a\" && c === \"r\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13324,8 +13324,8 @@ var [a, b, c] = iterable;
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13384,8 +13384,8 @@ var [a, b, c] = Object.create(iterable);
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
       ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13443,8 +13443,8 @@ var {c, x:d, e} = {c:7, x:8};
 return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
       ">test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c === 7 && d === 8 && e === undefined;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13503,8 +13503,8 @@ var { [qux]: grault } = { corge: &quot;garply&quot; };
 return grault === &quot;garply&quot;;
       ">test(function(){try{return Function("\nvar qux = \"corge\";\nvar { [qux]: grault } = { corge: \"garply\" };\nreturn grault === \"garply\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13562,8 +13562,8 @@ var [a,b] = [5,6], {c,d} = {c:7,d:8};
 return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
       ">test(function(){try{return Function("\nvar [a,b] = [5,6], {c,d} = {c:7,d:8};\nreturn a === 5 && b === 6 && c === 7 && d === 8;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13621,8 +13621,8 @@ var [e, {x:f, g}] = [9, {x:10}];
 return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined;
       ">test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn e === 9 && f === 10 && g === undefined;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13682,8 +13682,8 @@ return (function({a, x:b, y:e}, [c, d]) {
 }({a:1, x:2}, [3, 4]));
       ">test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {\n  return a === 1 && b === 2 && c === 3 &&\n    d === 4 && e === undefined;\n}({a:1, x:2}, [3, 4]));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13742,8 +13742,8 @@ for(var [i, j, k] in { qux: 1 }) {
 }
       ">test(function(){try{return Function("\nfor(var [i, j, k] in { qux: 1 }) {\n  return i === \"q\" && j === \"u\" && k === \"x\";\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13802,8 +13802,8 @@ for(var [i, j, k] of [[1,2,3]]) {
 }
       ">test(function(){try{return Function("\nfor(var [i, j, k] of [[1,2,3]]) {\n  return i === 1 && j === 2 && k === 3;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13863,8 +13863,8 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
    c === 6 &amp;&amp; d instanceof Array &amp;&amp; d.length === 0;
       ">test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d] = [6];\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -13923,8 +13923,8 @@ var a = [1, 2, 3], first, last;
 return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot;1,2,2&quot;;
       ">test(function(){try{return Function("\nvar a = [1, 2, 3], first, last;\n[first, ...[a[2], last]] = a;\nreturn first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -13982,8 +13982,8 @@ var {a = 1, b = 0, c = 3} = {b:2, c:undefined};
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
       ">test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undefined};\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14043,8 +14043,8 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
 }({b:2, c:undefined, x:4}));
       ">test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n  return a === 1 && b === 2 && c === 3 && d === 4 &&\n    e === 5 && f === undefined;\n}({b:2, c:undefined, x:4}));\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14102,8 +14102,8 @@ return typeof Promise !== &apos;undefined&apos; &amp;&amp;
        typeof Promise.all === &apos;function&apos;;
   ">test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\n       typeof Promise.all === 'function';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14157,8 +14157,8 @@ return typeof Promise !== &apos;undefined&apos; &amp;&amp;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -14216,8 +14216,8 @@ var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot; in o;
       ">test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14276,8 +14276,8 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
  !Object.is(-0, 0);
       ">test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14337,8 +14337,8 @@ o[sym] = &quot;foo&quot;;
 return Object.getOwnPropertySymbols(o)[0] === sym;
       ">test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14395,8 +14395,8 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
       ">test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14450,8 +14450,8 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function "name" property</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/16</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/16</td>
+<td data-browser="tr" class="tally" data-tally="0">0/16</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/16</td>
 <td data-browser="closure" class="tally" data-tally="0">0/16</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/16</td>
@@ -14510,8 +14510,8 @@ return foo.name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
       ">test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14569,8 +14569,8 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
       ">test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14627,8 +14627,8 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 return (new Function).name === &quot;anonymous&quot;;
       ">test(function(){try{return Function("\nreturn (new Function).name === \"anonymous\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14687,8 +14687,8 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
   (function(){}).bind({}).name === &quot;bound &quot;;
       ">test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14747,8 +14747,8 @@ var bar = function baz() {};
 return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
       ">test(function(){try{return Function("\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14809,8 +14809,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
       ">test(function(){try{return Function("\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14870,8 +14870,8 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
        descriptor.set.name === &quot;set foo&quot;;
       ">test(function(){try{return Function("\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14929,8 +14929,8 @@ var o = { foo(){} };
 return o.foo.name === &quot;foo&quot;;
       ">test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14995,8 +14995,8 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
        o[sym2].name === &quot;&quot;;
       ">test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15056,8 +15056,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
   typeof bar.name === &quot;function&quot;;
       ">test(function(){try{return Function("\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15115,8 +15115,8 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
   typeof class bar { static name() {} }.name === &quot;function&quot;;
       ">test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15178,8 +15178,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
        typeof qux.name === &quot;function&quot;;
       ">test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15240,8 +15240,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
       ">test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15299,8 +15299,8 @@ class C { foo(){} };
 return (new C).foo.name === &quot;foo&quot;;
       ">test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15358,8 +15358,8 @@ class C { static foo(){} };
 return C.foo.name === &quot;foo&quot;;
       ">test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15419,8 +15419,8 @@ return descriptor.enumerable   === false &amp;&amp;
        descriptor.configurable === true;
       ">test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15477,8 +15477,8 @@ return descriptor.enumerable   === false &amp;&amp;
 return typeof Function.prototype.toMethod === &quot;function&quot;;
   ">test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15532,8 +15532,8 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="String_static_methods"><span><a class="anchor" href="#String_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-constructor">String static methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="1">2/2</td>
+<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="closure" class="tally" data-tally="0">0/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -15590,8 +15590,8 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 return typeof String.raw === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof String.raw === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15648,8 +15648,8 @@ return typeof String.raw === &apos;function&apos;;
 return typeof String.fromCodePoint === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15703,8 +15703,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8333333333333334">5/6</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="tr" class="tally" data-tally="0.8333333333333334">5/6</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/6</td>
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
@@ -15761,8 +15761,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 return typeof String.prototype.codePointAt === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof String.prototype.codePointAt === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15821,8 +15821,8 @@ return typeof String.prototype.normalize === &quot;function&quot;
   &amp;&amp; &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
       ">test(function(){try{return Function("\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15880,8 +15880,8 @@ return typeof String.prototype.repeat === &apos;function&apos;
   &amp;&amp; &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
       ">test(function(){try{return Function("\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15939,8 +15939,8 @@ return typeof String.prototype.startsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.startsWith(&quot;foo&quot;);
       ">test(function(){try{return Function("\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15998,8 +15998,8 @@ return typeof String.prototype.endsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.endsWith(&quot;bar&quot;);
       ">test(function(){try{return Function("\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16057,8 +16057,8 @@ return typeof String.prototype.includes === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.includes(&quot;oba&quot;);
       ">test(function(){try{return Function("\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16115,8 +16115,8 @@ return typeof String.prototype.includes === &apos;function&apos;
 return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
   ">test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16170,8 +16170,8 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Symbol"><span><a class="anchor" href="#Symbol">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.4444444444444444">4/9</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5555555555555556">5/9</td>
+<td data-browser="tr" class="tally" data-tally="0.4444444444444444">4/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
@@ -16232,8 +16232,8 @@ object[symbol] = value;
 return object[symbol] === value;
       ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16290,8 +16290,8 @@ return object[symbol] === value;
 return typeof Symbol() === &quot;symbol&quot;;
       ">test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16360,8 +16360,8 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 return passed;
       ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16427,8 +16427,8 @@ if (Object.defineProperty) {
 return passed;
       ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16498,8 +16498,8 @@ try {
 return true;
       ">test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16556,8 +16556,8 @@ return true;
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
       ">test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16619,8 +16619,8 @@ try {
 }
       ">test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16682,8 +16682,8 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
   symbolObject.valueOf() === symbol;
       ">test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16742,8 +16742,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
    Symbol.keyFor(symbol) === &apos;foo&apos;;
       ">test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16797,8 +16797,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.14285714285714285">1/7</td>
 <td data-browser="_6to5" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="tr" class="tally" data-tally="0.14285714285714285">1/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -16862,8 +16862,8 @@ obj instanceof C;
 return passed;
       ">test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16923,8 +16923,8 @@ a = a.concat(b);
 return a[0] === b;
       ">test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -16994,8 +16994,8 @@ for (c of b) {}
 return c === &quot;foo&quot;;
       ">test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17054,8 +17054,8 @@ return RegExp[Symbol.species] === RegExp
   &amp;&amp; !(Symbol.species in Object);
       ">test(function(){try{return Function("\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17121,8 +17121,8 @@ c == 0;
 return passed === 3;
       ">test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17181,8 +17181,8 @@ a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
       ">test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17243,8 +17243,8 @@ with (a) {
 }
       ">test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17298,8 +17298,8 @@ with (a) {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/5</td>
+<td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -17356,8 +17356,8 @@ with (a) {
 return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
       ">test(function(){try{return Function("\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17414,8 +17414,8 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17472,8 +17472,8 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17530,8 +17530,8 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17588,8 +17588,8 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17643,8 +17643,8 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="1">2/2</td>
+<td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="closure" class="tally" data-tally="0">0/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -17701,8 +17701,8 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 return typeof Array.from === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.from === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17760,8 +17760,8 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
   Array.of(2)[0] === 2;
       ">test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17815,8 +17815,8 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="_6to5" class="tally" data-tally="0.875">7/8</td>
+<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/8</td>
 <td data-browser="closure" class="tally" data-tally="0">0/8</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/8</td>
@@ -17873,8 +17873,8 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17931,8 +17931,8 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 return typeof Array.prototype.find === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17989,8 +17989,8 @@ return typeof Array.prototype.find === &apos;function&apos;;
 return typeof Array.prototype.findIndex === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18047,8 +18047,8 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 return typeof Array.prototype.fill === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18105,8 +18105,8 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 return typeof Array.prototype.keys === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18163,8 +18163,8 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 return typeof Array.prototype.values === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.values === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18221,8 +18221,8 @@ return typeof Array.prototype.values === &apos;function&apos;;
 return typeof Array.prototype.entries === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Array.prototype.entries === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18287,8 +18287,8 @@ for (var i = 0; i &lt; ns.length; i++) {
 return true;
       ">test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18342,8 +18342,8 @@ return true;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Number_properties"><span><a class="anchor" href="#Number_properties">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isfinite-number">Number properties</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">7/7</td>
 <td data-browser="_6to5" class="tally" data-tally="1">7/7</td>
+<td data-browser="tr" class="tally" data-tally="1">7/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -18400,8 +18400,8 @@ return true;
 return typeof Number.isFinite === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.isFinite === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18458,8 +18458,8 @@ return typeof Number.isFinite === &apos;function&apos;;
 return typeof Number.isInteger === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.isInteger === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18516,8 +18516,8 @@ return typeof Number.isInteger === &apos;function&apos;;
 return typeof Number.isSafeInteger === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18574,8 +18574,8 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 return typeof Number.isNaN === &apos;function&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18632,8 +18632,8 @@ return typeof Number.isNaN === &apos;function&apos;;
 return typeof Number.EPSILON === &apos;number&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18690,8 +18690,8 @@ return typeof Number.EPSILON === &apos;number&apos;;
 return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18748,8 +18748,8 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
       ">test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18803,8 +18803,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Math_methods"><span><a class="anchor" href="#Math_methods">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-math">Math methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/17</td>
 <td data-browser="_6to5" class="tally" data-tally="1">17/17</td>
+<td data-browser="tr" class="tally" data-tally="0">0/17</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/17</td>
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
@@ -18861,8 +18861,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 return typeof Math.clz32 === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18919,8 +18919,8 @@ return typeof Math.clz32 === &quot;function&quot;;
 return typeof Math.imul === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18977,8 +18977,8 @@ return typeof Math.imul === &quot;function&quot;;
 return typeof Math.sign === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19035,8 +19035,8 @@ return typeof Math.sign === &quot;function&quot;;
 return typeof Math.log10 === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19093,8 +19093,8 @@ return typeof Math.log10 === &quot;function&quot;;
 return typeof Math.log2 === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19151,8 +19151,8 @@ return typeof Math.log2 === &quot;function&quot;;
 return typeof Math.log1p === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19209,8 +19209,8 @@ return typeof Math.log1p === &quot;function&quot;;
 return typeof Math.expm1 === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19267,8 +19267,8 @@ return typeof Math.expm1 === &quot;function&quot;;
 return typeof Math.cosh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19325,8 +19325,8 @@ return typeof Math.cosh === &quot;function&quot;;
 return typeof Math.sinh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19383,8 +19383,8 @@ return typeof Math.sinh === &quot;function&quot;;
 return typeof Math.tanh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19441,8 +19441,8 @@ return typeof Math.tanh === &quot;function&quot;;
 return typeof Math.acosh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19499,8 +19499,8 @@ return typeof Math.acosh === &quot;function&quot;;
 return typeof Math.asinh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19557,8 +19557,8 @@ return typeof Math.asinh === &quot;function&quot;;
 return typeof Math.atanh === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19615,8 +19615,8 @@ return typeof Math.atanh === &quot;function&quot;;
 return typeof Math.hypot === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19673,8 +19673,8 @@ return typeof Math.hypot === &quot;function&quot;;
 return typeof Math.trunc === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19731,8 +19731,8 @@ return typeof Math.trunc === &quot;function&quot;;
 return typeof Math.fround === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.fround === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19789,8 +19789,8 @@ return typeof Math.fround === &quot;function&quot;;
 return typeof Math.cbrt === &quot;function&quot;;
 ">test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";\n")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19844,8 +19844,8 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="_6to5" class="tally" data-tally="0.42857142857142855">3/7</td>
+<td data-browser="tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -19868,7 +19868,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td data-browser="firefox31" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox34" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="firefox34" class="tally" data-tally="0.42857142857142855">3/7</td>
 <td data-browser="firefox35" class="tally" data-tally="0.5714285714285714">4/7</td>
 <td data-browser="firefox36" class="tally" data-tally="0.5714285714285714">4/7</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
@@ -19903,8 +19903,8 @@ return typeof Math.cbrt === &quot;function&quot;;
 return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
       ">test(function(){try{return Function("\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19927,7 +19927,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox33">No</td>
-<td class="no" data-browser="firefox34">No</td>
+<td class="yes" data-browser="firefox34">Yes</td>
 <td class="yes" data-browser="firefox35">Yes</td>
 <td class="yes" data-browser="firefox36">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
@@ -19961,8 +19961,8 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 do {} while (false) return true;
       ">test(function(){try{return Function("\ndo {} while (false) return true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20024,8 +20024,8 @@ catch(e) {
 }
       ">test(function(){try{return Function("\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20086,8 +20086,8 @@ try {
 }
       ">test(function(){try{return Function("\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20151,8 +20151,8 @@ for (var i = 0; i &lt; methods.length; i++) {
 return true;
       ">test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',\n  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];\nfor (var i = 0; i < methods.length; i++) {\n  Object[methods[i]](20000, \"foo\");\n  Object[methods[i]](\"foo\", \"foo\");\n  Object[methods[i]](false, \"foo\");\n}\nreturn true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20209,8 +20209,8 @@ return true;
 return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
       ">test(function(){try{return Function("\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20267,8 +20267,8 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 return new RegExp(/./im, &quot;g&quot;).global === true;
       ">test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global === true;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20334,8 +20334,8 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
   ">test(function(){try{return Function("\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20389,8 +20389,8 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[22]</sup></a></span></td>
-<td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
+<td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="closure" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="jsx" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
@@ -20448,8 +20448,8 @@ return { __proto__ : [] } instanceof Array
   &amp;&amp; !({ __proto__ : null } instanceof Object);
       ">test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20511,8 +20511,8 @@ catch(e) {
 }
       ">test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20573,8 +20573,8 @@ var a = &quot;__proto__&quot;;
 return !({ [a] : [] } instanceof Array);
       ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20635,8 +20635,8 @@ var __proto__ = [];
 return !({ __proto__ } instanceof Array);
       ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20696,8 +20696,8 @@ if (!({ __proto__ : [] } instanceof Array)) {
 return !({ __proto__(){} } instanceof Function);
       ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20751,8 +20751,8 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
-<td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="_6to5" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
+<td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="closure" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="jsx" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
@@ -20810,8 +20810,8 @@ var A = function(){};
 return (new A()).__proto__ === A.prototype;
       ">test(function(){try{return Function("\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20870,8 +20870,8 @@ o.__proto__ = Array.prototype;
 return o instanceof Array;
       ">test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -20935,8 +20935,8 @@ return (desc
   &amp;&amp; !desc.enumerable);
       ">test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -21000,8 +21000,8 @@ for (i = 0; i &lt; names.length; i++) {
 return true;
   ">test(function(){try{return Function("\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>
@@ -21058,8 +21058,8 @@ return true;
 return typeof RegExp.prototype.compile === &apos;function&apos;;
   ">test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile === 'function';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms.">No</td>

--- a/es7/index.html
+++ b/es7/index.html
@@ -65,8 +65,8 @@
           <th></th>
 
           <!-- TABLE HEADERS -->
-        <th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></a></th>
-<th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></a></th>
+        <th class="platform _6to5 compiler"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br>polyfill</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></a></th>
+<th class="platform tr compiler"><a href="#tr" class="browser-name"><abbr title="Traceur compiler">Traceur</abbr></a></th>
 <th class="platform ie11 desktop"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform firefox31 desktop"><a href="#firefox31" class="browser-name"><abbr title="Firefox">FF 31</abbr></a></th>
 <th class="platform firefox32 desktop"><a href="#firefox32" class="browser-name"><abbr title="Firefox">FF 32</abbr></a></th>
@@ -96,8 +96,8 @@
 return 2 ** 3 === 8;
   ">test(function(){try{return Function("\nreturn 2 ** 3 === 8;\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>
@@ -123,8 +123,8 @@ return 2 ** 3 === 8;
 return [for (a of [1, 2, 3]) a * a][0] === 1
   ">test(function(){try{return Function("\nreturn [for (a of [1, 2, 3]) a * a][0] === 1\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="firefox31">Yes</td>
 <td class="yes" data-browser="firefox32">Yes</td>
@@ -150,8 +150,8 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 (for (a of [1, 2, 3]) a * a)
   ">test(function(){try{return Function("\n(for (a of [1, 2, 3]) a * a)\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="firefox31">Yes</td>
 <td class="yes" data-browser="firefox32">Yes</td>
@@ -177,8 +177,8 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 return typeof StructType !== &apos;undefined&apos;;
   ">test(function(){try{return Function("\nreturn typeof StructType !== 'undefined';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>
@@ -204,8 +204,8 @@ return typeof StructType !== &apos;undefined&apos;;
 return typeof Object.observe === &apos;function&apos;;
   ">test(function(){try{return Function("\nreturn typeof Object.observe === 'function';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>
@@ -231,8 +231,8 @@ return typeof Object.observe === &apos;function&apos;;
 return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
   ">test(function(){try{return Function("\nreturn typeof Object.getOwnPropertyDescriptors === 'function';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>
@@ -258,8 +258,8 @@ return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
 return typeof Array.prototype.contains === &apos;function&apos;;
   ">test(function(){try{return Function("\nreturn typeof Array.prototype.contains === 'function';\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>
@@ -298,8 +298,8 @@ for (i = 0; i &lt; names.length; i++) {
 return true;
   ">test(function(){try{return Function("\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")()}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>


### PR DESCRIPTION
It seems like for the most part that each group is sorted by most supported (browsers sub-sorted by version) with the exception of "server-ish". So I moved 6to5 to the first position since it now has the most support for transpilers.
