### PR TITLE
Fix usage of "cheerio" to work with the current version.

### DIFF
--- a/node.js
+++ b/node.js
@@ -14,9 +14,9 @@ var fs = require('fs')
 global.__script_executed = {};
 
 $('#body tbody tr').each(function (index) {
-  if (this.find('.separator')[0])
+  if ($(this).find('.separator')[0])
     return
-  var scripts = this.find('script')
+  var scripts = $(this).find('script')
     , i = 0, scr
     , test = function test (expression) {
       results[index] = results[index] || expression
@@ -42,7 +42,7 @@ $('#body tbody tr').each(function (index) {
   
   results[index] = null
   
-  desc[index] = this.find('td>span:first-child').text()
+  desc[index] = $(this).find('td>span:first-child').text()
 
   // can be multiple scripts
   for (; scripts[i] && scripts[i].children && scripts[i].children.length; i++) {


### PR DESCRIPTION
I struggled to get the "node.js" script working in order to test a version of "node," and I ended up having to make the following change in order for it to work. Without this change I get an error on line 17 saying that "find" is not a member of "this".
