### PR TITLE
Improved Promise tests, and added support for async testing

### DIFF
--- a/build.js
+++ b/build.js
@@ -184,6 +184,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
   var head = $('table thead tr:last-child');
   var body = $('table tbody');
   var footnoteIndex = {};
+  var rowNum = 0;
   
   function interpolateResults(res) {
     var browser, prevBrowser, result, prevResult, bid, prevBid, j;

--- a/build.js
+++ b/build.js
@@ -253,7 +253,9 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
   });
   
   // Now print the results.
-  tests.forEach(function(t) {
+  tests.forEach(function(t, testNum) {
+    var subtests;
+    // Calculate the result totals for tests which consist solely of subtests.
     if ("subtests" in t) {
       Object.keys(t.subtests).forEach(function(e) {
         interpolateResults(t.subtests[e].res);
@@ -269,7 +271,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
       .append($('<td></td>')
         .attr('id',id)
         .append('<span><a class="anchor" href="#' + id + '">&sect;</a>' + name + footnoteHTML(t) + '</span></td>')
-        .append(testScript(t.exec, compiler, id))
+        .append(testScript(t.exec, compiler, rowNum++))
       );
     body.append(testRow);
     
@@ -307,7 +309,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
     
     // Print all the results for the subtests
     if ("subtests" in t) {
-      Object.keys(t.subtests).forEach(function(subtestName) {
+      Object.keys(t.subtests).forEach(function(subtestName, subtestNum) {
         var subtest = t.subtests[subtestName];
         
         subtestRow = $('<tr class="subtest"></tr>')
@@ -315,7 +317,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
           .append(
             $('<td></td>')
               .append('<span>' + subtestName + '</span>')
-              .append(testScript(subtest.exec, compiler, id))
+              .append(testScript(subtest.exec, compiler, rowNum++))
           );
         body.append(subtestRow);
         
@@ -401,7 +403,7 @@ function replaceAndIndent(str, replacements) {
   return str;
 }
 
-function testScript(fn, transformFn, id) {
+function testScript(fn, transformFn, rowNum) {
   
   function deindentFunc(fn) {
     fn = (fn+'');
@@ -449,7 +451,7 @@ function testScript(fn, transformFn, id) {
       }
       var async = !!/asyncTestPassed/.exec(fn);
       var codeString = JSON.stringify(expr).replace(/\\r/g,'');
-      var asyncFn = 'global.__asyncPassedFn && __asyncPassedFn("' + id.replace(/"/g,'\\"') + '")';
+      var asyncFn = 'global.__asyncPassedFn && __asyncPassedFn("' + rowNum + '")';
       var funcString =
         transformed ? '' + asyncFn + ' && eval(' + codeString + ')'
         : 'Function("asyncTestPassed",' + codeString + ')(asyncTestPassed);';

--- a/data-es6.js
+++ b/data-es6.js
@@ -3613,16 +3613,36 @@ exports.tests = [
     },
   },
 },
+
 {
   name: 'Promise',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
-  exec: function () {/*
-    return typeof Promise !== 'undefined' &&
-           typeof Promise.all === 'function';
+  exec: function (passTest) {/*
+    var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
+    var p2 = new Promise(function(resolve, reject) { reject("quux"); });
+    var score = 0;
+    
+    function thenFn(result)  { score += (result === "foo");  check(); }
+    function catchFn(result) { score += (result === "quux"); check(); }
+    function shouldNotRun(result)  { score = -Infinity;   }
+    
+    p1.then(thenFn, shouldNotRun);
+    p2.then(shouldNotRun, catchFn);
+    p1.catch(shouldNotRun);
+    p2.catch(catchFn);
+    
+    p1.then(function() {
+      // Promise.prototype.then() should return a new Promise
+      score += p1.then() !== p1;
+      check();
+    });
+    
+    function check() {
+      if (score === 4) asyncTestPassed();
+    }
   */},
   res: {
     tr:          true,
-    _6to5:       true,
     ejs:         true,
     ie11tp:      true,
     firefox29:   true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -3675,6 +3675,7 @@ exports.tests = [
       res: {
         tr:          true,
         ejs:         true,
+        ie11tp:      true,
         firefox29:   true,
         chrome33:    true,
         webkit:      true,
@@ -3702,6 +3703,7 @@ exports.tests = [
       res: {
       tr:          true,
       ejs:         true,
+      ie11tp:      true,
       firefox29:   true,
       chrome33:    true,
       webkit:      true,
@@ -3825,7 +3827,7 @@ exports.tests = [
         webkit:      true,
         opera:       true,
         rhino17:     true,
-        node:        flag,
+        node:        true,
         ios7:        true,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3613,167 +3613,102 @@ exports.tests = [
     },
   },
 },
-
 {
   name: 'Promise',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
-  exec: function () {/*
-    var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
-    var p2 = new Promise(function(resolve, reject) { reject("quux"); });
-    var score = 0;
+  subtests: {
+    'basic functionality': {
+      exec: function () {/*
+        var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
+        var p2 = new Promise(function(resolve, reject) { reject("quux"); });
+        var score = 0;
     
-    function thenFn(result)  { score += (result === "foo");  check(); }
-    function catchFn(result) { score += (result === "quux"); check(); }
-    function shouldNotRun(result)  { score = -Infinity;   }
+        function thenFn(result)  { score += (result === "foo");  check(); }
+        function catchFn(result) { score += (result === "quux"); check(); }
+        function shouldNotRun(result)  { score = -Infinity;   }
     
-    p1.then(thenFn, shouldNotRun);
-    p2.then(shouldNotRun, catchFn);
-    p1.catch(shouldNotRun);
-    p2.catch(catchFn);
+        p1.then(thenFn, shouldNotRun);
+        p2.then(shouldNotRun, catchFn);
+        p1.catch(shouldNotRun);
+        p2.catch(catchFn);
     
-    p1.then(function() {
-      // Promise.prototype.then() should return a new Promise
-      score += p1.then() !== p1;
-      check();
-    });
+        p1.then(function() {
+          // Promise.prototype.then() should return a new Promise
+          score += p1.then() !== p1;
+          check();
+        });
+        
+        function check() {
+          if (score === 4) asyncTestPassed();
+        }
+      */},
+      res: {
+        tr:          true,
+        ejs:         true,
+        ie11tp:      true,
+        firefox29:   true,
+        chrome33:    true,
+        safari71_8:  true,
+        webkit:      true,
+        nodeharmony: true,
+        ios8:        true,
+      },
+    },
+    'Promise.all': {
+      exec: function () {/*
+        var fulfills = Promise.all([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
+        ]);
+        var rejects = Promise.all([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
+        ]);
+        var score = 0;
+        fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
+        rejects.catch(function(result) { score += (result === "qux"); check(); });
     
-    function check() {
-      if (score === 4) asyncTestPassed();
-    }
-  */},
-  res: {
-    tr:          true,
-    ejs:         true,
-    ie11tp:      true,
-    firefox29:   true,
-    chrome33:    true,
-    safari71_8:  true,
-    webkit:      true,
-    nodeharmony: true,
-    ios8:        true
-  }
-},
-{
-  name: 'Promise.all',
-  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all',
-  exec: function () {/*
-    var fulfills = Promise.all([
-      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
-      new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
-    ]);
-    var rejects = Promise.all([
-      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
-      new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
-    ]);
-    var score = 0;
-    fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
-    rejects.catch(function(result) { score += (result === "qux"); check(); });
+        function check() {
+          if (score === 2) asyncTestPassed();
+        }
+      */},
+      res: {
+        tr:          true,
+        ejs:         true,
+        firefox29:   true,
+        chrome33:    true,
+        webkit:      true,
+        nodeharmony: true,
+      },
+    },
+    'Promise.race': {
+      exec: function () {/*
+        var fulfills = Promise.race([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
+        ]);
+        var rejects = Promise.race([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
+        ]);
+        var score = 0;
+        fulfills.then(function(result) { score += (result === "foo"); check(); });
+        rejects.catch(function(result) { score += (result === "baz"); check(); });
     
-    function check() {
-      if (score === 2) asyncTestPassed();
-    }
-  */},
-  res: {
-    tr:          true,
-    ejs:         true,
-    ie10:        false,
-    ie11:        false,
-    firefox11:   false,
-    firefox13:   false,
-    firefox16:   false,
-    firefox17:   false,
-    firefox18:   false,
-    firefox23:   false,
-    firefox24:   false,
-    firefox25:   false,
-    firefox27:   false,
-    firefox28:   false,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
-    firefox34:   true,
-    chrome:      false,
-    chrome19dev: false,
-    chrome21dev: false,
-    chrome30:    false,
-    chrome33:    true,
-    chrome34:    true,
-    chrome35:    true,
-    chrome37:    true,
-    safari51:    false,
-    safari6:     false,
-    safari7:     false,
-    webkit:      true,
-    opera:       false,
-    konq49:      false,
-    rhino17:     false,
-    phantom:     false,
-    node:        false,
-    nodeharmony: true
-  }
-},
-{
-  name: 'Promise.race',
-  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.race',
-  exec: function () {/*
-    var fulfills = Promise.race([
-      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
-      new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
-    ]);
-    var rejects = Promise.race([
-      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
-      new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
-    ]);
-    var score = 0;
-    fulfills.then(function(result) { score += (result === "foo"); check(); });
-    rejects.catch(function(result) { score += (result === "baz"); check(); });
-    
-    function check() {
-      if (score === 2) asyncTestPassed();
-    }
-  */},
-  res: {
-    tr:          true,
-    ejs:         true,
-    ie10:        false,
-    ie11:        false,
-    firefox11:   false,
-    firefox13:   false,
-    firefox16:   false,
-    firefox17:   false,
-    firefox18:   false,
-    firefox23:   false,
-    firefox24:   false,
-    firefox25:   false,
-    firefox27:   false,
-    firefox28:   false,
-    firefox29:   true,
-    firefox30:   true,
-    firefox31:   true,
-    firefox32:   true,
-    firefox33:   true,
-    firefox34:   true,
-    chrome:      false,
-    chrome19dev: false,
-    chrome21dev: false,
-    chrome30:    false,
-    chrome33:    true,
-    chrome34:    true,
-    chrome35:    true,
-    chrome37:    true,
-    safari51:    false,
-    safari6:     false,
-    safari7:     false,
-    webkit:      true,
-    opera:       false,
-    konq49:      false,
-    rhino17:     false,
-    phantom:     false,
-    node:        false,
-    nodeharmony: true
-  }
+        function check() {
+          if (score === 2) asyncTestPassed();
+        }
+      */},
+      res: {
+      tr:          true,
+      ejs:         true,
+      firefox29:   true,
+      chrome33:    true,
+      webkit:      true,
+      nodeharmony: true,
+    },
+  },
+  },
 },
 {
   name: 'Object static methods',

--- a/data-es6.js
+++ b/data-es6.js
@@ -1985,7 +1985,7 @@ exports.tests = [
         closure:     true,
         firefox34:   true,
       },
-    }
+    },
   },
 },
 {
@@ -3617,7 +3617,7 @@ exports.tests = [
 {
   name: 'Promise',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
-  exec: function (passTest) {/*
+  exec: function () {/*
     var p1 = new Promise(function(resolve, reject) { resolve("foo"); });
     var p2 = new Promise(function(resolve, reject) { reject("quux"); });
     var score = 0;
@@ -3651,6 +3651,128 @@ exports.tests = [
     webkit:      true,
     nodeharmony: true,
     ios8:        true
+  }
+},
+{
+  name: 'Promise.all',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.all',
+  exec: function () {/*
+    var fulfills = Promise.all([
+      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+      new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
+    ]);
+    var rejects = Promise.all([
+      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+      new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
+    ]);
+    var score = 0;
+    fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
+    rejects.catch(function(result) { score += (result === "qux"); check(); });
+    
+    function check() {
+      if (score === 2) asyncTestPassed();
+    }
+  */},
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      true,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: true
+  }
+},
+{
+  name: 'Promise.race',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise.race',
+  exec: function () {/*
+    var fulfills = Promise.race([
+      new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+      new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
+    ]);
+    var rejects = Promise.race([
+      new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+      new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
+    ]);
+    var score = 0;
+    fulfills.then(function(result) { score += (result === "foo"); check(); });
+    rejects.catch(function(result) { score += (result === "baz"); check(); });
+    
+    function check() {
+      if (score === 2) asyncTestPassed();
+    }
+  */},
+  res: {
+    tr:          true,
+    ejs:         true,
+    ie10:        false,
+    ie11:        false,
+    firefox11:   false,
+    firefox13:   false,
+    firefox16:   false,
+    firefox17:   false,
+    firefox18:   false,
+    firefox23:   false,
+    firefox24:   false,
+    firefox25:   false,
+    firefox27:   false,
+    firefox28:   false,
+    firefox29:   true,
+    firefox30:   true,
+    firefox31:   true,
+    firefox32:   true,
+    firefox33:   true,
+    firefox34:   true,
+    chrome:      false,
+    chrome19dev: false,
+    chrome21dev: false,
+    chrome30:    false,
+    chrome33:    true,
+    chrome34:    true,
+    chrome35:    true,
+    chrome37:    true,
+    safari51:    false,
+    safari6:     false,
+    safari7:     false,
+    webkit:      true,
+    opera:       false,
+    konq49:      false,
+    rhino17:     false,
+    phantom:     false,
+    node:        false,
+    nodeharmony: true
   }
 },
 {

--- a/es5/index.html
+++ b/es5/index.html
@@ -1205,7 +1205,7 @@ return typeof Array.prototype.reduceRight == 'function';
 </tr>
 <tr><td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&sect;</a>Getter in property initializer</span><script data-source="
 return ({ get x(){ return 1 } }).x === 1;
-  ">test(function(){try{return Function("\nreturn ({ get x(){ return 1 } }).x === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");return Function("asyncTestPassed","\nreturn ({ get x(){ return 1 } }).x === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -1244,7 +1244,7 @@ return ({ get x(){ return 1 } }).x === 1;
 var value = 0;
 ({ set x(v){ value = v; } }).x = 1;
 return value === 1;
-  ">test(function(){try{return Function("\nvar value = 0;\n({ set x(v){ value = v; } }).x = 1;\nreturn value === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");return Function("asyncTestPassed","\nvar value = 0;\n({ set x(v){ value = v; } }).x = 1;\nreturn value === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -1322,7 +1322,7 @@ return "foobar"[3] === "b";
 </tr>
 <tr><td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&sect;</a>Reserved words as property names</span><script data-source="
 return ({ if: 1 }).if === 1;
-  ">test(function(){try{return Function("\nreturn ({ if: 1 }).if === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");return Function("asyncTestPassed","\nreturn ({ if: 1 }).if === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -1362,7 +1362,7 @@ return ({ if: 1 }).if === 1;
 <tr><td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&sect;</a>Zero-width chars in identifiers</span><script data-source="
 var _\u200c\u200d = true;
 return _\u200c\u200d;
-  ">test(function(){try{return Function("\nvar _\\u200c\\u200d = true;\nreturn _\\u200c\\u200d;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");return Function("asyncTestPassed","\nvar _\\u200c\\u200d = true;\nreturn _\\u200c\\u200d;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
@@ -1441,7 +1441,7 @@ undefined = 12345;
 var result = typeof undefined == &apos;undefined&apos;;
 undefined = void 0;
 return result;
-  ">test(function(){try{return Function("\nundefined = 12345;\nvar result = typeof undefined == 'undefined';\nundefined = void 0;\nreturn result;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");return Function("asyncTestPassed","\nundefined = 12345;\nvar result = typeof undefined == 'undefined';\nundefined = void 0;\nreturn result;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -168,7 +168,7 @@ return (function f(n){
   }
   return f(n - 1);
 }(1e6)) === &quot;foo&quot;;
-  ">test(function(){try{return Function("\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("0");return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return f(n - 1);\n}(1e6)) === \"foo\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -281,7 +281,7 @@ return (function f(n){
 </tr>
 <tr class="subtest" data-parent="arrow_functions"><td><span>0 parameters</span><script data-source="
 return (() =&gt; 5)() === 5;
-      ">test(function(){try{return Function("\nreturn (() => 5)() === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");return Function("asyncTestPassed","\nreturn (() => 5)() === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -340,7 +340,7 @@ return (() =&gt; 5)() === 5;
 <tr class="subtest" data-parent="arrow_functions"><td><span>1 parameter, no brackets</span><script data-source="
 var b = x =&gt; x + &quot;foo&quot;;
 return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
-      ">test(function(){try{return Function("\nvar b = x => x + \"foo\";\nreturn (b(\"fee fie foe \") === \"fee fie foe foo\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");return Function("asyncTestPassed","\nvar b = x => x + \"foo\";\nreturn (b(\"fee fie foe \") === \"fee fie foe foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -399,7 +399,7 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <tr class="subtest" data-parent="arrow_functions"><td><span>multiple parameters</span><script data-source="
 var c = (v, w, x, y, z) =&gt; &quot;&quot; + v + w + x + y + z;
 return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
-      ">test(function(){try{return Function("\nvar c = (v, w, x, y, z) => \"\" + v + w + x + y + z;\nreturn (c(6, 5, 4, 3, 2) === \"65432\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");return Function("asyncTestPassed","\nvar c = (v, w, x, y, z) => \"\" + v + w + x + y + z;\nreturn (c(6, 5, 4, 3, 2) === \"65432\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -459,7 +459,7 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 var d = { x : &quot;bar&quot;, y : function() { return z =&gt; this.x + z; }}.y();
 var e = { x : &quot;baz&quot;, y : d };
 return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;) === &quot;barley&quot;;
-      ">test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }}.y();\nvar e = { x : \"baz\", y : d };\nreturn d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");return Function("asyncTestPassed","\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }}.y();\nvar e = { x : \"baz\", y : d };\nreturn d(\"ley\") === \"barley\" && e.y(\"ley\") === \"barley\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -519,7 +519,7 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 var d = { x : &quot;foo&quot;, y : function() { return () =&gt; this.x; }};
 var e = { x : &quot;bar&quot; };
 return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nvar d = { x : \"foo\", y : function() { return () => this.x; }};\nvar e = { x : \"bar\" };\nreturn d.y().call(e) === \"foo\" && d.y().apply(e) === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");return Function("asyncTestPassed","\nvar d = { x : \"foo\", y : function() { return () => this.x; }};\nvar e = { x : \"bar\" };\nreturn d.y().call(e) === \"foo\" && d.y().apply(e) === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -579,7 +579,7 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 var d = { x : &quot;bar&quot;, y : function() { return z =&gt; this.x + z; }};
 var e = { x : &quot;baz&quot; };
 return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
-      ">test(function(){try{return Function("\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }};\nvar e = { x : \"baz\" };\nreturn d.y().bind(e, \"ley\")() === \"barley\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");return Function("asyncTestPassed","\nvar d = { x : \"bar\", y : function() { return z => this.x + z; }};\nvar e = { x : \"baz\" };\nreturn d.y().bind(e, \"ley\")() === \"barley\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -638,7 +638,7 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <tr class="subtest" data-parent="arrow_functions"><td><span>lexical "arguments" binding</span><script data-source="
 var f = (function() { return z =&gt; arguments[0]; }(5));
 return f(6) === 5;
-      ">test(function(){try{return Function("\nvar f = (function() { return z => arguments[0]; }(5));\nreturn f(6) === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");return Function("asyncTestPassed","\nvar f = (function() { return z => arguments[0]; }(5));\nreturn f(6) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -698,7 +698,7 @@ return f(6) === 5;
 return (() =&gt; {
   try { Function(&quot;x\n =&gt; 2&quot;)(); } catch(e) { return true; }
 })();
-      ">test(function(){try{return Function("\nreturn (() => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n})();\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");return Function("asyncTestPassed","\nreturn (() => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n})();\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -757,7 +757,7 @@ return (() =&gt; {
 <tr class="subtest" data-parent="arrow_functions"><td><span>no "prototype" property</span><script data-source="
 var a = () =&gt; 5;
 return !a.hasOwnProperty(&quot;prototype&quot;);
-      ">test(function(){try{return Function("\nvar a = () => 5;\nreturn !a.hasOwnProperty(\"prototype\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");return Function("asyncTestPassed","\nvar a = () => 5;\nreturn !a.hasOwnProperty(\"prototype\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -871,7 +871,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <tr class="subtest" data-parent="const"><td><span>basic support</span><script data-source="
 const foo = 123;
 return (foo === 123);
-      ">test(function(){try{return Function("\nconst foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");return Function("asyncTestPassed","\nconst foo = 123;\nreturn (foo === 123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -931,7 +931,7 @@ return (foo === 123);
 const bar = 123;
 { const bar = 456; }
 return bar === 123;
-      ">test(function(){try{return Function("\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");return Function("asyncTestPassed","\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -994,7 +994,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\nconst baz = 1;\ntry {\n  Function(\"const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");return Function("asyncTestPassed","\nconst baz = 1;\ntry {\n  Function(\"const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1054,7 +1054,7 @@ try {
 var passed = (function(){ try { qux; } catch(e) { return true; }}());
 const qux = 456;
 return passed;
-      ">test(function(){try{return Function("\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");return Function("asyncTestPassed","\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -1114,7 +1114,7 @@ return passed;
 &quot;use strict&quot;;
 const foo = 123;
 return (foo === 123);
-      ">test(function(){try{return Function("\n\"use strict\";\nconst foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");return Function("asyncTestPassed","\n\"use strict\";\nconst foo = 123;\nreturn (foo === 123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1175,7 +1175,7 @@ return (foo === 123);
 const bar = 123;
 { const bar = 456; }
 return bar === 123;
-      ">test(function(){try{return Function("\n'use strict';\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");return Function("asyncTestPassed","\n'use strict';\nconst bar = 123;\n{ const bar = 456; }\nreturn bar === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1239,7 +1239,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\n'use strict';\nconst baz = 1;\ntry {\n  Function(\"'use strict'; const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");return Function("asyncTestPassed","\n'use strict';\nconst baz = 1;\ntry {\n  Function(\"'use strict'; const foo = 1; foo = 2;\")();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1300,7 +1300,7 @@ try {
 var passed = (function(){ try { qux; } catch(e) { return true; }}());
 const qux = 456;
 return passed;
-      ">test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");return Function("asyncTestPassed","\n'use strict';\nvar passed = (function(){ try { qux; } catch(e) { return true; }}());\nconst qux = 456;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -1414,7 +1414,7 @@ return passed;
 <tr class="subtest" data-parent="let"><td><span>basic support</span><script data-source="
 let foo = 123;
 return (foo === 123);
-      ">test(function(){try{return Function("\nlet foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");return Function("asyncTestPassed","\nlet foo = 123;\nreturn (foo === 123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1474,7 +1474,7 @@ return (foo === 123);
 let bar = 123;
 { let bar = 456; }
 return bar === 123;
-      ">test(function(){try{return Function("\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");return Function("asyncTestPassed","\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1534,7 +1534,7 @@ return bar === 123;
 let baz = 1;
 for(let baz = 0; false; false) {}
 return baz === 1;
-      ">test(function(){try{return Function("\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");return Function("asyncTestPassed","\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1594,7 +1594,7 @@ return baz === 1;
 var passed = (function(){ try {  qux; } catch(e) { return true; }}());
 let qux = 456;
 return passed;
-      ">test(function(){try{return Function("\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");return Function("asyncTestPassed","\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -1663,7 +1663,7 @@ for(let i in { a:1, b:1 }) {
 }
 passed &amp;= (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 return passed;
-      ">test(function(){try{return Function("\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");return Function("asyncTestPassed","\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1723,7 +1723,7 @@ return passed;
 &apos;use strict&apos;;
 let foo = 123;
 return (foo === 123);
-      ">test(function(){try{return Function("\n'use strict';\nlet foo = 123;\nreturn (foo === 123);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");return Function("asyncTestPassed","\n'use strict';\nlet foo = 123;\nreturn (foo === 123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1784,7 +1784,7 @@ return (foo === 123);
 let bar = 123;
 { let bar = 456; }
 return bar === 123;
-      ">test(function(){try{return Function("\n'use strict';\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");return Function("asyncTestPassed","\n'use strict';\nlet bar = 123;\n{ let bar = 456; }\nreturn bar === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1845,7 +1845,7 @@ return bar === 123;
 let baz = 1;
 for(let baz = 0; false; false) {}
 return baz === 1;
-      ">test(function(){try{return Function("\n'use strict';\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");return Function("asyncTestPassed","\n'use strict';\nlet baz = 1;\nfor(let baz = 0; false; false) {}\nreturn baz === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1906,7 +1906,7 @@ return baz === 1;
 var passed = (function(){ try {  qux; } catch(e) { return true; }}());
 let qux = 456;
 return passed;
-      ">test(function(){try{return Function("\n'use strict';\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");return Function("asyncTestPassed","\n'use strict';\nvar passed = (function(){ try {  qux; } catch(e) { return true; }}());\nlet qux = 456;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -1976,7 +1976,7 @@ for(let i in { a:1, b:1 }) {
 }
 passed &amp;= (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 return passed;
-      ">test(function(){try{return Function("\n'use strict';\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");return Function("asyncTestPassed","\n'use strict';\nlet scopes = [];\nfor(let i = 0; i < 2; i++) {\n  scopes.push(function(){ return i; });\n}\nlet passed = (scopes[0]() === 0 && scopes[1]() === 1);\n\nscopes = [];\nfor(let i in { a:1, b:1 }) {\n  scopes.push(function(){ return i; });\n}\npassed &= (scopes[0]() === \"a\" && scopes[1]() === \"b\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2089,7 +2089,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="default_function_parameters"><td><span>basic functionality</span><script data-source="
 return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
-      ">test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");return Function("asyncTestPassed","\nreturn (function (a = 1, b = 2) { return a === 3 && b === 2; }(3));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2147,7 +2147,7 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 </tr>
 <tr class="subtest" data-parent="default_function_parameters"><td><span>explicit undefined defers to the default</span><script data-source="
 return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined, 3));
-      ">test(function(){try{return Function("\nreturn (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");return Function("asyncTestPassed","\nreturn (function (a = 1, b = 2) { return a === 1 && b === 3; }(undefined, 3));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2205,7 +2205,7 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 </tr>
 <tr class="subtest" data-parent="default_function_parameters"><td><span>defaults can refer to previous params</span><script data-source="
 return (function (a, b = a) { return b === 5; }(5));
-      ">test(function(){try{return Function("\nreturn (function (a, b = a) { return b === 5; }(5));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");return Function("asyncTestPassed","\nreturn (function (a, b = a) { return b === 5; }(5));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2273,7 +2273,7 @@ return (function(x = 1) {
   } catch(e) {}
   return true;
 }());
-      ">test(function(){try{return Function("\nreturn (function(x = 1) {\n  try {\n    eval(\"(function(a=a){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=b,b){}())\");\n    return false;\n  } catch(e) {}\n  return true;\n}());\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");return Function("asyncTestPassed","\nreturn (function(x = 1) {\n  try {\n    eval(\"(function(a=a){}())\");\n    return false;\n  } catch(e) {}\n  try {\n    eval(\"(function(a=b,b){}())\");\n    return false;\n  } catch(e) {}\n  return true;\n}());\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2336,7 +2336,7 @@ return (function(a=function(){
   var b = 1;
   return a();
 }());
-      ">test(function(){try{return Function("\nreturn (function(a=function(){\n  return typeof b === 'undefined';\n}){\n  var b = 1;\n  return a();\n}());\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");return Function("asyncTestPassed","\nreturn (function(a=function(){\n  return typeof b === 'undefined';\n}){\n  var b = 1;\n  return a();\n}());\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2451,7 +2451,7 @@ return (function(a=function(){
 return (function (foo, ...args) {
   return args instanceof Array &amp;&amp; args + &quot;&quot; === &quot;bar,baz&quot;;
 }(&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;));
-      ">test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  return args instanceof Array && args + \"\" === \"bar,baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");return Function("asyncTestPassed","\nreturn (function (foo, ...args) {\n  return args instanceof Array && args + \"\" === \"bar,baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2509,7 +2509,7 @@ return (function (foo, ...args) {
 </tr>
 <tr class="subtest" data-parent="rest_parameters"><td><span>function 'length' property</span><script data-source="
 return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0;
-      ">test(function(){try{return Function("\nreturn function(a, ...b){}.length === 1 && function(...c){}.length === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");return Function("asyncTestPassed","\nreturn function(a, ...b){}.length === 1 && function(...c){}.length === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2575,7 +2575,7 @@ return (function (foo, ...args) {
     &amp;&amp; arguments[1] === &quot;bar&quot;
     &amp;&amp; arguments[2] === &quot;baz&quot;;
 }(&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;));
-      ">test(function(){try{return Function("\nreturn (function (foo, ...args) {\n  foo = \"qux\";\n  // The arguments object is not mapped to the\n  // parameters, even outside of strict mode.\n  return arguments.length === 3\n    && arguments[0] === \"foo\"\n    && arguments[1] === \"bar\"\n    && arguments[2] === \"baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");return Function("asyncTestPassed","\nreturn (function (foo, ...args) {\n  foo = \"qux\";\n  // The arguments object is not mapped to the\n  // parameters, even outside of strict mode.\n  return arguments.length === 3\n    && arguments[0] === \"foo\"\n    && arguments[1] === \"bar\"\n    && arguments[2] === \"baz\";\n}(\"foo\", \"bar\", \"baz\"));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -2688,7 +2688,7 @@ return (function (foo, ...args) {
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with arrays, in function calls</span><script data-source="
 return Math.max(...[1, 2, 3]) === 3
-      ">test(function(){try{return Function("\nreturn Math.max(...[1, 2, 3]) === 3\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");return Function("asyncTestPassed","\nreturn Math.max(...[1, 2, 3]) === 3\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2746,7 +2746,7 @@ return Math.max(...[1, 2, 3]) === 3
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with arrays, in array literals</span><script data-source="
 return [...[1, 2, 3]][2] === 3;
-      ">test(function(){try{return Function("\nreturn [...[1, 2, 3]][2] === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");return Function("asyncTestPassed","\nreturn [...[1, 2, 3]][2] === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2804,7 +2804,7 @@ return [...[1, 2, 3]][2] === 3;
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with strings, in function calls</span><script data-source="
 return Math.max(...&quot;1234&quot;) === 4;
-      ">test(function(){try{return Function("\nreturn Math.max(...\"1234\") === 4;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");return Function("asyncTestPassed","\nreturn Math.max(...\"1234\") === 4;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2862,7 +2862,7 @@ return Math.max(...&quot;1234&quot;) === 4;
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with strings, in array literals</span><script data-source="
 return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
-      ">test(function(){try{return Function("\nreturn [\"a\", ...\"bcd\", \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");return Function("asyncTestPassed","\nreturn [\"a\", ...\"bcd\", \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2921,7 +2921,7 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with generic iterables, in calls</span><script data-source="
 var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...iterable) === 3;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2980,7 +2980,7 @@ return Math.max(...iterable) === 3;
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with generic iterables, in arrays</span><script data-source="
 var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3039,7 +3039,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with instances of iterables, in calls</span><script data-source="
 var iterable = window.__createIterableObject(1, 2, 3);
 return Math.max(...Object.create(iterable)) === 3;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3098,7 +3098,7 @@ return Math.max(...Object.create(iterable)) === 3;
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with instances of iterables, in arrays</span><script data-source="
 var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d&quot;;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3212,7 +3212,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <tr class="subtest" data-parent="class"><td><span>class statement</span><script data-source="
 class C {}
 return typeof C === &quot;function&quot;;
-      ">test(function(){try{return Function("\nclass C {}\nreturn typeof C === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");return Function("asyncTestPassed","\nclass C {}\nreturn typeof C === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3276,7 +3276,7 @@ var c1 = C;
   var c2 = C;
 }
 return C === c1;
-      ">test(function(){try{return Function("\nclass C {}\nvar c1 = C;\n{\n  class C {}\n  var c2 = C;\n}\nreturn C === c1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");return Function("asyncTestPassed","\nclass C {}\nvar c1 = C;\n{\n  class C {}\n  var c2 = C;\n}\nreturn C === c1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3334,7 +3334,7 @@ return C === c1;
 </tr>
 <tr class="subtest" data-parent="class"><td><span>class expression</span><script data-source="
 return typeof class C {} === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof class C {} === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");return Function("asyncTestPassed","\nreturn typeof class C {} === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3396,7 +3396,7 @@ class C {
 }
 return C.prototype.constructor === C
   &amp;&amp; new C().x === 1;
-      ">test(function(){try{return Function("\nclass C {\n  constructor() { this.x = 1; }\n}\nreturn C.prototype.constructor === C\n  && new C().x === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");return Function("asyncTestPassed","\nclass C {\n  constructor() { this.x = 1; }\n}\nreturn C.prototype.constructor === C\n  && new C().x === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3458,7 +3458,7 @@ class C {
 }
 return typeof C.prototype.method === &quot;function&quot;
   &amp;&amp; new C().method() === 2;
-      ">test(function(){try{return Function("\nclass C {\n  method() { return 2; }\n}\nreturn typeof C.prototype.method === \"function\"\n  && new C().method() === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");return Function("asyncTestPassed","\nclass C {\n  method() { return 2; }\n}\nreturn typeof C.prototype.method === \"function\"\n  && new C().method() === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3520,7 +3520,7 @@ class C {
 }
 return typeof C.method === &quot;function&quot;
   &amp;&amp; C.method() === 3;
-      ">test(function(){try{return Function("\nclass C {\n  static method() { return 3; }\n}\nreturn typeof C.method === \"function\"\n  && C.method() === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");return Function("asyncTestPassed","\nclass C {\n  static method() { return 3; }\n}\nreturn typeof C.method === \"function\"\n  && C.method() === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3584,7 +3584,7 @@ class C {
 }
 new C().bar = true;
 return new C().foo === &quot;foo&quot; &amp;&amp; baz;
-      ">test(function(){try{return Function("\nvar baz = false;\nclass C {\n  get foo() { return \"foo\"; }\n  set bar(x) { baz = x; }\n}\nnew C().bar = true;\nreturn new C().foo === \"foo\" && baz;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");return Function("asyncTestPassed","\nvar baz = false;\nclass C {\n  get foo() { return \"foo\"; }\n  set bar(x) { baz = x; }\n}\nnew C().bar = true;\nreturn new C().foo === \"foo\" && baz;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3648,7 +3648,7 @@ class C {
 }
 C.bar = true;
 return C.foo === &quot;foo&quot; &amp;&amp; baz;
-      ">test(function(){try{return Function("\nvar baz = false;\nclass C {\n  static get foo() { return \"foo\"; }\n  static set bar(x) { baz = x; }\n}\nC.bar = true;\nreturn C.foo === \"foo\" && baz;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");return Function("asyncTestPassed","\nvar baz = false;\nclass C {\n  static get foo() { return \"foo\"; }\n  static set bar(x) { baz = x; }\n}\nC.bar = true;\nreturn C.foo === \"foo\" && baz;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3710,7 +3710,7 @@ var c = class C {
 }.method;
 
 return c();
-      ">test(function(){try{return Function("\nvar c = class C {\n  static method() { return this === undefined; }\n}.method;\n\nreturn c();\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");return Function("asyncTestPassed","\nvar c = class C {\n  static method() { return this === undefined; }\n}.method;\n\nreturn c();\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3772,7 +3772,7 @@ var c = new C();
 return c instanceof Array
   &amp;&amp; Array.isPrototypeOf(C)
   &amp;&amp; Array.prototype.isPrototypeOf(C.prototype);
-      ">test(function(){try{return Function("\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof Array\n  && Array.isPrototypeOf(C)\n  && Array.prototype.isPrototypeOf(C.prototype);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof Array\n  && Array.isPrototypeOf(C)\n  && Array.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
@@ -3834,7 +3834,7 @@ var c = new C();
 return !(c instanceof Object)
   &amp;&amp; Function.prototype.isPrototypeOf(C)
   &amp;&amp; Object.getPrototypeOf(C.prototype) === null;
-      ">test(function(){try{return Function("\nclass C extends null {}\nvar c = new C();\nreturn !(c instanceof Object)\n  && Function.prototype.isPrototypeOf(C)\n  && Object.getPrototypeOf(C.prototype) === null;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");return Function("asyncTestPassed","\nclass C extends null {}\nvar c = new C();\nreturn !(c instanceof Object)\n  && Function.prototype.isPrototypeOf(C)\n  && Object.getPrototypeOf(C.prototype) === null;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="_6to5">No</td>
@@ -3952,7 +3952,7 @@ class B extends class {
   constructor(a) { return super(&quot;bar&quot; + a); }
 }
 return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
-      ">test(function(){try{return Function("\nclass B extends class {\n  constructor(a) { return [\"foo\" + a]; }\n} {\n  constructor(a) { return super(\"bar\" + a); }\n}\nreturn new B(\"baz\")[0] === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");return Function("asyncTestPassed","\nclass B extends class {\n  constructor(a) { return [\"foo\" + a]; }\n} {\n  constructor(a) { return super(\"bar\" + a); }\n}\nreturn new B(\"baz\")[0] === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4015,7 +4015,7 @@ class B extends class {
   qux(a) { return super.qux(&quot;bar&quot; + a); }
 }
 return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
-      ">test(function(){try{return Function("\nclass B extends class {\n  qux(a) { return \"foo\" + a; }\n} {\n  qux(a) { return super.qux(\"bar\" + a); }\n}\nreturn new B().qux(\"baz\") === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");return Function("asyncTestPassed","\nclass B extends class {\n  qux(a) { return \"foo\" + a; }\n} {\n  qux(a) { return super.qux(\"bar\" + a); }\n}\nreturn new B().qux(\"baz\") === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4082,7 +4082,7 @@ var obj = {
   corge: &quot;ley&quot;
 };
 return obj.qux() === &quot;barley&quot;;
-      ">test(function(){try{return Function("\nclass B extends class {\n  qux() { return \"bar\"; }\n} {\n  qux() { return super.qux() + this.corge; }\n}\nvar obj = {\n  qux: B.prototype.qux,\n  corge: \"ley\"\n};\nreturn obj.qux() === \"barley\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");return Function("asyncTestPassed","\nclass B extends class {\n  qux() { return \"bar\"; }\n} {\n  qux() { return super.qux() + this.corge; }\n}\nvar obj = {\n  qux: B.prototype.qux,\n  corge: \"ley\"\n};\nreturn obj.qux() === \"barley\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4196,7 +4196,7 @@ return obj.qux() === &quot;barley&quot;;
 <tr class="subtest" data-parent="object_literal_extensions"><td><span>computed properties</span><script data-source="
 var x = &apos;y&apos;;
 return ({ [x]: 1 }).y === 1;
-      ">test(function(){try{return Function("\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");return Function("asyncTestPassed","\nvar x = 'y';\nreturn ({ [x]: 1 }).y === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4255,7 +4255,7 @@ return ({ [x]: 1 }).y === 1;
 <tr class="subtest" data-parent="object_literal_extensions"><td><span>shorthand properties</span><script data-source="
 var a = 7, b = 8, c = {a,b};
 return c.a === 7 &amp;&amp; c.b === 8;
-      ">test(function(){try{return Function("\nvar a = 7, b = 8, c = {a,b};\nreturn c.a === 7 && c.b === 8;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");return Function("asyncTestPassed","\nvar a = 7, b = 8, c = {a,b};\nreturn c.a === 7 && c.b === 8;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4313,7 +4313,7 @@ return c.a === 7 &amp;&amp; c.b === 8;
 </tr>
 <tr class="subtest" data-parent="object_literal_extensions"><td><span>shorthand methods</span><script data-source="
 return ({ y() { return 2; } }).y() === 2;
-      ">test(function(){try{return Function("\nreturn ({ y() { return 2; } }).y() === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");return Function("asyncTestPassed","\nreturn ({ y() { return 2; } }).y() === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4428,7 +4428,7 @@ return ({ y() { return 2; } }).y() === 2;
 var arr = [5];
 for (var item of arr)
   return item === 5;
-      ">test(function(){try{return Function("\nvar arr = [5];\nfor (var item of arr)\n  return item === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");return Function("asyncTestPassed","\nvar arr = [5];\nfor (var item of arr)\n  return item === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4489,7 +4489,7 @@ var str = &quot;&quot;;
 for (var item of &quot;foo&quot;)
   str += item;
 return str === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nvar str = \"\";\nfor (var item of \"foo\")\n  str += item;\nreturn str === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");return Function("asyncTestPassed","\nvar str = \"\";\nfor (var item of \"foo\")\n  str += item;\nreturn str === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4552,7 +4552,7 @@ for (var item of iterable) {
   result += item;
 }
 return result === &quot;123&quot;;
-      ">test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4615,7 +4615,7 @@ for (var item of Object.create(iterable)) {
   result += item;
 }
 return result === &quot;123&quot;;
-      ">test(function(){try{return Function("\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4738,7 +4738,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4806,7 +4806,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nfunction * generator(){\n  yield this.x; yield this.y;\n};\nvar iterator = { g: generator, x: 5, y: 6 }.g();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");return Function("asyncTestPassed","\nfunction * generator(){\n  yield this.x; yield this.y;\n};\nvar iterator = { g: generator, x: 5, y: 6 }.g();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4872,7 +4872,7 @@ iterator.next();
 iterator.next(&quot;foo&quot;);
 iterator.next(&quot;bar&quot;);
 return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
-      ">test(function(){try{return Function("\nvar sent;\nfunction * generator(){\n  sent = [yield 5, yield 6];\n};\nvar iterator = generator();\niterator.next();\niterator.next(\"foo\");\niterator.next(\"bar\");\nreturn sent[0] === \"foo\" && sent[1] === \"bar\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");return Function("asyncTestPassed","\nvar sent;\nfunction * generator(){\n  sent = [yield 5, yield 6];\n};\nvar iterator = generator();\niterator.next();\niterator.next(\"foo\");\niterator.next(\"bar\");\nreturn sent[0] === \"foo\" && sent[1] === \"bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -4939,7 +4939,7 @@ passed &amp;= sharedProto !== Object.prototype &amp;&amp;
   sharedProto.hasOwnProperty(&apos;next&apos;);
 
 return passed;
-      ">test(function(){try{return Function("\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");return Function("asyncTestPassed","\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -5008,7 +5008,7 @@ var iterator = generator();
 iterator.next();
 iterator.throw(&quot;foo&quot;);
 return passed;
-      ">test(function(){try{return Function("\nvar passed = false;\nfunction * generator(){\n  try {\n    yield 5; yield 6;\n  } catch(e) {\n    passed = (e === \"foo\");\n  }\n};\nvar iterator = generator();\niterator.next();\niterator.throw(\"foo\");\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");return Function("asyncTestPassed","\nvar passed = false;\nfunction * generator(){\n  try {\n    yield 5; yield 6;\n  } catch(e) {\n    passed = (e === \"foo\");\n  }\n};\nvar iterator = generator();\niterator.next();\niterator.throw(\"foo\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5076,7 +5076,7 @@ passed    &amp;= item.value === &quot;quxquux&quot; &amp;&amp; item.done === tru
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.return(\"quxquux\");\npassed    &= item.value === \"quxquux\" && item.done === true;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.return(\"quxquux\");\npassed    &= item.value === \"quxquux\" && item.done === true;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5141,7 +5141,7 @@ var iterator = generator();
 iterator.next();
 iterator.next(true);
 return passed;
-      ">test(function(){try{return Function("\nvar passed;\nfunction * generator(){\n  passed = yield 0 ? true : false;\n};\nvar iterator = generator();\niterator.next();\niterator.next(true);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");return Function("asyncTestPassed","\nvar passed;\nfunction * generator(){\n  passed = yield 0 ? true : false;\n};\nvar iterator = generator();\niterator.next();\niterator.next(true);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5208,7 +5208,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5275,7 +5275,7 @@ passed    &amp;= item.value === &quot;6&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5344,7 +5344,7 @@ passed    &amp;= item.value === 7 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * window.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * window.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5413,7 +5413,7 @@ passed    &amp;= item.value === 7 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5483,7 +5483,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar o = {\n  * generator() {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");return Function("asyncTestPassed","\nvar o = {\n  * generator() {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5596,7 +5596,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="octal_and_binary_literals"><td><span>octal literals</span><script data-source="
 return 0o10 === 8 &amp;&amp; 0O10 === 8;
-      ">test(function(){try{return Function("\nreturn 0o10 === 8 && 0O10 === 8;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");return Function("asyncTestPassed","\nreturn 0o10 === 8 && 0O10 === 8;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5654,7 +5654,7 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 </tr>
 <tr class="subtest" data-parent="octal_and_binary_literals"><td><span>binary literals</span><script data-source="
 return 0b10 === 2 &amp;&amp; 0B10 === 2;
-      ">test(function(){try{return Function("\nreturn 0b10 === 2 && 0B10 === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");return Function("asyncTestPassed","\nreturn 0b10 === 2 && 0B10 === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5712,7 +5712,7 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 </tr>
 <tr class="subtest" data-parent="octal_and_binary_literals"><td><span>octal supported by Number()</span><script data-source="
 return Number(&apos;0o1&apos;) === 1;
-      ">test(function(){try{return Function("\nreturn Number('0o1') === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");return Function("asyncTestPassed","\nreturn Number('0o1') === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -5770,7 +5770,7 @@ return Number(&apos;0o1&apos;) === 1;
 </tr>
 <tr class="subtest" data-parent="octal_and_binary_literals"><td><span>binary supported by Number()</span><script data-source="
 return Number(&apos;0b1&apos;) === 1;
-      ">test(function(){try{return Function("\nreturn Number('0b1') === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");return Function("asyncTestPassed","\nreturn Number('0b1') === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -5885,7 +5885,7 @@ return Number(&apos;0b1&apos;) === 1;
 var a = &quot;ba&quot;, b = &quot;QUX&quot;;
 return `foo bar
 ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
-      ">test(function(){try{return Function("\nvar a = \"ba\", b = \"QUX\";\nreturn `foo bar\n${a + \"z\"} ${b.toLowerCase()}` === \"foo bar\\nbaz qux\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");return Function("asyncTestPassed","\nvar a = \"ba\", b = \"QUX\";\nreturn `foo bar\n${a + \"z\"} ${b.toLowerCase()}` === \"foo bar\\nbaz qux\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5954,7 +5954,7 @@ function fn(parts, a, b) {
     b === 456;
 }
 return fn `foo${123}bar\n${456}` &amp;&amp; called;
-      ">test(function(){try{return Function("\nvar called = false;\nfunction fn(parts, a, b) {\n  called = true;\n  return parts instanceof Array &&\n    parts[0]     === \"foo\"      &&\n    parts[1]     === \"bar\\n\"    &&\n    parts.raw[0] === \"foo\"      &&\n    parts.raw[1] === \"bar\\\\n\"   &&\n    a === 123                   &&\n    b === 456;\n}\nreturn fn `foo${123}bar\\n${456}` && called;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");return Function("asyncTestPassed","\nvar called = false;\nfunction fn(parts, a, b) {\n  called = true;\n  return parts instanceof Array &&\n    parts[0]     === \"foo\"      &&\n    parts[1]     === \"bar\\n\"    &&\n    parts.raw[0] === \"foo\"      &&\n    parts.raw[1] === \"bar\\\\n\"   &&\n    a === 123                   &&\n    b === 456;\n}\nreturn fn `foo${123}bar\\n${456}` && called;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -6071,7 +6071,7 @@ var re2 = new RegExp(&apos;\\w&apos;, &apos;y&apos;);
 re.exec(&apos;xy&apos;);
 re2.exec(&apos;xy&apos;);
 return (re.exec(&apos;xy&apos;)[0] === &apos;x&apos; &amp;&amp; re2.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
-      ">test(function(){try{return Function("\nvar re = new RegExp('\\\\w');\nvar re2 = new RegExp('\\\\w', 'y');\nre.exec('xy');\nre2.exec('xy');\nreturn (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("97");return Function("asyncTestPassed","\nvar re = new RegExp('\\\\w');\nvar re2 = new RegExp('\\\\w', 'y');\nre.exec('xy');\nre2.exec('xy');\nreturn (re.exec('xy')[0] === 'x' && re2.exec('xy')[0] === 'y');\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6129,7 +6129,7 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;x&apos; &amp;&amp; re2.exec(&apos;x
 </tr>
 <tr class="subtest" data-parent="RegExp_y_and_u_flags"><td><span>"u" flag</span><script data-source="
 return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
-      ">test(function(){try{return Function("\nreturn \"𠮷\".match(/./u)[0].length === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");return Function("asyncTestPassed","\nreturn \"𠮷\".match(/./u)[0].length === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -6244,7 +6244,7 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 var buffer = new ArrayBuffer(64);
 var view = new Int8Array(buffer);         view[0] = 0x80;
 return view[0] === -0x80;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6304,7 +6304,7 @@ return view[0] === -0x80;
 var buffer = new ArrayBuffer(64);
 var view = new Uint8Array(buffer);        view[0] = 0x100;
 return view[0] === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6364,7 +6364,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Uint8ClampedArray(buffer); view[0] = 0x100;
 return view[0] === 0xFF;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6424,7 +6424,7 @@ return view[0] === 0xFF;
 var buffer = new ArrayBuffer(64);
 var view = new Int16Array(buffer);        view[0] = 0x8000;
 return view[0] === -0x8000;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6484,7 +6484,7 @@ return view[0] === -0x8000;
 var buffer = new ArrayBuffer(64);
 var view = new Uint16Array(buffer);       view[0] = 0x10000;
 return view[0] === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6544,7 +6544,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Int32Array(buffer);        view[0] = 0x80000000;
 return view[0] === -0x80000000;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6604,7 +6604,7 @@ return view[0] === -0x80000000;
 var buffer = new ArrayBuffer(64);
 var view = new Uint32Array(buffer);       view[0] = 0x100000000;
 return view[0] === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6664,7 +6664,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Float32Array(buffer);       view[0] = 0.1;
 return view[0] === 0.10000000149011612;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6724,7 +6724,7 @@ return view[0] === 0.10000000149011612;
 var buffer = new ArrayBuffer(64);
 var view = new Float64Array(buffer);       view[0] = 0.1;
 return view[0] === 0.1;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6785,7 +6785,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt8 (0, 0x80);
 return view.getInt8(0) === -0x80;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6846,7 +6846,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6907,7 +6907,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -6968,7 +6968,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7029,7 +7029,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7090,7 +7090,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7151,7 +7151,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7212,7 +7212,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
-      ">test(function(){try{return Function("\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7278,7 +7278,7 @@ return typeof Int8Array.from === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.from === &quot;function&quot; &amp;&amp;
   typeof Float32Array.from === &quot;function&quot; &amp;&amp;
   typeof Float64Array.from === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");return Function("asyncTestPassed","\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7344,7 +7344,7 @@ return typeof Int8Array.of === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.of === &quot;function&quot; &amp;&amp;
   typeof Float32Array.of === &quot;function&quot; &amp;&amp;
   typeof Float64Array.of === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");return Function("asyncTestPassed","\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7410,7 +7410,7 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.subarray === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7476,7 +7476,7 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.join === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7542,7 +7542,7 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.indexOf === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7608,7 +7608,7 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp
   typeof Uint32Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7674,7 +7674,7 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.slice === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7740,7 +7740,7 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.every === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7806,7 +7806,7 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.filter === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7872,7 +7872,7 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.forEach === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7938,7 +7938,7 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.map === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8004,7 +8004,7 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reduce === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8070,7 +8070,7 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &amp;&amp
   typeof Uint32Array.prototype.reduceRight === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reduceRight === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8136,7 +8136,7 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reverse === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8202,7 +8202,7 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.some === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8268,7 +8268,7 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.sort === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8334,7 +8334,7 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8400,7 +8400,7 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.find === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8466,7 +8466,7 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.findIndex === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8532,7 +8532,7 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.fill === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8598,7 +8598,7 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.keys === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8664,7 +8664,7 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.values === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8730,7 +8730,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.entries === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8848,7 +8848,7 @@ var map = new Map();
 map.set(key, 123);
 
 return map.has(key) &amp;&amp; map.get(key) === 123;
-      ">test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -8911,7 +8911,7 @@ var map = new Map([[key1, 123], [key2, 456]]);
 
 return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
        map.has(key2) &amp;&amp; map.get(key2) === 456;
-      ">test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -8970,7 +8970,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.set returns this</span><script data-source="
 var map = new Map();
 return map.set(0, 0) === map;
-      ">test(function(){try{return Function("\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");return Function("asyncTestPassed","\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9034,7 +9034,7 @@ map.forEach(function (value, key) {
   k = 1 / key;
 });
 return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
-      ">test(function(){try{return Function("\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9097,7 +9097,7 @@ var map = new Map();
 map.set(key, 123);
 
 return map.size === 1;
-      ">test(function(){try{return Function("\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9155,7 +9155,7 @@ return map.size === 1;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.delete</span><script data-source="
 return typeof Map.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");return Function("asyncTestPassed","\nreturn typeof Map.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9213,7 +9213,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.clear</span><script data-source="
 return typeof Map.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");return Function("asyncTestPassed","\nreturn typeof Map.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9271,7 +9271,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.forEach</span><script data-source="
 return typeof Map.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.forEach === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");return Function("asyncTestPassed","\nreturn typeof Map.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9329,7 +9329,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.keys</span><script data-source="
 return typeof Map.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.keys === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");return Function("asyncTestPassed","\nreturn typeof Map.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9387,7 +9387,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.values</span><script data-source="
 return typeof Map.prototype.values === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.values === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");return Function("asyncTestPassed","\nreturn typeof Map.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9445,7 +9445,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.entries</span><script data-source="
 return typeof Map.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Map.prototype.entries === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");return Function("asyncTestPassed","\nreturn typeof Map.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9564,7 +9564,7 @@ set.add(123);
 set.add(123);
 
 return set.has(123);
-      ">test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9626,7 +9626,7 @@ var obj2 = {};
 var set = new Set([obj1, obj2]);
 
 return set.has(obj1) &amp;&amp; set.has(obj2);
-      ">test(function(){try{return Function("\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");return Function("asyncTestPassed","\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9685,7 +9685,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.add returns this</span><script data-source="
 var set = new Set();
 return set.add(0) === set;
-      ">test(function(){try{return Function("\nvar set = new Set();\nreturn set.add(0) === set;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");return Function("asyncTestPassed","\nvar set = new Set();\nreturn set.add(0) === set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9749,7 +9749,7 @@ set.forEach(function (value) {
   k = 1 / value;
 });
 return k === Infinity &amp;&amp; set.has(+0);
-      ">test(function(){try{return Function("\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");return Function("asyncTestPassed","\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9814,7 +9814,7 @@ set.add(123);
 set.add(456);
 
 return set.size === 2;
-      ">test(function(){try{return Function("\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9872,7 +9872,7 @@ return set.size === 2;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.delete</span><script data-source="
 return typeof Set.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");return Function("asyncTestPassed","\nreturn typeof Set.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9930,7 +9930,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.clear</span><script data-source="
 return typeof Set.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.clear === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");return Function("asyncTestPassed","\nreturn typeof Set.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -9988,7 +9988,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.forEach</span><script data-source="
 return typeof Set.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.forEach === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");return Function("asyncTestPassed","\nreturn typeof Set.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10046,7 +10046,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.keys</span><script data-source="
 return typeof Set.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.keys === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");return Function("asyncTestPassed","\nreturn typeof Set.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10104,7 +10104,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.values</span><script data-source="
 return typeof Set.prototype.values === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.values === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");return Function("asyncTestPassed","\nreturn typeof Set.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10162,7 +10162,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.entries</span><script data-source="
 return typeof Set.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Set.prototype.entries === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");return Function("asyncTestPassed","\nreturn typeof Set.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10280,7 +10280,7 @@ var weakmap = new WeakMap();
 weakmap.set(key, 123);
 
 return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
-      ">test(function(){try{return Function("\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");return Function("asyncTestPassed","\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10343,7 +10343,7 @@ var weakmap = new WeakMap([[key1, 123], [key2, 456]]);
 
 return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
        weakmap.has(key2) &amp;&amp; weakmap.get(key2) === 456;
-      ">test(function(){try{return Function("\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10403,7 +10403,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 var weakmap = new WeakMap();
 var key = {};
 return weakmap.set(key, 0) === weakmap;
-      ">test(function(){try{return Function("\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");return Function("asyncTestPassed","\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10461,7 +10461,7 @@ return weakmap.set(key, 0) === weakmap;
 </tr>
 <tr class="subtest" data-parent="WeakMap"><td><span>WeakMap.prototype.delete</span><script data-source="
 return typeof WeakMap.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");return Function("asyncTestPassed","\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10580,7 +10580,7 @@ weakset.add(obj1);
 weakset.add(obj1);
 
 return weakset.has(obj1);
-      ">test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10641,7 +10641,7 @@ var obj1 = {}, obj2 = {};
 var weakset = new WeakSet([obj1, obj2]);
 
 return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
-      ">test(function(){try{return Function("\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10701,7 +10701,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 var weakset = new WeakSet();
 var obj = {};
 return weakset.add(obj) === weakset;
-      ">test(function(){try{return Function("\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10759,7 +10759,7 @@ return weakset.add(obj) === weakset;
 </tr>
 <tr class="subtest" data-parent="WeakSet"><td><span>WeakSet.prototype.delete</span><script data-source="
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10878,7 +10878,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return proxy.foo === 5;
-      ">test(function(){try{return Function("\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10942,7 +10942,7 @@ var proxy = Object.create(new Proxy(proxied, {
   }
 }));
 return proxy.foo === 5;
-      ">test(function(){try{return Function("\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11008,7 +11008,7 @@ var proxy = new Proxy(proxied, {
 });
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11074,7 +11074,7 @@ var proxy = Object.create(new Proxy(proxied, {
 }));
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11139,7 +11139,7 @@ var passed = false;
   }
 });
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11204,7 +11204,7 @@ var passed = false;
   }
 }));
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11269,7 +11269,7 @@ var proxied = {};
     }
   }).foo;
   return passed;
-">test(function(){try{return Function("\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("181");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11340,7 +11340,7 @@ return (returnedDesc.value     === fakeDesc.value
   &amp;&amp; returnedDesc.configurable === fakeDesc.configurable
   &amp;&amp; returnedDesc.writable     === false
   &amp;&amp; returnedDesc.enumerable   === false);
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11410,7 +11410,7 @@ Object.defineProperty(
   { value: 5, configurable: true }
 );
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11475,7 +11475,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return Object.getPrototypeOf(proxy) === fakeProto;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11545,7 +11545,7 @@ Object.setPrototypeOf(
   newProto
 );
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("185");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11612,7 +11612,7 @@ Object.isExtensible(
   })
 );
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("186");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11680,7 +11680,7 @@ Object.preventExtensions(
   })
 );
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("187");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11750,7 +11750,7 @@ for (var i in
   })
 ) { }
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11817,7 +11817,7 @@ Object.keys(
   })
 );
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("189");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11885,7 +11885,7 @@ var host = {
 };
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("190");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -11951,7 +11951,7 @@ new new Proxy(proxied, {
   }
 })(&quot;foo&quot;,&quot;bar&quot;);
 return passed;
-      ">test(function(){try{return Function("\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("191");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12017,7 +12017,7 @@ try {
   passed &amp;= e instanceof TypeError;
 }
 return passed;
-      ">test(function(){try{return Function("\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12075,7 +12075,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>Array.isArray support</span><script data-source="
 return Array.isArray(new Proxy([], {}));
-      ">test(function(){try{return Function("\nreturn Array.isArray(new Proxy([], {}));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("193");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12133,7 +12133,7 @@ return Array.isArray(new Proxy([], {}));
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>JSON.stringify support</span><script data-source="
 return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quot;]&apos;;
-      ">test(function(){try{return Function("\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("194");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12246,7 +12246,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.get</span><script data-source="
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
-      ">test(function(){try{return Function("\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12306,7 +12306,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 var obj = {};
 Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
-      ">test(function(){try{return Function("\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12364,7 +12364,7 @@ return obj.quux === 654;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.has</span><script data-source="
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
-      ">test(function(){try{return Function("\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12424,7 +12424,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 var obj = { bar: 456 };
 Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
-      ">test(function(){try{return Function("\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12485,7 +12485,7 @@ var obj = { baz: 789 };
 var desc = Reflect.getOwnPropertyDescriptor(obj, &quot;baz&quot;);
 return desc.value === 789 &amp;&amp;
   desc.configurable &amp;&amp; desc.writable &amp;&amp; desc.enumerable;
-      ">test(function(){try{return Function("\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12545,7 +12545,7 @@ return desc.value === 789 &amp;&amp;
 var obj = {};
 Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
-      ">test(function(){try{return Function("\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12603,7 +12603,7 @@ return obj.foo === 123;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.getPrototypeOf</span><script data-source="
 return Reflect.getPrototypeOf([]) === Array.prototype;
-      ">test(function(){try{return Function("\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12663,7 +12663,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 var obj = {};
 Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
-      ">test(function(){try{return Function("\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12722,7 +12722,7 @@ return obj instanceof Array;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.isExtensible</span><script data-source="
 return Reflect.isExtensible({}) &amp;&amp;
   !Reflect.isExtensible(Object.preventExtensions({}));
-      ">test(function(){try{return Function("\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12782,7 +12782,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 var obj = {};
 Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
-      ">test(function(){try{return Function("\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12849,7 +12849,7 @@ passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12908,7 +12908,7 @@ return passed;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.ownKeys</span><script data-source="
 var obj = { foo: 1, bar: 2 };
 return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
-      ">test(function(){try{return Function("\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -12966,7 +12966,7 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.apply</span><script data-source="
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
-      ">test(function(){try{return Function("\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13026,7 +13026,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 return Reflect.construct(function(a, b, c) {
   this.qux = a + b + c;
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
-      ">test(function(){try{return Function("\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13089,7 +13089,7 @@ function f() { return 1; }
   function f() { return 2; }
 }
 return f() === 1;
-  ">test(function(){try{return Function("\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");return Function("asyncTestPassed","\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13203,7 +13203,7 @@ return f() === 1;
 <tr class="subtest" data-parent="destructuring"><td><span>with arrays</span><script data-source="
 var [a, , [b], c] = [5, null, [6]];
 return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
-      ">test(function(){try{return Function("\nvar [a, , [b], c] = [5, null, [6]];\nreturn a === 5 && b === 6 && c === undefined;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");return Function("asyncTestPassed","\nvar [a, , [b], c] = [5, null, [6]];\nreturn a === 5 && b === 6 && c === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13262,7 +13262,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <tr class="subtest" data-parent="destructuring"><td><span>with strings</span><script data-source="
 var [a, b, c] = &quot;bar&quot;;
 return a === &quot;b&quot; &amp;&amp; b === &quot;a&quot; &amp;&amp; c === &quot;r&quot;;
-      ">test(function(){try{return Function("\nvar [a, b, c] = \"bar\";\nreturn a === \"b\" && b === \"a\" && c === \"r\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");return Function("asyncTestPassed","\nvar [a, b, c] = \"bar\";\nreturn a === \"b\" && b === \"a\" && c === \"r\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13322,7 +13322,7 @@ return a === &quot;b&quot; &amp;&amp; b === &quot;a&quot; &amp;&amp; c === &quot
 var iterable = window.__createIterableObject(1, 2, 3);
 var [a, b, c] = iterable;
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13382,7 +13382,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 var iterable = window.__createIterableObject(1, 2, 3);
 var [a, b, c] = Object.create(iterable);
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
-      ">test(function(){try{return Function("\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13441,7 +13441,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <tr class="subtest" data-parent="destructuring"><td><span>with objects</span><script data-source="
 var {c, x:d, e} = {c:7, x:8};
 return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
-      ">test(function(){try{return Function("\nvar {c, x:d, e} = {c:7, x:8};\nreturn c === 7 && d === 8 && e === undefined;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");return Function("asyncTestPassed","\nvar {c, x:d, e} = {c:7, x:8};\nreturn c === 7 && d === 8 && e === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13501,7 +13501,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 var qux = &quot;corge&quot;;
 var { [qux]: grault } = { corge: &quot;garply&quot; };
 return grault === &quot;garply&quot;;
-      ">test(function(){try{return Function("\nvar qux = \"corge\";\nvar { [qux]: grault } = { corge: \"garply\" };\nreturn grault === \"garply\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("217");return Function("asyncTestPassed","\nvar qux = \"corge\";\nvar { [qux]: grault } = { corge: \"garply\" };\nreturn grault === \"garply\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13560,7 +13560,7 @@ return grault === &quot;garply&quot;;
 <tr class="subtest" data-parent="destructuring"><td><span>multiples in a single var statement</span><script data-source="
 var [a,b] = [5,6], {c,d} = {c:7,d:8};
 return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
-      ">test(function(){try{return Function("\nvar [a,b] = [5,6], {c,d} = {c:7,d:8};\nreturn a === 5 && b === 6 && c === 7 && d === 8;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");return Function("asyncTestPassed","\nvar [a,b] = [5,6], {c,d} = {c:7,d:8};\nreturn a === 5 && b === 6 && c === 7 && d === 8;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13619,7 +13619,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <tr class="subtest" data-parent="destructuring"><td><span>nested</span><script data-source="
 var [e, {x:f, g}] = [9, {x:10}];
 return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined;
-      ">test(function(){try{return Function("\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn e === 9 && f === 10 && g === undefined;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");return Function("asyncTestPassed","\nvar [e, {x:f, g}] = [9, {x:10}];\nreturn e === 9 && f === 10 && g === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13680,7 +13680,7 @@ return (function({a, x:b, y:e}, [c, d]) {
   return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp;
     d === 4 &amp;&amp; e === undefined;
 }({a:1, x:2}, [3, 4]));
-      ">test(function(){try{return Function("\nreturn (function({a, x:b, y:e}, [c, d]) {\n  return a === 1 && b === 2 && c === 3 &&\n    d === 4 && e === undefined;\n}({a:1, x:2}, [3, 4]));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");return Function("asyncTestPassed","\nreturn (function({a, x:b, y:e}, [c, d]) {\n  return a === 1 && b === 2 && c === 3 &&\n    d === 4 && e === undefined;\n}({a:1, x:2}, [3, 4]));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13740,7 +13740,7 @@ return (function({a, x:b, y:e}, [c, d]) {
 for(var [i, j, k] in { qux: 1 }) {
   return i === &quot;q&quot; &amp;&amp; j === &quot;u&quot; &amp;&amp; k === &quot;x&quot;;
 }
-      ">test(function(){try{return Function("\nfor(var [i, j, k] in { qux: 1 }) {\n  return i === \"q\" && j === \"u\" && k === \"x\";\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");return Function("asyncTestPassed","\nfor(var [i, j, k] in { qux: 1 }) {\n  return i === \"q\" && j === \"u\" && k === \"x\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13800,7 +13800,7 @@ for(var [i, j, k] in { qux: 1 }) {
 for(var [i, j, k] of [[1,2,3]]) {
   return i === 1 &amp;&amp; j === 2 &amp;&amp; k === 3;
 }
-      ">test(function(){try{return Function("\nfor(var [i, j, k] of [[1,2,3]]) {\n  return i === 1 && j === 2 && k === 3;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");return Function("asyncTestPassed","\nfor(var [i, j, k] of [[1,2,3]]) {\n  return i === 1 && j === 2 && k === 3;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13861,7 +13861,7 @@ var [a, ...b] = [3, 4, 5];
 var [c, ...d] = [6];
 return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &quot;4,5&quot; &amp;&amp;
    c === 6 &amp;&amp; d instanceof Array &amp;&amp; d.length === 0;
-      ">test(function(){try{return Function("\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d] = [6];\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");return Function("asyncTestPassed","\nvar [a, ...b] = [3, 4, 5];\nvar [c, ...d] = [6];\nreturn a === 3 && b instanceof Array && (b + \"\") === \"4,5\" &&\n   c === 6 && d instanceof Array && d.length === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13921,7 +13921,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 var a = [1, 2, 3], first, last;
 [first, ...[a[2], last]] = a;
 return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot;1,2,2&quot;;
-      ">test(function(){try{return Function("\nvar a = [1, 2, 3], first, last;\n[first, ...[a[2], last]] = a;\nreturn first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");return Function("asyncTestPassed","\nvar a = [1, 2, 3], first, last;\n[first, ...[a[2], last]] = a;\nreturn first === 1 && last === 3 && (a + \"\") === \"1,2,2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13980,7 +13980,7 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <tr class="subtest" data-parent="destructuring"><td><span>defaults</span><script data-source="
 var {a = 1, b = 0, c = 3} = {b:2, c:undefined};
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
-      ">test(function(){try{return Function("\nvar {a = 1, b = 0, c = 3} = {b:2, c:undefined};\nreturn a === 1 && b === 2 && c === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");return Function("asyncTestPassed","\nvar {a = 1, b = 0, c = 3} = {b:2, c:undefined};\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14041,7 +14041,7 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
   return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4 &amp;&amp;
     e === 5 &amp;&amp; f === undefined;
 }({b:2, c:undefined, x:4}));
-      ">test(function(){try{return Function("\nreturn (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n  return a === 1 && b === 2 && c === 3 && d === 4 &&\n    e === 5 && f === undefined;\n}({b:2, c:undefined, x:4}));\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");return Function("asyncTestPassed","\nreturn (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {\n  return a === 1 && b === 2 && c === 3 && d === 4 &&\n    e === 5 && f === undefined;\n}({b:2, c:undefined, x:4}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14097,13 +14097,88 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Promise"><span><a class="anchor" href="#Promise">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span><script data-source="
-return typeof Promise !== &apos;undefined&apos; &amp;&amp;
-       typeof Promise.all === &apos;function&apos;;
-  ">test(function(){try{return Function("\nreturn typeof Promise !== 'undefined' &&\n       typeof Promise.all === 'function';\n  ")()}catch(e){return false;}}());
+<tr class="supertest"><td id="Promise"><span><a class="anchor" href="#Promise">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span></td>
+<td data-browser="tr" class="tally" data-tally="1">3/3</td>
+<td data-browser="_6to5" class="tally" data-tally="0">0/3</td>
+<td data-browser="es6tr" class="tally" data-tally="0">0/3</td>
+<td data-browser="closure" class="tally" data-tally="0">0/3</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/3</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/3</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/3</td>
+<td data-browser="ie11" class="tally" data-tally="0">0/3</td>
+<td data-browser="ie11tp" class="tally" data-tally="1">3/3</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="firefox31" class="tally" data-tally="1">3/3</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="firefox34" class="tally" data-tally="1">3/3</td>
+<td data-browser="firefox35" class="tally" data-tally="1">3/3</td>
+<td data-browser="firefox36" class="tally" data-tally="1">3/3</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="1">3/3</td>
+<td data-browser="chrome39" class="tally" data-tally="1">3/3</td>
+<td data-browser="chrome40" class="tally" data-tally="1">3/3</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/3</td>
+<td data-browser="safari6" class="tally" data-tally="0">0/3</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/3</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.3333333333333333">1/3</td>
+<td data-browser="webkit" class="tally" data-tally="1">3/3</td>
+<td data-browser="opera" class="tally" data-tally="0">0/3</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/3</td>
+<td data-browser="rhino17" class="tally" data-tally="0">0/3</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/3</td>
+<td data-browser="node" class="tally" data-tally="0">0/3</td>
+<td data-browser="ejs" class="tally" data-tally="1">3/3</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/3</td>
+<td data-browser="ios8" class="tally" data-tally="0.3333333333333333">1/3</td>
+</tr>
+<tr class="subtest" data-parent="Promise"><td><span>basic functionality</span><script data-source="
+var p1 = new Promise(function(resolve, reject) { resolve(&quot;foo&quot;); });
+var p2 = new Promise(function(resolve, reject) { reject(&quot;quux&quot;); });
+var score = 0;
+    
+function thenFn(result)  { score += (result === &quot;foo&quot;);  check(); }
+function catchFn(result) { score += (result === &quot;quux&quot;); check(); }
+function shouldNotRun(result)  { score = -Infinity;   }
+    
+p1.then(thenFn, shouldNotRun);
+p2.then(shouldNotRun, catchFn);
+p1.catch(shouldNotRun);
+p2.catch(catchFn);
+    
+p1.then(function() {
+  // Promise.prototype.then() should return a new Promise
+  score += p1.then() !== p1;
+  check();
+});
+
+function check() {
+  if (score === 4) asyncTestPassed();
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n    \nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n    \np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n    \np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="_6to5">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14155,6 +14230,150 @@ return typeof Promise !== &apos;undefined&apos; &amp;&amp;
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
+</tr>
+<tr class="subtest" data-parent="Promise"><td><span>Promise.all</span><script data-source="
+var fulfills = Promise.all([
+  new Promise(function(resolve)   { setTimeout(resolve,200,&quot;foo&quot;); }),
+  new Promise(function(resolve)   { setTimeout(resolve,100,&quot;bar&quot;); }),
+]);
+var rejects = Promise.all([
+  new Promise(function(_, reject) { setTimeout(reject, 200,&quot;baz&quot;); }),
+  new Promise(function(_, reject) { setTimeout(reject, 100,&quot;qux&quot;); }),
+]);
+var score = 0;
+fulfills.then(function(result) { score += (result + &quot;&quot; === &quot;foo,bar&quot;); check(); });
+rejects.catch(function(result) { score += (result === &quot;qux&quot;); check(); });
+    
+function check() {
+  if (score === 2) asyncTestPassed();
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n    \nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="ie11tp">Yes</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="yes obsolete" data-browser="firefox29">Yes</td>
+<td class="yes obsolete" data-browser="firefox30">Yes</td>
+<td class="yes" data-browser="firefox31">Yes</td>
+<td class="yes obsolete" data-browser="firefox32">Yes</td>
+<td class="yes obsolete" data-browser="firefox33">Yes</td>
+<td class="yes" data-browser="firefox34">Yes</td>
+<td class="yes" data-browser="firefox35">Yes</td>
+<td class="yes" data-browser="firefox36">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="yes obsolete" data-browser="chrome33">Yes</td>
+<td class="yes obsolete" data-browser="chrome34">Yes</td>
+<td class="yes obsolete" data-browser="chrome35">Yes</td>
+<td class="yes obsolete" data-browser="chrome36">Yes</td>
+<td class="yes obsolete" data-browser="chrome37">Yes</td>
+<td class="yes obsolete" data-browser="chrome38">Yes</td>
+<td class="yes" data-browser="chrome39">Yes</td>
+<td class="yes" data-browser="chrome40">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes" data-browser="webkit">Yes</td>
+<td class="no" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="ejs">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="Promise"><td><span>Promise.race</span><script data-source="
+var fulfills = Promise.race([
+  new Promise(function(resolve)   { setTimeout(resolve,200,&quot;foo&quot;); }),
+  new Promise(function(_, reject) { setTimeout(reject, 300,&quot;bar&quot;); }),
+]);
+var rejects = Promise.race([
+  new Promise(function(_, reject) { setTimeout(reject, 200,&quot;baz&quot;); }),
+  new Promise(function(resolve)   { setTimeout(resolve,300,&quot;qux&quot;); }),
+]);
+var score = 0;
+fulfills.then(function(result) { score += (result === &quot;foo&quot;); check(); });
+rejects.catch(function(result) { score += (result === &quot;baz&quot;); check(); });
+    
+function check() {
+  if (score === 2) asyncTestPassed();
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n    \nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="no" data-browser="_6to5">No</td>
+<td class="no" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="ie11tp">Yes</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="yes obsolete" data-browser="firefox29">Yes</td>
+<td class="yes obsolete" data-browser="firefox30">Yes</td>
+<td class="yes" data-browser="firefox31">Yes</td>
+<td class="yes obsolete" data-browser="firefox32">Yes</td>
+<td class="yes obsolete" data-browser="firefox33">Yes</td>
+<td class="yes" data-browser="firefox34">Yes</td>
+<td class="yes" data-browser="firefox35">Yes</td>
+<td class="yes" data-browser="firefox36">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="yes obsolete" data-browser="chrome33">Yes</td>
+<td class="yes obsolete" data-browser="chrome34">Yes</td>
+<td class="yes obsolete" data-browser="chrome35">Yes</td>
+<td class="yes obsolete" data-browser="chrome36">Yes</td>
+<td class="yes obsolete" data-browser="chrome37">Yes</td>
+<td class="yes obsolete" data-browser="chrome38">Yes</td>
+<td class="yes" data-browser="chrome39">Yes</td>
+<td class="yes" data-browser="chrome40">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes" data-browser="webkit">Yes</td>
+<td class="no" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="ejs">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
@@ -14214,7 +14433,7 @@ return typeof Promise !== &apos;undefined&apos; &amp;&amp;
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.assign</span><script data-source="
 var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot; in o;
-      ">test(function(){try{return Function("\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14274,7 +14493,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 return typeof Object.is === &apos;function&apos; &amp;&amp;
   Object.is(NaN, NaN) &amp;&amp;
  !Object.is(-0, 0);
-      ">test(function(){try{return Function("\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14335,7 +14554,7 @@ var o = {};
 var sym = Symbol();
 o[sym] = &quot;foo&quot;;
 return Object.getOwnPropertySymbols(o)[0] === sym;
-      ">test(function(){try{return Function("\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14393,7 +14612,7 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.setPrototypeOf</span><script data-source="
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
-      ">test(function(){try{return Function("\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[9]</sup></a></td>
@@ -14508,7 +14727,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 function foo(){};
 return foo.name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{return Function("\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14567,7 +14786,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>function expressions</span><script data-source="
 return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{return Function("\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14625,7 +14844,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="function_name_property"><td><span>new Function</span><script data-source="
 return (new Function).name === &quot;anonymous&quot;;
-      ">test(function(){try{return Function("\nreturn (new Function).name === \"anonymous\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14685,7 +14904,7 @@ return (new Function).name === &quot;anonymous&quot;;
 function foo() {};
 return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
   (function(){}).bind({}).name === &quot;bound &quot;;
-      ">test(function(){try{return Function("\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14745,7 +14964,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 var foo = function() {};
 var bar = function baz() {};
 return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
-      ">test(function(){try{return Function("\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14807,7 +15026,7 @@ o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{return Function("\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14868,7 +15087,7 @@ var o = { get foo(){}, set foo(x){} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
        descriptor.set.name === &quot;set foo&quot;;
-      ">test(function(){try{return Function("\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14927,7 +15146,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>shorthand methods</span><script data-source="
 var o = { foo(){} };
 return o.foo.name === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14993,7 +15212,7 @@ var o = {
 
 return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
        o[sym2].name === &quot;&quot;;
-      ">test(function(){try{return Function("\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15054,7 +15273,7 @@ class foo {};
 class bar { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
   typeof bar.name === &quot;function&quot;;
-      ">test(function(){try{return Function("\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15113,7 +15332,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class expressions</span><script data-source="
 return class foo {}.name === &quot;foo&quot; &amp;&amp;
   typeof class bar { static name() {} }.name === &quot;function&quot;;
-      ">test(function(){try{return Function("\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15176,7 +15395,7 @@ var qux = class { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
        bar.name === &quot;baz&quot; &amp;&amp;
        typeof qux.name === &quot;function&quot;;
-      ">test(function(){try{return Function("\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15238,7 +15457,7 @@ o.qux = class {};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{return Function("\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15297,7 +15516,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class prototype methods</span><script data-source="
 class C { foo(){} };
 return (new C).foo.name === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15356,7 +15575,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <tr class="subtest" data-parent="function_name_property"><td><span>class static methods</span><script data-source="
 class C { static foo(){} };
 return C.foo.name === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15417,7 +15636,7 @@ var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;
 return descriptor.enumerable   === false &amp;&amp;
        descriptor.writable     === false &amp;&amp;
        descriptor.configurable === true;
-      ">test(function(){try{return Function("\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15475,7 +15694,7 @@ return descriptor.enumerable   === false &amp;&amp;
 </tr>
 <tr><td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span><script data-source="
 return typeof Function.prototype.toMethod === &quot;function&quot;;
-  ">test(function(){try{return Function("\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15588,7 +15807,7 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.raw</span><script data-source="
 return typeof String.raw === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof String.raw === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15646,7 +15865,7 @@ return typeof String.raw === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.fromCodePoint</span><script data-source="
 return typeof String.fromCodePoint === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof String.fromCodePoint === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15759,7 +15978,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.codePointAt</span><script data-source="
 return typeof String.prototype.codePointAt === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.codePointAt === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15819,7 +16038,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 return typeof String.prototype.normalize === &quot;function&quot;
   &amp;&amp; &quot;c\u0327\u0301&quot;.normalize(&quot;NFC&quot;) === &quot;\u1e09&quot;
   &amp;&amp; &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -15878,7 +16097,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.repeat</span><script data-source="
 return typeof String.prototype.repeat === &apos;function&apos;
   &amp;&amp; &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15937,7 +16156,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.startsWith</span><script data-source="
 return typeof String.prototype.startsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.startsWith(&quot;foo&quot;);
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15996,7 +16215,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.endsWith</span><script data-source="
 return typeof String.prototype.endsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.endsWith(&quot;bar&quot;);
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16055,7 +16274,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.includes</span><script data-source="
 return typeof String.prototype.includes === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.includes(&quot;oba&quot;);
-      ">test(function(){try{return Function("\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16113,7 +16332,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 </tr>
 <tr><td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&sect;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span><script data-source="
 return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
-  ">test(function(){try{return Function("\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16230,7 +16449,7 @@ var symbol = Symbol();
 var value = {};
 object[symbol] = value;
 return object[symbol] === value;
-      ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16288,7 +16507,7 @@ return object[symbol] === value;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>typeof support</span><script data-source="
 return typeof Symbol() === &quot;symbol&quot;;
-      ">test(function(){try{return Function("\nreturn typeof Symbol() === \"symbol\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16358,7 +16577,7 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 }
 
 return passed;
-      ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16425,7 +16644,7 @@ if (Object.defineProperty) {
 }
 
 return passed;
-      ">test(function(){try{return Function("\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16496,7 +16715,7 @@ try {
 } catch(e) {}
 
 return true;
-      ">test(function(){try{return Function("\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16554,7 +16773,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>can convert with String()</span><script data-source="
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
-      ">test(function(){try{return Function("\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16617,7 +16836,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16680,7 +16899,7 @@ var symbolObject = Object(symbol);
 return typeof symbolObject === &quot;object&quot; &amp;&amp;
   symbolObject == symbol &amp;&amp;
   symbolObject.valueOf() === symbol;
-      ">test(function(){try{return Function("\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16740,7 +16959,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 var symbol = Symbol.for(&apos;foo&apos;);
 return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
    Symbol.keyFor(symbol) === &apos;foo&apos;;
-      ">test(function(){try{return Function("\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16860,7 +17079,7 @@ Object.defineProperty(C, Symbol.hasInstance, {
 });
 obj instanceof C;
 return passed;
-      ">test(function(){try{return Function("\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16921,7 +17140,7 @@ var a = [], b = [];
 b[Symbol.isConcatSpreadable] = false;
 a = a.concat(b);
 return a[0] === b;
-      ">test(function(){try{return Function("\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16992,7 +17211,7 @@ b[Symbol.iterator] = function() {
 var c;
 for (c of b) {}
 return c === &quot;foo&quot;;
-      ">test(function(){try{return Function("\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17052,7 +17271,7 @@ return c === &quot;foo&quot;;
 return RegExp[Symbol.species] === RegExp
   &amp;&amp; Array[Symbol.species] === Array
   &amp;&amp; !(Symbol.species in Object);
-      ">test(function(){try{return Function("\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17119,7 +17338,7 @@ a &gt;= 0;
 b in {};
 c == 0;
 return passed === 3;
-      ">test(function(){try{return Function("\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17179,7 +17398,7 @@ return passed === 3;
 var a = {};
 a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
-      ">test(function(){try{return Function("\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17241,7 +17460,7 @@ a[Symbol.unscopables] = { bar: true };
 with (a) {
   return foo === 1 &amp;&amp; typeof bar === &quot;undefined&quot;;
 }
-      ">test(function(){try{return Function("\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17354,7 +17573,7 @@ with (a) {
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype.flags</span><script data-source="
 return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
-      ">test(function(){try{return Function("\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17412,7 +17631,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.match]</span><script data-source="
 return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("285");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17470,7 +17689,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.replace]</span><script data-source="
 return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("286");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17528,7 +17747,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.split]</span><script data-source="
 return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17586,7 +17805,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.search]</span><script data-source="
 return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17699,7 +17918,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from</span><script data-source="
 return typeof Array.from === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.from === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nreturn typeof Array.from === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17758,7 +17977,7 @@ return typeof Array.from === &apos;function&apos;;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.of</span><script data-source="
 return typeof Array.of === &apos;function&apos; &amp;&amp;
   Array.of(2)[0] === 2;
-      ">test(function(){try{return Function("\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17871,7 +18090,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.copyWithin</span><script data-source="
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("293");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17929,7 +18148,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.find</span><script data-source="
 return typeof Array.prototype.find === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.find === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17987,7 +18206,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.findIndex</span><script data-source="
 return typeof Array.prototype.findIndex === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.findIndex === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18045,7 +18264,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.fill</span><script data-source="
 return typeof Array.prototype.fill === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.fill === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18103,7 +18322,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.keys</span><script data-source="
 return typeof Array.prototype.keys === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.keys === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18161,7 +18380,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.values</span><script data-source="
 return typeof Array.prototype.values === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.values === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18219,7 +18438,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.entries</span><script data-source="
 return typeof Array.prototype.entries === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Array.prototype.entries === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("299");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18285,7 +18504,7 @@ for (var i = 0; i &lt; ns.length; i++) {
   if (Array.prototype[ns[i]] &amp;&amp; !unscopables[ns[i]]) return false;
 }
 return true;
-      ">test(function(){try{return Function("\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18398,7 +18617,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isFinite</span><script data-source="
 return typeof Number.isFinite === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.isFinite === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18456,7 +18675,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isInteger</span><script data-source="
 return typeof Number.isInteger === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.isInteger === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18514,7 +18733,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isSafeInteger</span><script data-source="
 return typeof Number.isSafeInteger === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.isSafeInteger === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18572,7 +18791,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isNaN</span><script data-source="
 return typeof Number.isNaN === &apos;function&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.isNaN === 'function';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18630,7 +18849,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.EPSILON</span><script data-source="
 return typeof Number.EPSILON === &apos;number&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.EPSILON === 'number';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18688,7 +18907,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MIN_SAFE_INTEGER</span><script data-source="
 return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18746,7 +18965,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MAX_SAFE_INTEGER</span><script data-source="
 return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{return Function("\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18859,7 +19078,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.clz32</span><script data-source="
 return typeof Math.clz32 === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.clz32 === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18917,7 +19136,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.imul</span><script data-source="
 return typeof Math.imul === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.imul === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18975,7 +19194,7 @@ return typeof Math.imul === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sign</span><script data-source="
 return typeof Math.sign === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.sign === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19033,7 +19252,7 @@ return typeof Math.sign === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log10</span><script data-source="
 return typeof Math.log10 === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.log10 === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19091,7 +19310,7 @@ return typeof Math.log10 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log2</span><script data-source="
 return typeof Math.log2 === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.log2 === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19149,7 +19368,7 @@ return typeof Math.log2 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log1p</span><script data-source="
 return typeof Math.log1p === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.log1p === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19207,7 +19426,7 @@ return typeof Math.log1p === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.expm1</span><script data-source="
 return typeof Math.expm1 === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.expm1 === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19265,7 +19484,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.cosh</span><script data-source="
 return typeof Math.cosh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.cosh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19323,7 +19542,7 @@ return typeof Math.cosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sinh</span><script data-source="
 return typeof Math.sinh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.sinh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19381,7 +19600,7 @@ return typeof Math.sinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.tanh</span><script data-source="
 return typeof Math.tanh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.tanh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19439,7 +19658,7 @@ return typeof Math.tanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.acosh</span><script data-source="
 return typeof Math.acosh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.acosh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19497,7 +19716,7 @@ return typeof Math.acosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.asinh</span><script data-source="
 return typeof Math.asinh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.asinh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19555,7 +19774,7 @@ return typeof Math.asinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.atanh</span><script data-source="
 return typeof Math.atanh === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.atanh === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19613,7 +19832,7 @@ return typeof Math.atanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.hypot</span><script data-source="
 return typeof Math.hypot === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.hypot === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("323");return Function("asyncTestPassed","\nreturn typeof Math.hypot === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19671,7 +19890,7 @@ return typeof Math.hypot === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.trunc</span><script data-source="
 return typeof Math.trunc === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.trunc === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn typeof Math.trunc === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19729,7 +19948,7 @@ return typeof Math.trunc === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.fround</span><script data-source="
 return typeof Math.fround === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.fround === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nreturn typeof Math.fround === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19787,7 +20006,7 @@ return typeof Math.fround === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.cbrt</span><script data-source="
 return typeof Math.cbrt === &quot;function&quot;;
-">test(function(){try{return Function("\nreturn typeof Math.cbrt === \"function\";\n")()}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nreturn typeof Math.cbrt === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19868,7 +20087,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td data-browser="firefox31" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox34" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="firefox34" class="tally" data-tally="0.42857142857142855">3/7</td>
 <td data-browser="firefox35" class="tally" data-tally="0.5714285714285714">4/7</td>
 <td data-browser="firefox36" class="tally" data-tally="0.5714285714285714">4/7</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
@@ -19901,7 +20120,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <tr class="subtest" data-parent="miscellaneous"><td><span>duplicate property names in strict mode</span><script data-source="
 &apos;use strict&apos;;
 return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
-      ">test(function(){try{return Function("\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19927,7 +20146,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox33">No</td>
-<td class="no" data-browser="firefox34">No</td>
+<td class="yes" data-browser="firefox34">Yes</td>
 <td class="yes" data-browser="firefox35">Yes</td>
 <td class="yes" data-browser="firefox36">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
@@ -19959,7 +20178,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>no semicolon needed after do-while</span><script data-source="
 do {} while (false) return true;
-      ">test(function(){try{return Function("\ndo {} while (false) return true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20022,7 +20241,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20084,7 +20303,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -20149,7 +20368,7 @@ for (var i = 0; i &lt; methods.length; i++) {
   Object[methods[i]](false, &quot;foo&quot;);
 }
 return true;
-      ">test(function(){try{return Function("\nvar methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',\n  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];\nfor (var i = 0; i < methods.length; i++) {\n  Object[methods[i]](20000, \"foo\");\n  Object[methods[i]](\"foo\", \"foo\");\n  Object[methods[i]](false, \"foo\");\n}\nreturn true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nvar methods = ['freeze', 'seal', 'preventExtensions', 'getOwnPropertyDescriptor',\n  'getPrototypeOf', 'isExtensible', 'isSealed', 'isFrozen', 'keys', 'getOwnPropertyNames'];\nfor (var i = 0; i < methods.length; i++) {\n  Object[methods[i]](20000, \"foo\");\n  Object[methods[i]](\"foo\", \"foo\");\n  Object[methods[i]](false, \"foo\");\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -20207,7 +20426,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>Invalid Date</span><script data-source="
 return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
-      ">test(function(){try{return Function("\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -20265,7 +20484,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>RegExp constructor can alter flags</span><script data-source="
 return new RegExp(/./im, &quot;g&quot;).global === true;
-      ">test(function(){try{return Function("\nreturn new RegExp(/./im, \"g\").global === true;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -20332,7 +20551,7 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
   function h() { return 2; }
 
 return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
-  ">test(function(){try{return Function("\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20446,7 +20665,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <tr class="subtest" data-parent="__proto___in_object_literals"><td><span>basic support</span><script data-source="
 return { __proto__ : [] } instanceof Array
   &amp;&amp; !({ __proto__ : null } instanceof Object);
-      ">test(function(){try{return Function("\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("337");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20509,7 +20728,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{return Function("\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("338");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20571,7 +20790,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var a = &quot;__proto__&quot;;
 return !({ [a] : [] } instanceof Array);
-      ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20633,7 +20852,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var __proto__ = [];
 return !({ __proto__ } instanceof Array);
-      ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20694,7 +20913,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 return !({ __proto__(){} } instanceof Function);
-      ">test(function(){try{return Function("\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20800,7 +21019,7 @@ return !({ __proto__(){} } instanceof Function);
 <td data-browser="konq49" class="tally" data-tally="0.6666666666666666">2/3</td>
 <td data-browser="rhino17" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
 <td data-browser="phantom" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
-<td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.6666666666666666" data-flagged-tally="1">2/3</td>
+<td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
 <td data-browser="ejs" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="ios7" class="tally" data-tally="1">3/3</td>
 <td data-browser="ios8" class="tally" data-tally="1">3/3</td>
@@ -20808,7 +21027,7 @@ return !({ __proto__(){} } instanceof Function);
 <tr class="subtest" data-parent="Object.prototype.__proto__"><td><span>get prototype</span><script data-source="
 var A = function(){};
 return (new A()).__proto__ === A.prototype;
-      ">test(function(){try{return Function("\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20868,7 +21087,7 @@ return (new A()).__proto__ === A.prototype;
 var o = {};
 o.__proto__ = Array.prototype;
 return o instanceof Array;
-      ">test(function(){try{return Function("\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20933,7 +21152,7 @@ return (desc
   &amp;&amp; &quot;set&quot; in desc
   &amp;&amp; desc.configurable
   &amp;&amp; !desc.enumerable);
-      ">test(function(){try{return Function("\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")()}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -20984,7 +21203,7 @@ return (desc
 <td class="no" data-browser="konq49">No</td>
 <td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
-<td class="no flagged not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Flag</td>
+<td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms.">No</td>
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
@@ -20998,7 +21217,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-  ">test(function(){try{return Function("\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -21056,7 +21275,7 @@ return true;
 </tr>
 <tr><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&sect;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
-  ">test(function(){try{return Function("\nreturn typeof RegExp.prototype.compile === 'function';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -27,15 +27,6 @@
           return eval("(function*() { yield a; yield b; yield c; }())");
         }
       }
-      // For async tests, this returned function is used to set results
-      // instead of returning true/false.
-      var __asyncPassedFn = function(rowNum) {
-      return function() {
-          var elem = $("#table-wrapper tr:nth-child(" + (+rowNum + 1) + ") .current")[0];
-          elem.className = "yes";
-          elem.textContent = "Yes";
-        }
-      }
     </script>
     <script>
       (function() {

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -27,6 +27,18 @@
           return eval("(function*() { yield a; yield b; yield c; }())");
         }
       }
+      // For async tests, this returned function is used to set results
+      // instead of returning true/false.
+      var __asyncPassedFn = function(id) {
+      return function() {
+          // Uses nextSibling for IE < 9 compatibility
+          // rather than document.querySelector("#" + id + " ~ td")
+          var elem = document.getElementById(id)
+            .nextSibling.nextSibling.nextSibling;
+          elem.className = "yes";
+          elem.textContent = "Yes";
+        }
+      }
     </script>
     <script>
       (function() {

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -29,12 +29,9 @@
       }
       // For async tests, this returned function is used to set results
       // instead of returning true/false.
-      var __asyncPassedFn = function(id) {
+      var __asyncPassedFn = function(rowNum) {
       return function() {
-          // Uses nextSibling for IE < 9 compatibility
-          // rather than document.querySelector("#" + id + " ~ td")
-          var elem = document.getElementById(id)
-            .nextSibling.nextSibling.nextSibling;
+          var elem = $("#table-wrapper tr:nth-child(" + (+rowNum + 1) + ") .current")[0];
           elem.className = "yes";
           elem.textContent = "Yes";
         }

--- a/es7/index.html
+++ b/es7/index.html
@@ -94,7 +94,7 @@
         <!-- TABLE BODY -->
       <tr><td id="Exponentiation_operator"><span><a class="anchor" href="#Exponentiation_operator">&sect;</a><a href="https://gist.github.com/rwaldron/ebe0f4d2d267370be882">Exponentiation operator</a></span><script data-source="
 return 2 ** 3 === 8;
-  ">test(function(){try{return Function("\nreturn 2 ** 3 === 8;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("0");return Function("asyncTestPassed","\nreturn 2 ** 3 === 8;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -121,7 +121,7 @@ return 2 ** 3 === 8;
 </tr>
 <tr><td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span><script data-source="
 return [for (a of [1, 2, 3]) a * a][0] === 1
-  ">test(function(){try{return Function("\nreturn [for (a of [1, 2, 3]) a * a][0] === 1\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a][0] === 1\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -148,7 +148,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 </tr>
 <tr><td id="Generator_comprehensions"><span><a class="anchor" href="#Generator_comprehensions">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions</a></span><script data-source="
 (for (a of [1, 2, 3]) a * a)
-  ">test(function(){try{return Function("\n(for (a of [1, 2, 3]) a * a)\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");return Function("asyncTestPassed","\n(for (a of [1, 2, 3]) a * a)\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -175,7 +175,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 </tr>
 <tr><td id="Typed_objects"><span><a class="anchor" href="#Typed_objects">&sect;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed objects</a></span><script data-source="
 return typeof StructType !== &apos;undefined&apos;;
-  ">test(function(){try{return Function("\nreturn typeof StructType !== 'undefined';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");return Function("asyncTestPassed","\nreturn typeof StructType !== 'undefined';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -202,7 +202,7 @@ return typeof StructType !== &apos;undefined&apos;;
 </tr>
 <tr><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&sect;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:observe">Object.observe</a></span><script data-source="
 return typeof Object.observe === &apos;function&apos;;
-  ">test(function(){try{return Function("\nreturn typeof Object.observe === 'function';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");return Function("asyncTestPassed","\nreturn typeof Object.observe === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -229,7 +229,7 @@ return typeof Object.observe === &apos;function&apos;;
 </tr>
 <tr><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&sect;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
 return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
-  ">test(function(){try{return Function("\nreturn typeof Object.getOwnPropertyDescriptors === 'function';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");return Function("asyncTestPassed","\nreturn typeof Object.getOwnPropertyDescriptors === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -256,7 +256,7 @@ return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
 </tr>
 <tr><td id="Array.prototype.contains"><span><a class="anchor" href="#Array.prototype.contains">&sect;</a><a href="https://github.com/domenic/Array.prototype.contains/blob/master/spec.md">Array.prototype.contains</a></span><script data-source="
 return typeof Array.prototype.contains === &apos;function&apos;;
-  ">test(function(){try{return Function("\nreturn typeof Array.prototype.contains === 'function';\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");return Function("asyncTestPassed","\nreturn typeof Array.prototype.contains === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -296,7 +296,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-  ">test(function(){try{return Function("\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");return Function("asyncTestPassed","\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>

--- a/node.js
+++ b/node.js
@@ -13,18 +13,16 @@ var fs = require('fs')
 
 global.__script_executed = {};
 
-$('#body tbody tr').each(function () {
+$('#body tbody tr').each(function (index) {
   if (this.find('.separator')[0])
     return
   var scripts = this.find('script')
-    , result = null
-	, id = this.find('td').attr('id')
     , i = 0, scr
     , test = function test (expression) {
-      results[id] = results[id] || expression
+      results[index] = results[index] || expression
     }
-	, asyncTestPassed = function passTest (id) {
-	  results[id] = true
+	, asyncPassed = function asyncPassed () {
+	  results[index] = true
     }
     , __createIterableObject = function(a, b, c) {
       if (typeof Symbol === "function" && Symbol.iterator) {
@@ -42,33 +40,27 @@ $('#body tbody tr').each(function () {
       }
     }
   
-  desc[id] = (function (el) {
-    while (el && !el.data)
-      el = el.children[0]
-    return (el && el.data) || 'ERROR!'
-  }(this.find('td>span')[0].children[1]))
+  results[index] = null
+  
+  desc[index] = this.find('td>span:first-child').text()
 
   // can be multiple scripts
   for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {
     scr = scripts[i].children[0].data.trim()
+      .replace(/global\.__asyncPassedFn && __asyncPassedFn\(".*?"\)/g, "asyncPassed")
     eval(scr)
-  }
-  if (result === null) {
-    console.log('\u25BC\t' + desc.replace('§',''))
-  }
-  else {
-    console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
   }
 })
 
 setTimeout(function(){
   Object.keys(results).forEach(function(test) {
-    var result = results[test];
+    var result = results[test]
+    var name = desc[test]
     if (result === null) {
-      console.log('\u25BC\t' + desc.replace('§',''))
+      console.log('\u25BC\t' + name.replace('§',''))
     }
     else {
-      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
+      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (name[0]!== '§' ? '\t' + name : name.slice(1)) + '\t'))
     }
   })
 },500)

--- a/node.js
+++ b/node.js
@@ -7,19 +7,25 @@ var fs = require('fs')
 
   , page = fs.readFileSync(path.join(__dirname, 'es6', 'index.html')).toString().replace(/data-source="[^"]*"/g,'')
   , $ = cheerio.load(page)
+  , results = {}
+  , desc = {}
+  , done = false
 
 global.__script_executed = {};
 
 $('#body tbody tr').each(function () {
   if (this.find('.separator')[0])
     return
-  var desc = this.find('td>span:first-child').text()
-    , scripts = this.find('script')
+  var scripts = this.find('script')
     , result = null
+	, id = this.find('td').attr('id')
     , i = 0, scr
     , test = function test (expression) {
-        result = result || expression
-      }
+      results[id] = results[id] || expression
+    }
+	, asyncTestPassed = function passTest (id) {
+	  results[id] = true
+    }
     , __createIterableObject = function(a, b, c) {
       if (typeof Symbol === "function" && Symbol.iterator) {
         var arr = [a, b, c, ,]
@@ -35,6 +41,12 @@ $('#body tbody tr').each(function () {
         return eval("(function*() { yield a; yield b; yield c; }())")
       }
     }
+  
+  desc[id] = (function (el) {
+    while (el && !el.data)
+      el = el.children[0]
+    return (el && el.data) || 'ERROR!'
+  }(this.find('td>span')[0].children[1]))
 
   // can be multiple scripts
   for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {
@@ -48,3 +60,15 @@ $('#body tbody tr').each(function () {
     console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
   }
 })
+
+setTimeout(function(){
+  Object.keys(results).forEach(function(test) {
+    var result = results[test];
+    if (result === null) {
+      console.log('\u25BC\t' + desc.replace('§',''))
+    }
+    else {
+      console.log(chalk[result ? 'green' : 'red']((result ? '\u2714' : '\u2718') + '\t' + (desc[0]!== '§' ? '\t' + desc : desc.slice(1)) + '\t'))
+    }
+  })
+},500)

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -490,7 +490,7 @@ catch(e) {
 }
 var func = obj.__lookupGetter__(&quot;foo&quot;);
 return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot;;
-  ">test(function(){try{return Function("\ntry {\n  var obj = eval('{ get foo() { return \"bar\"; } }');\n}\ncatch(e) {\n  obj = {}; obj.__defineGetter__(\"foo\", function(){ return \"bar\"; });\n}\nvar func = obj.__lookupGetter__(\"foo\");\nreturn typeof func === \"function\" && func() === \"bar\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");return Function("asyncTestPassed","\ntry {\n  var obj = eval('{ get foo() { return \"bar\"; } }');\n}\ncatch(e) {\n  obj = {}; obj.__defineGetter__(\"foo\", function(){ return \"bar\"; });\n}\nvar func = obj.__lookupGetter__(\"foo\");\nreturn typeof func === \"function\" && func() === \"bar\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -587,7 +587,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var a = [i * 2 for (i in obj) if (i !== &quot;foo&quot;)];
 return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
-  ">test(function(){try{return Function("\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -616,7 +616,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </tr>
 <tr><td id="Expression_closures"><span><a class="anchor" href="#Expression_closures">&sect;</a>Expression closures</span><script data-source="
 return (function(x)x)(1) === 1;
-  ">test(function(){try{return Function("\nreturn (function(x)x)(1) === 1;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");return Function("asyncTestPassed","\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -645,7 +645,7 @@ return (function(x)x)(1) === 1;
 </tr>
 <tr><td id="ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#ECMAScript_for_XML_(E4X)">&sect;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
-  ">test(function(){try{return Function("\nreturn typeof <foo/> === \"xml\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");return Function("asyncTestPassed","\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -678,7 +678,7 @@ for each (var item in {a: &quot;foo&quot;, b: &quot;bar&quot;, c: &quot;baz&quot
   str += item;
 }
 return str === &quot;foobarbaz&quot;;
-  ">test(function(){try{return Function("\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");return Function("asyncTestPassed","\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -708,7 +708,7 @@ return str === &quot;foobarbaz&quot;;
 <tr><td id="Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&sect;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
 var arr = #1=[1, #1#, 3];
 return arr[1] === arr;
-  ">test(function(){try{return Function("\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");return Function("asyncTestPassed","\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -906,7 +906,7 @@ test(function () {
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var g = (i * 2 for (i in obj) if (i !== &quot;foo&quot;));
 return g.next() === 4 &amp;&amp; g.next() === 8;
-  ">test(function(){try{return Function("\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1054,7 +1054,7 @@ return true;
 </tr>
 <tr><td id="Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&sect;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
-  ">test(function(){try{return Function("\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");return Function("asyncTestPassed","\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1083,7 +1083,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </tr>
 <tr><td id="RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&sect;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
-  ">test(function(){try{return Function("\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")()}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>


### PR DESCRIPTION
Closes #247. This makes the Promise test call `Promise#then` and `Promise#catch` and checks what behaviour results, and also adds `Promise.all` and `Promise.race` tests.

In order to get the Promise test to work, I needed to implement asynchronous test result writing. To do this, test functions may now, instead of returning true/false, instead at some point call `asyncTestPassed()`, which is a function of no arguments, provided by the testing environment, that records the test as passed regardless of execution order. `build.js` has been updated to provide such a function (which manually updates the class and text of the corresponding `<td>`) as has the `node.js` test runner script.

This is a re-do of #248, now fully up-to-date with the current codebase.
