### PR TITLE
update 6to5's Symbol compatibility

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -4761,6 +4761,7 @@ exports.tests = [
         return true;
       */},
       res: {
+        _6to5:       true,
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -4774,6 +4775,7 @@ exports.tests = [
         return String(Symbol("foo")) === "Symbol(foo)";
       */},
       res: {
+        _6to5:       true,
         ejs:         true,
         chrome39:    true,
         firefox36:   true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -15348,7 +15348,7 @@ function check() {
 </tr>
 <tr class="supertest"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.4444444444444444">4/9</td>
-<td data-browser="_6to5" class="tally" data-tally="0.7777777777777778">7/9</td>
+<td data-browser="_6to5" class="tally" data-tally="1">9/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
@@ -15691,7 +15691,7 @@ return true;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15752,7 +15752,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>


### PR DESCRIPTION
[6to5 REPL](http://6to5.org/repl/#?experimental=true&playground=true&evaluate=true&loose=false&code=let%20foo%20%3D%20Symbol%28'foo'%29%3B%0Aconsole.log%28String%28foo%29%3D%3D%3D'Symbol%28foo%29'%29%3B%0Atry%20%7B%0A%20%20console.log%28foo%20%2B%20%22%22%29%3B%0A%7D%20catch%20%28e%29%20%7B%7D%0Atry%20%7B%0A%20%20console.log%28foo%20%2B%200%29%3B%0A%7D%20catch%20%28e%29%20%7B%7D)
