### PR TITLE
Revert "update 6to5's Symbol compatibility"

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -4717,7 +4717,6 @@ exports.tests = [
         return true;
       */},
       res: {
-        _6to5:       true,
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -4731,7 +4730,6 @@ exports.tests = [
         return String(Symbol("foo")) === "Symbol(foo)";
       */},
       res: {
-        _6to5:       true,
         ejs:         true,
         chrome39:    true,
         firefox36:   true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -15584,7 +15584,7 @@ function check() {
 </tr>
 <tr class="supertest"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.4444444444444444">4/9</td>
-<td data-browser="_6to5" class="tally" data-tally="0.7777777777777778" data-flagged-tally="0.8888888888888888">7/9</td>
+<td data-browser="_6to5" class="tally" data-tally="0.5555555555555556" data-flagged-tally="0.6666666666666666">5/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
@@ -15932,7 +15932,7 @@ return true;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="_6to5">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -15994,7 +15994,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="_6to5">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>


### PR DESCRIPTION
I had pushed [that commit](https://github.com/kangax/compat-table/commit/b03caff1ef3efaaf816a1f5d89b999471b292c5d) by mistake. I just noticed that actually this features doesn't on IE and Safary so changes should be reverted.
