### PR TITLE
Fix formatting for shell example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Edit the `data-es5.js`, `data-es6.js`, `data-es7.js`, or `data-non-standard.js` 
 The tests themselves should be written in pure ES3, *except* for the sole ES6 feature being tested (as well as any ES5 features strictly required to use the ES6 feature). The test code is placed in multi-line comments (as in [this hack](http://tomasz.janczuk.org/2013/05/multi-line-strings-in-javascript-and.html)), so that node can parse the data scripts without throwing syntax errors. The `build.js` script will wrap the code in an `eval` call inside a `try`, so the tests themselves do not need to catch errors that non-supporting platforms may throw.
 
 In order to test compilers:
-
+```shell
 > npm install # installs compilers
 > node build.js compilers # creates compiler test pages under /compilers
+```


### PR DESCRIPTION
Currently, the shell-code in the README is not readable.
