### PR TITLE
Fix for "Current-Browser" column

### DIFF
--- a/build.js
+++ b/build.js
@@ -383,7 +383,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
 
   $('#footnotes').append(allFootnotes());
 
-  return $.root().html().replace(/(<\/t\w>)/g, "$1\n");
+  return $.root().html();
 }
 
 function capitalise(s) {


### PR DESCRIPTION
Currently, the "Current Browser" column is broken, moving all the columns two to the left, displaying false data for each browser.

This was introduced by the "cheerio" work. 
Code that was previously:

``` javascript
            <script>
              document.write('<th class="current" title="' + navigator.userAgent + '">Current browser</th><th></th>');
            </script>
```

is now:

``` javascript
            <script>
              document.write('<th class="current" title="' + navigator.userAgent + '">Current browser</th>
<th></th>
');
            </script>
```

The change in this PR will remove the "new-line" within the JavaScript code.
