### PR TITLE
Marked io.js flagged features, and corrected some results.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -300,12 +300,13 @@ exports.browsers = {
     short: 'Node',
     platformtype: 'engine',
     note_id: 'harmony-flag',
-    note_html: 'Flagged features have to be enabled via <code>--harmony</code> flag'
+    note_html: 'Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag'
   },
   iojs: {
-    full: 'io.js 1.0.0',
+    full: 'io.js 1.0.3',
     short: 'io.js',
     platformtype: 'engine',
+    note_id: 'harmony-flag',
   },
   ejs: {
     full: 'Echo JS',
@@ -1101,7 +1102,7 @@ exports.tests = [
     },
     'with generic iterables, in calls': {
       exec: function () {/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         return Math.max(...iterable) === 3;
       */},
       res: {
@@ -1118,7 +1119,7 @@ exports.tests = [
     },
     'with generic iterables, in arrays': {
       exec: function () {/*
-        var iterable = window.__createIterableObject("b", "c", "d");
+        var iterable = global.__createIterableObject("b", "c", "d");
         return ["a", ...iterable, "e"][3] === "d";
       */},
       res: {
@@ -1131,7 +1132,7 @@ exports.tests = [
     },
     'with instances of iterables, in calls': {
       exec: function () {/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         return Math.max(...Object.create(iterable)) === 3;
       */},
       res: {
@@ -1143,7 +1144,7 @@ exports.tests = [
     },
     'with instances of iterables, in arrays': {
       exec: function () {/*
-        var iterable = window.__createIterableObject("b", "c", "d");
+        var iterable = global.__createIterableObject("b", "c", "d");
         return ["a", ...Object.create(iterable), "e"][3] === "d";
       */},
       res: {
@@ -1173,6 +1174,7 @@ exports.tests = [
         jsx:         true,
         closure:     true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required', note_html: 'Support for this feature incorrectly requires strict mode.' },
       },
     },
     'is block-scoped': {
@@ -1189,6 +1191,7 @@ exports.tests = [
         _6to5:       true,
         jsx:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'class expression': {
@@ -1203,6 +1206,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'constructor': {
@@ -1221,6 +1225,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'prototype methods': {
@@ -1239,6 +1244,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'static methods': {
@@ -1257,6 +1263,7 @@ exports.tests = [
         ejs:         true,
         closure:     true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'accessor properties': {
@@ -1275,6 +1282,7 @@ exports.tests = [
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'static accessor properties': {
@@ -1293,6 +1301,7 @@ exports.tests = [
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'implicit strict mode': {
@@ -1309,6 +1318,7 @@ exports.tests = [
         es6tr:       true,
         jsx:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'extends': {
@@ -1335,6 +1345,7 @@ exports.tests = [
         },
         jsx:         { val: false, note_id: 'compiled-extends' },
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'extends null': {
@@ -1352,6 +1363,7 @@ exports.tests = [
         es6tr:       true,
         jsx:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
   },
@@ -1361,7 +1373,27 @@ exports.tests = [
   category: 'functions',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword',
   subtests: {
-    'in constructors': {
+    'statement in constructors': {
+      exec: function() {/*
+        var passed = false;
+        class B extends class {
+          constructor(a) { passed = (a === "barbaz"); }
+        } {
+          constructor(a) { super("bar" + a); }
+        }
+        new B("baz");
+        return passed;
+      */},
+      res: {
+        tr:          true,
+        _6to5:       true,
+        es6tr:       true,
+        ejs:         true,
+        ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
+      },
+    },
+    'expression in constructors': {
       exec: function() {/*
         class B extends class {
           constructor(a) { return ["foo" + a]; }
@@ -1393,6 +1425,7 @@ exports.tests = [
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
     'is statically bound': {
@@ -1414,6 +1447,7 @@ exports.tests = [
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
+        iojs:        { val: flag, note_id: 'strict-required' },
       },
     },
   },
@@ -1458,6 +1492,7 @@ exports.tests = [
         firefox33:   true,
         chrome40:    flag,
         chrome41:    true,
+        iojs:        flag,
       },
     },
     'shorthand methods': {
@@ -1476,6 +1511,7 @@ exports.tests = [
         firefox34:   true,
         chrome39:    flag,
         chrome41:    true,
+        iojs:        flag,
       },
     },
     'computed shorthand methods': {
@@ -1660,7 +1696,7 @@ exports.tests = [
     'with generic iterables': {
       exec: function () {/*
         var result = "";
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         for (var item of iterable) {
           result += item;
         }
@@ -1677,12 +1713,13 @@ exports.tests = [
         chrome21dev: flag,
         chrome38:    true,
         node:        flag,
+        iojs:        true,
       },
     },
     'with instances of generic iterables': {
       exec: function () {/*
         var result = "";
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         for (var item of Object.create(iterable)) {
           result += item;
         }
@@ -1696,6 +1733,8 @@ exports.tests = [
         firefox36:   true,
         chrome35:    flag,
         chrome38:    true,
+        node:        flag,
+        iojs:        true,
       },
     },
   },
@@ -1912,7 +1951,7 @@ exports.tests = [
     'yield *, generic iterables': {
       exec: function () {/*
         var iterator = (function * generator() {
-          yield * window.__createIterableObject(5, 6, 7);
+          yield * global.__createIterableObject(5, 6, 7);
         }());
         var item = iterator.next();
         var passed = item.value === 5 && item.done === false;
@@ -1980,7 +2019,7 @@ exports.tests = [
         chrome39:    flag,
         chrome41:    true,
         firefox34:   true,
-        iojs:        true,
+        iojs:        flag,
       },
     },
     'computed shorthand generators': {
@@ -3646,7 +3685,7 @@ exports.tests = [
     },
     'with generic iterables': {
       exec: function(){/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         var [a, b, c] = iterable;
         return a === 1 && b === 2 && c === 3;
       */},
@@ -3658,7 +3697,7 @@ exports.tests = [
     },
     'with instances of generic iterables': {
       exec: function(){/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         var [a, b, c] = Object.create(iterable);
         return a === 1 && b === 2 && c === 3;
       */},
@@ -4891,6 +4930,7 @@ exports.tests = [
         _6to5:       true,
         ejs:         true,
         chrome40:    flag,
+        iojs:        flag,
       },
     },
     'Symbol.unscopables': {
@@ -5011,7 +5051,7 @@ exports.tests = [
     },
     'Array.from, generic iterables': {
       exec: function () {/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         return Array.from(iterable) + '' === "1,2,3";
       */},
       res: {
@@ -5025,7 +5065,7 @@ exports.tests = [
     },
     'Array.from, instances of generic iterables': {
       exec: function () {/*
-        var iterable = window.__createIterableObject(1, 2, 3);
+        var iterable = global.__createIterableObject(1, 2, 3);
         return Array.from(Object.create(iterable)) + '' === "1,2,3";
       */},
       res: {

--- a/es6/index.html
+++ b/es6/index.html
@@ -155,7 +155,7 @@
 <th class="platform rhino17 engine" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></a></th>
 <th class="platform node engine" data-browser="node"><a href="#node" class="browser-name"><abbr title="Node 0.11.14">Node</abbr><a href="#harmony-flag-note"><sup>[6]</sup></a></a></th>
-<th class="platform iojs engine" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js 1.0.0">io.js</abbr></a></th>
+<th class="platform iojs engine" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js 1.0.3">io.js</abbr><a href="#harmony-flag-note"><sup>[6]</sup></a></a></th>
 <th class="platform ejs engine" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>
 <th class="platform ios7 mobile" data-browser="ios7"><a href="#ios7" class="browser-name"><abbr title="iOS Safari">iOS7</abbr></a></th>
 <th class="platform ios8 mobile" data-browser="ios8"><a href="#ios8" class="browser-name"><abbr title="iOS Safari">iOS8</abbr></a></th>
@@ -1183,9 +1183,9 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with generic iterables, in calls</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 return Math.max(...iterable) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Math.max(...iterable) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1246,9 +1246,9 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with generic iterables, in arrays</span><script data-source="
-var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
+var iterable = global.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...iterable, \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1309,9 +1309,9 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with instances of iterables, in calls</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 return Math.max(...Object.create(iterable)) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Math.max(...Object.create(iterable)) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1372,9 +1372,9 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with instances of iterables, in arrays</span><script data-source="
-var iterable = window.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
+var iterable = global.__createIterableObject(&quot;b&quot;, &quot;c&quot;, &quot;d&quot;);
 return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(\"b\", \"c\", \"d\");\nreturn [\"a\", ...Object.create(iterable), \"e\"][3] === \"d\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -1488,7 +1488,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="rhino17" class="tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
-<td data-browser="iojs" class="tally" data-tally="0">0/5</td>
+<td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.4">0/5</td>
 <td data-browser="ejs" class="tally" data-tally="0.6">3/5</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/5</td>
 <td data-browser="ios8" class="tally" data-tally="0.2">1/5</td>
@@ -1614,7 +1614,7 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag</td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -1676,7 +1676,7 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag</td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -1866,8 +1866,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
 <td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
-<td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.25">0/4</td>
-<td data-browser="iojs" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
+<td data-browser="iojs" class="tally" data-tally="1">4/4</td>
 <td data-browser="ejs" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/4</td>
 <td data-browser="ios8" class="tally" data-tally="0.25">1/4</td>
@@ -2003,12 +2003,12 @@ return str === &quot;foo&quot;;
 </tr>
 <tr class="subtest" data-parent="for..of_loops"><td><span>with generic iterables</span><script data-source="
 var result = &quot;&quot;;
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 for (var item of iterable) {
   result += item;
 }
 return result === &quot;123&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = global.__createIterableObject(1, 2, 3);\nfor (var item of iterable) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2063,19 +2063,19 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="for..of_loops"><td><span>with instances of generic iterables</span><script data-source="
 var result = &quot;&quot;;
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 for (var item of Object.create(iterable)) {
   result += item;
 }
 return result === &quot;123&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = window.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");return Function("asyncTestPassed","\nvar result = \"\";\nvar iterable = global.__createIterableObject(1, 2, 3);\nfor (var item of Object.create(iterable)) {\n  result += item;\n}\nreturn result === \"123\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -2129,8 +2129,8 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="konq49">No</td>
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
-<td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="node">Flag</td>
+<td class="yes" data-browser="iojs">Yes</td>
 <td class="no" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -3011,10 +3011,10 @@ return a === &quot;b&quot; &amp;&amp; b === &quot;a&quot; &amp;&amp; c === &quot
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="subtest" data-parent="destructuring"><td><span>with generic iterables</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 var [a, b, c] = iterable;
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nvar [a, b, c] = iterable;\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -3075,10 +3075,10 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="destructuring"><td><span>with instances of generic iterables</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 var [a, b, c] = Object.create(iterable);
 return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nvar [a, b, c] = Object.create(iterable);\nreturn a === 1 && b === 2 && c === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -5956,7 +5956,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td data-browser="rhino17" class="tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
 <td data-browser="node" class="tally" data-tally="0">0/11</td>
-<td data-browser="iojs" class="tally" data-tally="0">0/11</td>
+<td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="1">0/11</td>
 <td data-browser="ejs" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/11</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/11</td>
@@ -6019,7 +6019,7 @@ return typeof C === &quot;function&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6087,7 +6087,7 @@ return C === c1;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6149,7 +6149,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6215,7 +6215,7 @@ return C.prototype.constructor === C
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6281,7 +6281,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6347,7 +6347,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6415,7 +6415,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6483,7 +6483,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6549,7 +6549,7 @@ return c();
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6562,11 +6562,11 @@ return c instanceof Array
   &amp;&amp; Array.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof Array\n  && Array.isPrototypeOf(C)\n  && Array.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[11]</sup></a></td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[12]</sup></a></td>
+<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[12]</sup></a></td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
@@ -6615,7 +6615,7 @@ return c instanceof Array
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6628,7 +6628,7 @@ return !(c instanceof Object)
   &amp;&amp; Object.getPrototypeOf(C.prototype) === null;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");return Function("asyncTestPassed","\nclass C extends null {}\nvar c = new C();\nreturn !(c instanceof Object)\n  && Function.prototype.isPrototypeOf(C)\n  && Object.getPrototypeOf(C.prototype) === null;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="yes" data-browser="_6to5">Yes</td>
 <td class="yes" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
@@ -6681,78 +6681,147 @@ return !(c instanceof Object)
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="super"><span><a class="anchor" href="#super">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword">super</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">3/3</td>
-<td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
-<td data-browser="es6tr" class="tally" data-tally="1">3/3</td>
-<td data-browser="closure" class="tally" data-tally="0">0/3</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/3</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/3</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/3</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/3</td>
-<td data-browser="ie11" class="tally" data-tally="0">0/3</td>
-<td data-browser="ie11tp" class="tally" data-tally="1">3/3</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox31" class="tally" data-tally="0">0/3</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox35" class="tally" data-tally="0">0/3</td>
-<td data-browser="firefox36" class="tally" data-tally="0">0/3</td>
-<td data-browser="firefox37" class="tally" data-tally="0">0/3</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="chrome39" class="tally" data-tally="0">0/3</td>
-<td data-browser="chrome40" class="tally" data-tally="0">0/3</td>
-<td data-browser="chrome41" class="tally" data-tally="0">0/3</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/3</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/3</td>
-<td data-browser="safari71_8" class="tally" data-tally="0">0/3</td>
-<td data-browser="webkit" class="tally" data-tally="0">0/3</td>
-<td data-browser="opera" class="tally" data-tally="0">0/3</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/3</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/3</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/3</td>
-<td data-browser="node" class="tally" data-tally="0">0/3</td>
-<td data-browser="iojs" class="tally" data-tally="0">0/3</td>
-<td data-browser="ejs" class="tally" data-tally="1">3/3</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/3</td>
-<td data-browser="ios8" class="tally" data-tally="0">0/3</td>
+<td data-browser="tr" class="tally" data-tally="1">4/4</td>
+<td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
+<td data-browser="es6tr" class="tally" data-tally="1">4/4</td>
+<td data-browser="closure" class="tally" data-tally="0">0/4</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/4</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/4</td>
+<td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/4</td>
+<td data-browser="ie11" class="tally" data-tally="0">0/4</td>
+<td data-browser="ie11tp" class="tally" data-tally="1">4/4</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox31" class="tally" data-tally="0">0/4</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="firefox35" class="tally" data-tally="0">0/4</td>
+<td data-browser="firefox36" class="tally" data-tally="0">0/4</td>
+<td data-browser="firefox37" class="tally" data-tally="0">0/4</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="chrome39" class="tally" data-tally="0">0/4</td>
+<td data-browser="chrome40" class="tally" data-tally="0">0/4</td>
+<td data-browser="chrome41" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
+<td data-browser="webkit" class="tally" data-tally="0">0/4</td>
+<td data-browser="opera" class="tally" data-tally="0">0/4</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/4</td>
+<td data-browser="node" class="tally" data-tally="0">0/4</td>
+<td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.75">0/4</td>
+<td data-browser="ejs" class="tally" data-tally="1">4/4</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/4</td>
+<td data-browser="ios8" class="tally" data-tally="0">0/4</td>
 </tr>
-<tr class="subtest" data-parent="super"><td><span>in constructors</span><script data-source="
+<tr class="subtest" data-parent="super"><td><span>statement in constructors</span><script data-source="
+var passed = false;
+class B extends class {
+  constructor(a) { passed = (a === &quot;barbaz&quot;); }
+} {
+  constructor(a) { super(&quot;bar&quot; + a); }
+}
+new B(&quot;baz&quot;);
+return passed;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");return Function("asyncTestPassed","\nvar passed = false;\nclass B extends class {\n  constructor(a) { passed = (a === \"barbaz\"); }\n} {\n  constructor(a) { super(\"bar\" + a); }\n}\nnew B(\"baz\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="yes" data-browser="_6to5">Yes</td>
+<td class="yes" data-browser="es6tr">Yes</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="ie11tp">Yes</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no" data-browser="firefox35">No</td>
+<td class="no" data-browser="firefox36">No</td>
+<td class="no" data-browser="firefox37">No</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no" data-browser="chrome39">No</td>
+<td class="no" data-browser="chrome40">No</td>
+<td class="no" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="no" data-browser="webkit">No</td>
+<td class="no" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="ejs">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="super"><td><span>expression in constructors</span><script data-source="
 class B extends class {
   constructor(a) { return [&quot;foo&quot; + a]; }
 } {
   constructor(a) { return super(&quot;bar&quot; + a); }
 }
 return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");return Function("asyncTestPassed","\nclass B extends class {\n  constructor(a) { return [\"foo\" + a]; }\n} {\n  constructor(a) { return super(\"bar\" + a); }\n}\nreturn new B(\"baz\")[0] === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");return Function("asyncTestPassed","\nclass B extends class {\n  constructor(a) { return [\"foo\" + a]; }\n} {\n  constructor(a) { return super(\"bar\" + a); }\n}\nreturn new B(\"baz\")[0] === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -6819,7 +6888,7 @@ class B extends class {
   qux(a) { return super.qux(&quot;bar&quot; + a); }
 }
 return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");return Function("asyncTestPassed","\nclass B extends class {\n  qux(a) { return \"foo\" + a; }\n} {\n  qux(a) { return super.qux(\"bar\" + a); }\n}\nreturn new B().qux(\"baz\") === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");return Function("asyncTestPassed","\nclass B extends class {\n  qux(a) { return \"foo\" + a; }\n} {\n  qux(a) { return super.qux(\"bar\" + a); }\n}\nreturn new B().qux(\"baz\") === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -6874,7 +6943,7 @@ return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -6890,7 +6959,7 @@ var obj = {
   corge: &quot;ley&quot;
 };
 return obj.qux() === &quot;barley&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");return Function("asyncTestPassed","\nclass B extends class {\n  qux() { return \"bar\"; }\n} {\n  qux() { return super.qux() + this.corge; }\n}\nvar obj = {\n  qux: B.prototype.qux,\n  corge: \"ley\"\n};\nreturn obj.qux() === \"barley\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");return Function("asyncTestPassed","\nclass B extends class {\n  qux() { return \"bar\"; }\n} {\n  qux() { return super.qux() + this.corge; }\n}\nvar obj = {\n  qux: B.prototype.qux,\n  corge: \"ley\"\n};\nreturn obj.qux() === \"barley\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -6945,7 +7014,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -7004,7 +7073,7 @@ return obj.qux() === &quot;barley&quot;;
 <td data-browser="rhino17" class="tally" data-tally="0">0/13</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/13</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5384615384615384">0/13</td>
-<td data-browser="iojs" class="tally" data-tally="0.6923076923076923">9/13</td>
+<td data-browser="iojs" class="tally" data-tally="0.6153846153846154" data-flagged-tally="0.6923076923076923">8/13</td>
 <td data-browser="ejs" class="tally" data-tally="0">0/13</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/13</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/13</td>
@@ -7021,7 +7090,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7093,7 +7162,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");return Function("asyncTestPassed","\nfunction * generator(){\n  yield this.x; yield this.y;\n};\nvar iterator = { g: generator, x: 5, y: 6 }.g();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");return Function("asyncTestPassed","\nfunction * generator(){\n  yield this.x; yield this.y;\n};\nvar iterator = { g: generator, x: 5, y: 6 }.g();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7163,7 +7232,7 @@ iterator.next();
 iterator.next(&quot;foo&quot;);
 iterator.next(&quot;bar&quot;);
 return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");return Function("asyncTestPassed","\nvar sent;\nfunction * generator(){\n  sent = [yield 5, yield 6];\n};\nvar iterator = generator();\niterator.next();\niterator.next(\"foo\");\niterator.next(\"bar\");\nreturn sent[0] === \"foo\" && sent[1] === \"bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");return Function("asyncTestPassed","\nvar sent;\nfunction * generator(){\n  sent = [yield 5, yield 6];\n};\nvar iterator = generator();\niterator.next();\niterator.next(\"foo\");\niterator.next(\"bar\");\nreturn sent[0] === \"foo\" && sent[1] === \"bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7234,7 +7303,7 @@ passed &amp;= sharedProto !== Object.prototype &amp;&amp;
   sharedProto.hasOwnProperty(&apos;next&apos;);
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");return Function("asyncTestPassed","\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");return Function("asyncTestPassed","\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -7307,7 +7376,7 @@ var iterator = generator();
 iterator.next();
 iterator.throw(&quot;foo&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");return Function("asyncTestPassed","\nvar passed = false;\nfunction * generator(){\n  try {\n    yield 5; yield 6;\n  } catch(e) {\n    passed = (e === \"foo\");\n  }\n};\nvar iterator = generator();\niterator.next();\niterator.throw(\"foo\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");return Function("asyncTestPassed","\nvar passed = false;\nfunction * generator(){\n  try {\n    yield 5; yield 6;\n  } catch(e) {\n    passed = (e === \"foo\");\n  }\n};\nvar iterator = generator();\niterator.next();\niterator.throw(\"foo\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7379,7 +7448,7 @@ passed    &amp;= item.value === &quot;quxquux&quot; &amp;&amp; item.done === tru
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.return(\"quxquux\");\npassed    &= item.value === \"quxquux\" && item.done === true;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");return Function("asyncTestPassed","\nfunction * generator(){\n  yield 5; yield 6;\n};\nvar iterator = generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.return(\"quxquux\");\npassed    &= item.value === \"quxquux\" && item.done === true;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7448,7 +7517,7 @@ var iterator = generator();
 iterator.next();
 iterator.next(true);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");return Function("asyncTestPassed","\nvar passed;\nfunction * generator(){\n  passed = yield 0 ? true : false;\n};\nvar iterator = generator();\niterator.next();\niterator.next(true);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");return Function("asyncTestPassed","\nvar passed;\nfunction * generator(){\n  passed = yield 0 ? true : false;\n};\nvar iterator = generator();\niterator.next();\niterator.next(true);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7519,7 +7588,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * [5, 6];\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7590,7 +7659,7 @@ passed    &amp;= item.value === &quot;6&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * \"56\";\n}());\nvar item = iterator.next();\nvar passed = item.value === \"5\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"6\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7652,7 +7721,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="generators"><td><span>yield *, generic iterables</span><script data-source="
 var iterator = (function * generator() {
-  yield * window.__createIterableObject(5, 6, 7);
+  yield * global.__createIterableObject(5, 6, 7);
 }());
 var item = iterator.next();
 var passed = item.value === 5 &amp;&amp; item.done === false;
@@ -7663,7 +7732,7 @@ passed    &amp;= item.value === 7 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * window.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * global.__createIterableObject(5, 6, 7);\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7736,7 +7805,7 @@ passed    &amp;= item.value === 7 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");return Function("asyncTestPassed","\nvar iterator = (function * generator() {\n  yield * Object.create(__createIterableObject(5, 6, 7));\n}());\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 7 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7810,7 +7879,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");return Function("asyncTestPassed","\nvar o = {\n  * generator() {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");return Function("asyncTestPassed","\nvar o = {\n  * generator() {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -7865,7 +7934,7 @@ return passed;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="yes" data-browser="iojs">Yes</td>
+<td class="no flagged" data-browser="iojs">Flag</td>
 <td class="no" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -7885,7 +7954,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");return Function("asyncTestPassed","\nvar garply = \"generator\";\nvar o = {\n  * [garply] () {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");return Function("asyncTestPassed","\nvar garply = \"generator\";\nvar o = {\n  * [garply] () {\n    yield 5; yield 6;\n  },\n};\nvar iterator = o.generator();\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -8010,7 +8079,7 @@ return passed;
 var buffer = new ArrayBuffer(64);
 var view = new Int8Array(buffer);         view[0] = 0x80;
 return view[0] === -0x80;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int8Array(buffer);         view[0] = 0x80;\nreturn view[0] === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8074,7 +8143,7 @@ return view[0] === -0x80;
 var buffer = new ArrayBuffer(64);
 var view = new Uint8Array(buffer);        view[0] = 0x100;
 return view[0] === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8Array(buffer);        view[0] = 0x100;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8138,7 +8207,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Uint8ClampedArray(buffer); view[0] = 0x100;
 return view[0] === 0xFF;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint8ClampedArray(buffer); view[0] = 0x100;\nreturn view[0] === 0xFF;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8202,7 +8271,7 @@ return view[0] === 0xFF;
 var buffer = new ArrayBuffer(64);
 var view = new Int16Array(buffer);        view[0] = 0x8000;
 return view[0] === -0x8000;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int16Array(buffer);        view[0] = 0x8000;\nreturn view[0] === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8266,7 +8335,7 @@ return view[0] === -0x8000;
 var buffer = new ArrayBuffer(64);
 var view = new Uint16Array(buffer);       view[0] = 0x10000;
 return view[0] === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint16Array(buffer);       view[0] = 0x10000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8330,7 +8399,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Int32Array(buffer);        view[0] = 0x80000000;
 return view[0] === -0x80000000;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Int32Array(buffer);        view[0] = 0x80000000;\nreturn view[0] === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8394,7 +8463,7 @@ return view[0] === -0x80000000;
 var buffer = new ArrayBuffer(64);
 var view = new Uint32Array(buffer);       view[0] = 0x100000000;
 return view[0] === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Uint32Array(buffer);       view[0] = 0x100000000;\nreturn view[0] === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8458,7 +8527,7 @@ return view[0] === 0;
 var buffer = new ArrayBuffer(64);
 var view = new Float32Array(buffer);       view[0] = 0.1;
 return view[0] === 0.10000000149011612;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float32Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8522,7 +8591,7 @@ return view[0] === 0.10000000149011612;
 var buffer = new ArrayBuffer(64);
 var view = new Float64Array(buffer);       view[0] = 0.1;
 return view[0] === 0.1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new Float64Array(buffer);       view[0] = 0.1;\nreturn view[0] === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8587,7 +8656,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt8 (0, 0x80);
 return view.getInt8(0) === -0x80;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt8 (0, 0x80);\nreturn view.getInt8(0) === -0x80;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8652,7 +8721,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint8(0, 0x100);
 return view.getUint8(0) === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint8(0, 0x100);\nreturn view.getUint8(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8717,7 +8786,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt16(0, 0x8000);
 return view.getInt16(0) === -0x8000;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt16(0, 0x8000);\nreturn view.getInt16(0) === -0x8000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8782,7 +8851,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint16(0, 0x10000);
 return view.getUint16(0) === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint16(0, 0x10000);\nreturn view.getUint16(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8847,7 +8916,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setInt32(0, 0x80000000);
 return view.getInt32(0) === -0x80000000;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setInt32(0, 0x80000000);\nreturn view.getInt32(0) === -0x80000000;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8912,7 +8981,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setUint32(0, 0x100000000);
 return view.getUint32(0) === 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setUint32(0, 0x100000000);\nreturn view.getUint32(0) === 0;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -8977,7 +9046,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat32(0, 0.1);
 return view.getFloat32(0) === 0.10000000149011612;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat32(0, 0.1);\nreturn view.getFloat32(0) === 0.10000000149011612;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9042,7 +9111,7 @@ var buffer = new ArrayBuffer(64);
 var view = new DataView(buffer);
 view.setFloat64(0, 0.1);
 return view.getFloat64(0) === 0.1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setFloat64(0, 0.1);\nreturn view.getFloat64(0) === 0.1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9112,7 +9181,7 @@ return typeof Int8Array.from === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.from === &quot;function&quot; &amp;&amp;
   typeof Float32Array.from === &quot;function&quot; &amp;&amp;
   typeof Float64Array.from === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");return Function("asyncTestPassed","\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");return Function("asyncTestPassed","\nreturn typeof Int8Array.from === \"function\" &&\n  typeof Uint8Array.from === \"function\" &&\n  typeof Uint8ClampedArray.from === \"function\" &&\n  typeof Int16Array.from === \"function\" &&\n  typeof Uint16Array.from === \"function\" &&\n  typeof Int32Array.from === \"function\" &&\n  typeof Uint32Array.from === \"function\" &&\n  typeof Float32Array.from === \"function\" &&\n  typeof Float64Array.from === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9182,7 +9251,7 @@ return typeof Int8Array.of === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.of === &quot;function&quot; &amp;&amp;
   typeof Float32Array.of === &quot;function&quot; &amp;&amp;
   typeof Float64Array.of === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");return Function("asyncTestPassed","\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");return Function("asyncTestPassed","\nreturn typeof Int8Array.of === \"function\" &&\n  typeof Uint8Array.of === \"function\" &&\n  typeof Uint8ClampedArray.of === \"function\" &&\n  typeof Int16Array.of === \"function\" &&\n  typeof Uint16Array.of === \"function\" &&\n  typeof Int32Array.of === \"function\" &&\n  typeof Uint32Array.of === \"function\" &&\n  typeof Float32Array.of === \"function\" &&\n  typeof Float64Array.of === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9252,7 +9321,7 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.subarray === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.subarray === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.subarray === \"function\" &&\n  typeof Uint8Array.prototype.subarray === \"function\" &&\n  typeof Uint8ClampedArray.prototype.subarray === \"function\" &&\n  typeof Int16Array.prototype.subarray === \"function\" &&\n  typeof Uint16Array.prototype.subarray === \"function\" &&\n  typeof Int32Array.prototype.subarray === \"function\" &&\n  typeof Uint32Array.prototype.subarray === \"function\" &&\n  typeof Float32Array.prototype.subarray === \"function\" &&\n  typeof Float64Array.prototype.subarray === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9322,7 +9391,7 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.join === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.join === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.join === \"function\" &&\n  typeof Uint8Array.prototype.join === \"function\" &&\n  typeof Uint8ClampedArray.prototype.join === \"function\" &&\n  typeof Int16Array.prototype.join === \"function\" &&\n  typeof Uint16Array.prototype.join === \"function\" &&\n  typeof Int32Array.prototype.join === \"function\" &&\n  typeof Uint32Array.prototype.join === \"function\" &&\n  typeof Float32Array.prototype.join === \"function\" &&\n  typeof Float64Array.prototype.join === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9392,7 +9461,7 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.indexOf === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8Array.prototype.indexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.indexOf === \"function\" &&\n  typeof Int16Array.prototype.indexOf === \"function\" &&\n  typeof Uint16Array.prototype.indexOf === \"function\" &&\n  typeof Int32Array.prototype.indexOf === \"function\" &&\n  typeof Uint32Array.prototype.indexOf === \"function\" &&\n  typeof Float32Array.prototype.indexOf === \"function\" &&\n  typeof Float64Array.prototype.indexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9462,7 +9531,7 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp
   typeof Uint32Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint8ClampedArray.prototype.lastIndexOf === \"function\" &&\n  typeof Int16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint16Array.prototype.lastIndexOf === \"function\" &&\n  typeof Int32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Uint32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float32Array.prototype.lastIndexOf === \"function\" &&\n  typeof Float64Array.prototype.lastIndexOf === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9532,7 +9601,7 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.slice === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.slice === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.slice === \"function\" &&\n  typeof Uint8Array.prototype.slice === \"function\" &&\n  typeof Uint8ClampedArray.prototype.slice === \"function\" &&\n  typeof Int16Array.prototype.slice === \"function\" &&\n  typeof Uint16Array.prototype.slice === \"function\" &&\n  typeof Int32Array.prototype.slice === \"function\" &&\n  typeof Uint32Array.prototype.slice === \"function\" &&\n  typeof Float32Array.prototype.slice === \"function\" &&\n  typeof Float64Array.prototype.slice === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9602,7 +9671,7 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.every === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.every === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.every === \"function\" &&\n  typeof Uint8Array.prototype.every === \"function\" &&\n  typeof Uint8ClampedArray.prototype.every === \"function\" &&\n  typeof Int16Array.prototype.every === \"function\" &&\n  typeof Uint16Array.prototype.every === \"function\" &&\n  typeof Int32Array.prototype.every === \"function\" &&\n  typeof Uint32Array.prototype.every === \"function\" &&\n  typeof Float32Array.prototype.every === \"function\" &&\n  typeof Float64Array.prototype.every === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9672,7 +9741,7 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.filter === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.filter === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.filter === \"function\" &&\n  typeof Uint8Array.prototype.filter === \"function\" &&\n  typeof Uint8ClampedArray.prototype.filter === \"function\" &&\n  typeof Int16Array.prototype.filter === \"function\" &&\n  typeof Uint16Array.prototype.filter === \"function\" &&\n  typeof Int32Array.prototype.filter === \"function\" &&\n  typeof Uint32Array.prototype.filter === \"function\" &&\n  typeof Float32Array.prototype.filter === \"function\" &&\n  typeof Float64Array.prototype.filter === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9742,7 +9811,7 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.forEach === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.forEach === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.forEach === \"function\" &&\n  typeof Uint8Array.prototype.forEach === \"function\" &&\n  typeof Uint8ClampedArray.prototype.forEach === \"function\" &&\n  typeof Int16Array.prototype.forEach === \"function\" &&\n  typeof Uint16Array.prototype.forEach === \"function\" &&\n  typeof Int32Array.prototype.forEach === \"function\" &&\n  typeof Uint32Array.prototype.forEach === \"function\" &&\n  typeof Float32Array.prototype.forEach === \"function\" &&\n  typeof Float64Array.prototype.forEach === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9812,7 +9881,7 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.map === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.map === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.map === \"function\" &&\n  typeof Uint8Array.prototype.map === \"function\" &&\n  typeof Uint8ClampedArray.prototype.map === \"function\" &&\n  typeof Int16Array.prototype.map === \"function\" &&\n  typeof Uint16Array.prototype.map === \"function\" &&\n  typeof Int32Array.prototype.map === \"function\" &&\n  typeof Uint32Array.prototype.map === \"function\" &&\n  typeof Float32Array.prototype.map === \"function\" &&\n  typeof Float64Array.prototype.map === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9882,7 +9951,7 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reduce === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reduce === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduce === \"function\" &&\n  typeof Uint8Array.prototype.reduce === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduce === \"function\" &&\n  typeof Int16Array.prototype.reduce === \"function\" &&\n  typeof Uint16Array.prototype.reduce === \"function\" &&\n  typeof Int32Array.prototype.reduce === \"function\" &&\n  typeof Uint32Array.prototype.reduce === \"function\" &&\n  typeof Float32Array.prototype.reduce === \"function\" &&\n  typeof Float64Array.prototype.reduce === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -9952,7 +10021,7 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &amp;&amp
   typeof Uint32Array.prototype.reduceRight === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reduceRight === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8Array.prototype.reduceRight === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reduceRight === \"function\" &&\n  typeof Int16Array.prototype.reduceRight === \"function\" &&\n  typeof Uint16Array.prototype.reduceRight === \"function\" &&\n  typeof Int32Array.prototype.reduceRight === \"function\" &&\n  typeof Uint32Array.prototype.reduceRight === \"function\" &&\n  typeof Float32Array.prototype.reduceRight === \"function\" &&\n  typeof Float64Array.prototype.reduceRight === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10022,7 +10091,7 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.reverse === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.reverse === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.reverse === \"function\" &&\n  typeof Uint8Array.prototype.reverse === \"function\" &&\n  typeof Uint8ClampedArray.prototype.reverse === \"function\" &&\n  typeof Int16Array.prototype.reverse === \"function\" &&\n  typeof Uint16Array.prototype.reverse === \"function\" &&\n  typeof Int32Array.prototype.reverse === \"function\" &&\n  typeof Uint32Array.prototype.reverse === \"function\" &&\n  typeof Float32Array.prototype.reverse === \"function\" &&\n  typeof Float64Array.prototype.reverse === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10092,7 +10161,7 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.some === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.some === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.some === \"function\" &&\n  typeof Uint8Array.prototype.some === \"function\" &&\n  typeof Uint8ClampedArray.prototype.some === \"function\" &&\n  typeof Int16Array.prototype.some === \"function\" &&\n  typeof Uint16Array.prototype.some === \"function\" &&\n  typeof Int32Array.prototype.some === \"function\" &&\n  typeof Uint32Array.prototype.some === \"function\" &&\n  typeof Float32Array.prototype.some === \"function\" &&\n  typeof Float64Array.prototype.some === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10162,7 +10231,7 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.sort === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.sort === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.sort === \"function\" &&\n  typeof Uint8Array.prototype.sort === \"function\" &&\n  typeof Uint8ClampedArray.prototype.sort === \"function\" &&\n  typeof Int16Array.prototype.sort === \"function\" &&\n  typeof Uint16Array.prototype.sort === \"function\" &&\n  typeof Int32Array.prototype.sort === \"function\" &&\n  typeof Uint32Array.prototype.sort === \"function\" &&\n  typeof Float32Array.prototype.sort === \"function\" &&\n  typeof Float64Array.prototype.sort === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10232,7 +10301,7 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8Array.prototype.copyWithin === \"function\" &&\n  typeof Uint8ClampedArray.prototype.copyWithin === \"function\" &&\n  typeof Int16Array.prototype.copyWithin === \"function\" &&\n  typeof Uint16Array.prototype.copyWithin === \"function\" &&\n  typeof Int32Array.prototype.copyWithin === \"function\" &&\n  typeof Uint32Array.prototype.copyWithin === \"function\" &&\n  typeof Float32Array.prototype.copyWithin === \"function\" &&\n  typeof Float64Array.prototype.copyWithin === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10302,7 +10371,7 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.find === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.find === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.find === \"function\" &&\n  typeof Uint8Array.prototype.find === \"function\" &&\n  typeof Uint8ClampedArray.prototype.find === \"function\" &&\n  typeof Int16Array.prototype.find === \"function\" &&\n  typeof Uint16Array.prototype.find === \"function\" &&\n  typeof Int32Array.prototype.find === \"function\" &&\n  typeof Uint32Array.prototype.find === \"function\" &&\n  typeof Float32Array.prototype.find === \"function\" &&\n  typeof Float64Array.prototype.find === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10372,7 +10441,7 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.findIndex === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8Array.prototype.findIndex === \"function\" &&\n  typeof Uint8ClampedArray.prototype.findIndex === \"function\" &&\n  typeof Int16Array.prototype.findIndex === \"function\" &&\n  typeof Uint16Array.prototype.findIndex === \"function\" &&\n  typeof Int32Array.prototype.findIndex === \"function\" &&\n  typeof Uint32Array.prototype.findIndex === \"function\" &&\n  typeof Float32Array.prototype.findIndex === \"function\" &&\n  typeof Float64Array.prototype.findIndex === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10442,7 +10511,7 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.fill === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.fill === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.fill === \"function\" &&\n  typeof Uint8Array.prototype.fill === \"function\" &&\n  typeof Uint8ClampedArray.prototype.fill === \"function\" &&\n  typeof Int16Array.prototype.fill === \"function\" &&\n  typeof Uint16Array.prototype.fill === \"function\" &&\n  typeof Int32Array.prototype.fill === \"function\" &&\n  typeof Uint32Array.prototype.fill === \"function\" &&\n  typeof Float32Array.prototype.fill === \"function\" &&\n  typeof Float64Array.prototype.fill === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10512,7 +10581,7 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.keys === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.keys === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.keys === \"function\" &&\n  typeof Uint8Array.prototype.keys === \"function\" &&\n  typeof Uint8ClampedArray.prototype.keys === \"function\" &&\n  typeof Int16Array.prototype.keys === \"function\" &&\n  typeof Uint16Array.prototype.keys === \"function\" &&\n  typeof Int32Array.prototype.keys === \"function\" &&\n  typeof Uint32Array.prototype.keys === \"function\" &&\n  typeof Float32Array.prototype.keys === \"function\" &&\n  typeof Float64Array.prototype.keys === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10582,7 +10651,7 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.values === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.values === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.values === \"function\" &&\n  typeof Uint8Array.prototype.values === \"function\" &&\n  typeof Uint8ClampedArray.prototype.values === \"function\" &&\n  typeof Int16Array.prototype.values === \"function\" &&\n  typeof Uint16Array.prototype.values === \"function\" &&\n  typeof Int32Array.prototype.values === \"function\" &&\n  typeof Uint32Array.prototype.values === \"function\" &&\n  typeof Float32Array.prototype.values === \"function\" &&\n  typeof Float64Array.prototype.values === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10652,7 +10721,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Uint32Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Float32Array.prototype.entries === &quot;function&quot; &amp;&amp;
   typeof Float64Array.prototype.entries === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");return Function("asyncTestPassed","\nreturn typeof Int8Array.prototype.entries === \"function\" &&\n  typeof Uint8Array.prototype.entries === \"function\" &&\n  typeof Uint8ClampedArray.prototype.entries === \"function\" &&\n  typeof Int16Array.prototype.entries === \"function\" &&\n  typeof Uint16Array.prototype.entries === \"function\" &&\n  typeof Int32Array.prototype.entries === \"function\" &&\n  typeof Uint32Array.prototype.entries === \"function\" &&\n  typeof Float32Array.prototype.entries === \"function\" &&\n  typeof Float64Array.prototype.entries === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -10778,7 +10847,7 @@ var map = new Map();
 map.set(key, 123);
 
 return map.has(key) &amp;&amp; map.get(key) === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10845,7 +10914,7 @@ var map = new Map([[key1, 123], [key2, 456]]);
 
 return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
        map.has(key2) &amp;&amp; map.get(key2) === 456;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar map = new Map([[key1, 123], [key2, 456]]);\n\nreturn map.has(key1) && map.get(key1) === 123 &&\n       map.has(key2) && map.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10908,7 +10977,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.set returns this</span><script data-source="
 var map = new Map();
 return map.set(0, 0) === map;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");return Function("asyncTestPassed","\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");return Function("asyncTestPassed","\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -10976,7 +11045,7 @@ map.forEach(function (value, key) {
   k = 1 / key;
 });
 return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11043,7 +11112,7 @@ var map = new Map();
 map.set(key, 123);
 
 return map.size === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11105,7 +11174,7 @@ return map.size === 1;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.delete</span><script data-source="
 return typeof Map.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");return Function("asyncTestPassed","\nreturn typeof Map.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");return Function("asyncTestPassed","\nreturn typeof Map.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11167,7 +11236,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.clear</span><script data-source="
 return typeof Map.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");return Function("asyncTestPassed","\nreturn typeof Map.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");return Function("asyncTestPassed","\nreturn typeof Map.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11229,7 +11298,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.forEach</span><script data-source="
 return typeof Map.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");return Function("asyncTestPassed","\nreturn typeof Map.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");return Function("asyncTestPassed","\nreturn typeof Map.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11291,7 +11360,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.keys</span><script data-source="
 return typeof Map.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");return Function("asyncTestPassed","\nreturn typeof Map.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");return Function("asyncTestPassed","\nreturn typeof Map.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11353,7 +11422,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.values</span><script data-source="
 return typeof Map.prototype.values === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");return Function("asyncTestPassed","\nreturn typeof Map.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");return Function("asyncTestPassed","\nreturn typeof Map.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11415,7 +11484,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>Map.prototype.entries</span><script data-source="
 return typeof Map.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");return Function("asyncTestPassed","\nreturn typeof Map.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");return Function("asyncTestPassed","\nreturn typeof Map.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11542,7 +11611,7 @@ set.add(123);
 set.add(123);
 
 return set.has(123);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11608,7 +11677,7 @@ var obj2 = {};
 var set = new Set([obj1, obj2]);
 
 return set.has(obj1) &amp;&amp; set.has(obj2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");return Function("asyncTestPassed","\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");return Function("asyncTestPassed","\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11671,7 +11740,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.add returns this</span><script data-source="
 var set = new Set();
 return set.add(0) === set;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");return Function("asyncTestPassed","\nvar set = new Set();\nreturn set.add(0) === set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");return Function("asyncTestPassed","\nvar set = new Set();\nreturn set.add(0) === set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11739,7 +11808,7 @@ set.forEach(function (value) {
   k = 1 / value;
 });
 return k === Infinity &amp;&amp; set.has(+0);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");return Function("asyncTestPassed","\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");return Function("asyncTestPassed","\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11808,7 +11877,7 @@ set.add(123);
 set.add(456);
 
 return set.size === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11870,7 +11939,7 @@ return set.size === 2;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.delete</span><script data-source="
 return typeof Set.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");return Function("asyncTestPassed","\nreturn typeof Set.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");return Function("asyncTestPassed","\nreturn typeof Set.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11932,7 +12001,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.clear</span><script data-source="
 return typeof Set.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");return Function("asyncTestPassed","\nreturn typeof Set.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("181");return Function("asyncTestPassed","\nreturn typeof Set.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -11994,7 +12063,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.forEach</span><script data-source="
 return typeof Set.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("181");return Function("asyncTestPassed","\nreturn typeof Set.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");return Function("asyncTestPassed","\nreturn typeof Set.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12056,7 +12125,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.keys</span><script data-source="
 return typeof Set.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");return Function("asyncTestPassed","\nreturn typeof Set.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");return Function("asyncTestPassed","\nreturn typeof Set.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12118,7 +12187,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.values</span><script data-source="
 return typeof Set.prototype.values === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");return Function("asyncTestPassed","\nreturn typeof Set.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");return Function("asyncTestPassed","\nreturn typeof Set.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12180,7 +12249,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>Set.prototype.entries</span><script data-source="
 return typeof Set.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");return Function("asyncTestPassed","\nreturn typeof Set.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("185");return Function("asyncTestPassed","\nreturn typeof Set.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12306,7 +12375,7 @@ var weakmap = new WeakMap();
 weakmap.set(key, 123);
 
 return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("186");return Function("asyncTestPassed","\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("187");return Function("asyncTestPassed","\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12373,7 +12442,7 @@ var weakmap = new WeakMap([[key1, 123], [key2, 456]]);
 
 return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
        weakmap.has(key2) &amp;&amp; weakmap.get(key2) === 456;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("187");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12437,7 +12506,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 var weakmap = new WeakMap();
 var key = {};
 return weakmap.set(key, 0) === weakmap;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");return Function("asyncTestPassed","\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("189");return Function("asyncTestPassed","\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12499,7 +12568,7 @@ return weakmap.set(key, 0) === weakmap;
 </tr>
 <tr class="subtest" data-parent="WeakMap"><td><span>WeakMap.prototype.delete</span><script data-source="
 return typeof WeakMap.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("189");return Function("asyncTestPassed","\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("190");return Function("asyncTestPassed","\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12626,7 +12695,7 @@ weakset.add(obj1);
 weakset.add(obj1);
 
 return weakset.has(obj1);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("191");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12691,7 +12760,7 @@ var obj1 = {}, obj2 = {};
 var weakset = new WeakSet([obj1, obj2]);
 
 return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("193");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12755,7 +12824,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 var weakset = new WeakSet();
 var obj = {};
 return weakset.add(obj) === weakset;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("193");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("194");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12817,7 +12886,7 @@ return weakset.add(obj) === weakset;
 </tr>
 <tr class="subtest" data-parent="WeakSet"><td><span>WeakSet.prototype.delete</span><script data-source="
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("194");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("195");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -12944,7 +13013,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13012,7 +13081,7 @@ var proxy = Object.create(new Proxy(proxied, {
   }
 }));
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13028,21 +13097,21 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
-<td class="no" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[12]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
+<td class="no" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -13082,7 +13151,7 @@ var proxy = new Proxy(proxied, {
 });
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13152,7 +13221,7 @@ var proxy = Object.create(new Proxy(proxied, {
 }));
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13221,7 +13290,7 @@ var passed = false;
   }
 });
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13290,7 +13359,7 @@ var passed = false;
   }
 }));
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13359,7 +13428,7 @@ var proxied = {};
     }
   }).foo;
   return passed;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13434,7 +13503,7 @@ return (returnedDesc.value     === fakeDesc.value
   &amp;&amp; returnedDesc.configurable === fakeDesc.configurable
   &amp;&amp; returnedDesc.writable     === false
   &amp;&amp; returnedDesc.enumerable   === false);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13450,13 +13519,13 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[13]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
 <td class="yes" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox32">Yes</td>
@@ -13508,7 +13577,7 @@ Object.defineProperty(
   { value: 5, configurable: true }
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13577,7 +13646,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return Object.getPrototypeOf(proxy) === fakeProto;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13651,7 +13720,7 @@ Object.setPrototypeOf(
   newProto
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13722,7 +13791,7 @@ Object.isExtensible(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13794,7 +13863,7 @@ Object.preventExtensions(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13868,7 +13937,7 @@ for (var i in
   })
 ) { }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13939,7 +14008,7 @@ Object.keys(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13955,16 +14024,16 @@ return passed;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox33">Yes</td>
 <td class="yes obsolete" data-browser="firefox34">Yes</td>
 <td class="yes" data-browser="firefox35">Yes</td>
@@ -14011,7 +14080,7 @@ var host = {
 };
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14081,7 +14150,7 @@ new new Proxy(proxied, {
   }
 })(&quot;foo&quot;,&quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14151,7 +14220,7 @@ try {
   passed &amp;= e instanceof TypeError;
 }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14213,7 +14282,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>Array.isArray support</span><script data-source="
 return Array.isArray(new Proxy([], {}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14275,7 +14344,7 @@ return Array.isArray(new Proxy([], {}));
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>JSON.stringify support</span><script data-source="
 return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quot;]&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14396,7 +14465,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.get</span><script data-source="
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("217");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14460,7 +14529,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 var obj = {};
 Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14522,7 +14591,7 @@ return obj.quux === 654;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.has</span><script data-source="
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14586,7 +14655,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 var obj = { bar: 456 };
 Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14651,7 +14720,7 @@ var obj = { baz: 789 };
 var desc = Reflect.getOwnPropertyDescriptor(obj, &quot;baz&quot;);
 return desc.value === 789 &amp;&amp;
   desc.configurable &amp;&amp; desc.writable &amp;&amp; desc.enumerable;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14715,7 +14784,7 @@ return desc.value === 789 &amp;&amp;
 var obj = {};
 Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14777,7 +14846,7 @@ return obj.foo === 123;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.getPrototypeOf</span><script data-source="
 return Reflect.getPrototypeOf([]) === Array.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14841,10 +14910,10 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 var obj = {};
 Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -14904,7 +14973,7 @@ return obj instanceof Array;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.isExtensible</span><script data-source="
 return Reflect.isExtensible({}) &amp;&amp;
   !Reflect.isExtensible(Object.preventExtensions({}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14968,7 +15037,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 var obj = {};
 Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15039,7 +15108,7 @@ passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15102,7 +15171,7 @@ return passed;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.ownKeys</span><script data-source="
 var obj = { foo: 1, bar: 2 };
 return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15164,7 +15233,7 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.apply</span><script data-source="
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15228,7 +15297,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 return Reflect.construct(function(a, b, c) {
   this.qux = a + b + c;
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("231");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15370,7 +15439,7 @@ p1.then(function() {
 function check() {
   if (score === 4) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15446,7 +15515,7 @@ rejects.catch(function(result) { score += (result === &quot;qux&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15522,7 +15591,7 @@ rejects.catch(function(result) { score += (result === &quot;baz&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15647,7 +15716,7 @@ var symbol = Symbol();
 var value = {};
 object[symbol] = value;
 return object[symbol] === value;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15709,7 +15778,7 @@ return object[symbol] === value;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>typeof support</span><script data-source="
 return typeof Symbol() === &quot;symbol&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no flagged" data-browser="_6to5">Flag</td>
@@ -15783,7 +15852,7 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15854,7 +15923,7 @@ if (Object.defineProperty) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15929,7 +15998,7 @@ try {
 } catch(e) {}
 
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15991,7 +16060,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>can convert with String()</span><script data-source="
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16058,7 +16127,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16125,7 +16194,7 @@ var symbolObject = Object(symbol);
 return typeof symbolObject === &quot;object&quot; &amp;&amp;
   symbolObject == symbol &amp;&amp;
   symbolObject.valueOf() === symbol;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16189,7 +16258,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 var symbol = Symbol.for(&apos;foo&apos;);
 return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
    Symbol.keyFor(symbol) === &apos;foo&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16303,7 +16372,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="rhino17" class="tally" data-tally="0">0/7</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/7</td>
 <td data-browser="node" class="tally" data-tally="0">0/7</td>
-<td data-browser="iojs" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="iojs" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
 <td data-browser="ejs" class="tally" data-tally="0.8571428571428571">6/7</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/7</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/7</td>
@@ -16317,7 +16386,7 @@ Object.defineProperty(C, Symbol.hasInstance, {
 });
 obj instanceof C;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16382,7 +16451,7 @@ var a = [], b = [];
 b[Symbol.isConcatSpreadable] = false;
 a = a.concat(b);
 return a[0] === b;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16457,7 +16526,7 @@ b[Symbol.iterator] = function() {
 var c;
 for (c of b) {}
 return c === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16521,7 +16590,7 @@ return c === &quot;foo&quot;;
 return RegExp[Symbol.species] === RegExp
   &amp;&amp; Array[Symbol.species] === Array
   &amp;&amp; !(Symbol.species in Object);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16592,7 +16661,7 @@ a &gt;= 0;
 b in {};
 c == 0;
 return passed === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16656,7 +16725,7 @@ return passed === 3;
 var a = {};
 a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16711,7 +16780,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="no flagged" data-browser="iojs">Flag</td>
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -16722,7 +16791,7 @@ a[Symbol.unscopables] = { bar: true };
 with (a) {
   return foo === 1 &amp;&amp; typeof bar === &quot;undefined&quot;;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16778,7 +16847,7 @@ with (a) {
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
-<td class="no" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[15]</sup></a></td>
+<td class="no" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[16]</sup></a></td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
@@ -16846,7 +16915,7 @@ with (a) {
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.assign</span><script data-source="
 var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot; in o;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16910,7 +16979,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 return typeof Object.is === &apos;function&apos; &amp;&amp;
   Object.is(NaN, NaN) &amp;&amp;
  !Object.is(-0, 0);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16975,7 +17044,7 @@ var o = {};
 var sym = Symbol();
 o[sym] = &quot;foo&quot;;
 return Object.getOwnPropertySymbols(o)[0] === sym;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17037,15 +17106,15 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.setPrototypeOf</span><script data-source="
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -17160,7 +17229,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 function foo(){};
 return foo.name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17223,7 +17292,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>function expressions</span><script data-source="
 return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17285,7 +17354,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="function_name_property"><td><span>new Function</span><script data-source="
 return (new Function).name === &quot;anonymous&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17349,7 +17418,7 @@ return (new Function).name === &quot;anonymous&quot;;
 function foo() {};
 return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
   (function(){}).bind({}).name === &quot;bound &quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17413,7 +17482,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 var foo = function() {};
 var bar = function baz() {};
 return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17479,7 +17548,7 @@ o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17544,7 +17613,7 @@ var o = { get foo(){}, set foo(x){} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
        descriptor.set.name === &quot;set foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17607,7 +17676,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>shorthand methods</span><script data-source="
 var o = { foo(){} };
 return o.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17677,7 +17746,7 @@ var o = {
 
 return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
        o[sym2].name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17742,7 +17811,7 @@ class foo {};
 class bar { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
   typeof bar.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17805,7 +17874,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class expressions</span><script data-source="
 return class foo {}.name === &quot;foo&quot; &amp;&amp;
   typeof class bar { static name() {} }.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17872,7 +17941,7 @@ var qux = class { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
        bar.name === &quot;baz&quot; &amp;&amp;
        typeof qux.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17938,7 +18007,7 @@ o.qux = class {};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18001,7 +18070,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class prototype methods</span><script data-source="
 class C { foo(){} };
 return (new C).foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18064,7 +18133,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <tr class="subtest" data-parent="function_name_property"><td><span>class static methods</span><script data-source="
 class C { static foo(){} };
 return C.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18129,7 +18198,7 @@ var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;
 return descriptor.enumerable   === false &amp;&amp;
        descriptor.writable     === false &amp;&amp;
        descriptor.configurable === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18191,7 +18260,7 @@ return descriptor.enumerable   === false &amp;&amp;
 </tr>
 <tr><td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span><script data-source="
 return typeof Function.prototype.toMethod === &quot;function&quot;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");return Function("asyncTestPassed","\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18312,7 +18381,7 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.raw</span><script data-source="
 return typeof String.raw === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18374,7 +18443,7 @@ return typeof String.raw === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.fromCodePoint</span><script data-source="
 return typeof String.fromCodePoint === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18495,7 +18564,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.codePointAt</span><script data-source="
 return typeof String.prototype.codePointAt === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18559,7 +18628,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 return typeof String.prototype.normalize === &quot;function&quot;
   &amp;&amp; &quot;c\u0327\u0301&quot;.normalize(&quot;NFC&quot;) === &quot;\u1e09&quot;
   &amp;&amp; &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18622,7 +18691,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.repeat</span><script data-source="
 return typeof String.prototype.repeat === &apos;function&apos;
   &amp;&amp; &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18685,7 +18754,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.startsWith</span><script data-source="
 return typeof String.prototype.startsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.startsWith(&quot;foo&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18748,7 +18817,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.endsWith</span><script data-source="
 return typeof String.prototype.endsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.endsWith(&quot;bar&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("285");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18811,7 +18880,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.includes</span><script data-source="
 return typeof String.prototype.includes === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.includes(&quot;oba&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("285");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("286");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18827,34 +18896,34 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="firefox35">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="firefox37">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="firefox35">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="firefox37">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
-<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="chrome39">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
-<td class="no" data-browser="chrome40">No<a href="#string-contains-note"><sup>[16]</sup></a></td>
+<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="chrome39">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="chrome40">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no" data-browser="safari6">No</td>
@@ -18932,7 +19001,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype.flags</span><script data-source="
 return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18994,7 +19063,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.match]</span><script data-source="
 return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19056,7 +19125,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.replace]</span><script data-source="
 return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19118,7 +19187,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.split]</span><script data-source="
 return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19180,7 +19249,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.search]</span><script data-source="
 return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("292");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19301,7 +19370,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, array-like objects</span><script data-source="
 return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos;&apos; === &quot;foo,bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("293");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19362,9 +19431,9 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, generic iterables</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19425,9 +19494,9 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, instances of generic iterables</span><script data-source="
-var iterable = window.__createIterableObject(1, 2, 3);
+var iterable = global.__createIterableObject(1, 2, 3);
 return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nvar iterable = window.__createIterableObject(1, 2, 3);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19490,10 +19559,10 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array subclass .from</span><script data-source="
 class C extends Array {}
 return C.from({ length: 0 }) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19553,7 +19622,7 @@ return C.from({ length: 0 }) instanceof C;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.of</span><script data-source="
 return typeof Array.of === &apos;function&apos; &amp;&amp;
   Array.of(2)[0] === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19616,10 +19685,10 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array subclass .of</span><script data-source="
 class C extends Array {}
 return C.of(0) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("299");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
-<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
+<td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19737,7 +19806,7 @@ return C.of(0) instanceof C;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.copyWithin</span><script data-source="
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19799,7 +19868,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.find</span><script data-source="
 return typeof Array.prototype.find === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19861,7 +19930,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.findIndex</span><script data-source="
 return typeof Array.prototype.findIndex === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19923,7 +19992,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.fill</span><script data-source="
 return typeof Array.prototype.fill === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19985,7 +20054,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.keys</span><script data-source="
 return typeof Array.prototype.keys === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20047,7 +20116,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.values</span><script data-source="
 return typeof Array.prototype.values === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20062,22 +20131,22 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox11">No</td>
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
-<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -20088,10 +20157,10 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome35">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome36">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome37">Flag</td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -20109,7 +20178,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.entries</span><script data-source="
 return typeof Array.prototype.entries === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20179,7 +20248,7 @@ for (var i = 0; i &lt; ns.length; i++) {
   if (Array.prototype[ns[i]] &amp;&amp; !unscopables[ns[i]]) return false;
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20300,7 +20369,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isFinite</span><script data-source="
 return typeof Number.isFinite === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("309");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20362,7 +20431,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isInteger</span><script data-source="
 return typeof Number.isInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20424,7 +20493,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isSafeInteger</span><script data-source="
 return typeof Number.isSafeInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20486,7 +20555,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isNaN</span><script data-source="
 return typeof Number.isNaN === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20548,7 +20617,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.EPSILON</span><script data-source="
 return typeof Number.EPSILON === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20610,7 +20679,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MIN_SAFE_INTEGER</span><script data-source="
 return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20672,7 +20741,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MAX_SAFE_INTEGER</span><script data-source="
 return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20793,7 +20862,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.clz32</span><script data-source="
 return typeof Math.clz32 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20855,7 +20924,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.imul</span><script data-source="
 return typeof Math.imul === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20888,7 +20957,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="firefox37">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
-<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[20]</sup></a></td>
+<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[21]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome30">Yes</td>
 <td class="yes obsolete" data-browser="chrome31">Yes</td>
 <td class="yes obsolete" data-browser="chrome33">Yes</td>
@@ -20917,7 +20986,7 @@ return typeof Math.imul === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sign</span><script data-source="
 return typeof Math.sign === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20979,7 +21048,7 @@ return typeof Math.sign === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log10</span><script data-source="
 return typeof Math.log10 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21041,7 +21110,7 @@ return typeof Math.log10 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log2</span><script data-source="
 return typeof Math.log2 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21103,7 +21172,7 @@ return typeof Math.log2 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log1p</span><script data-source="
 return typeof Math.log1p === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("323");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21165,7 +21234,7 @@ return typeof Math.log1p === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.expm1</span><script data-source="
 return typeof Math.expm1 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("323");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21227,7 +21296,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.cosh</span><script data-source="
 return typeof Math.cosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21289,7 +21358,7 @@ return typeof Math.cosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sinh</span><script data-source="
 return typeof Math.sinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21351,7 +21420,7 @@ return typeof Math.sinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.tanh</span><script data-source="
 return typeof Math.tanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21413,7 +21482,7 @@ return typeof Math.tanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.acosh</span><script data-source="
 return typeof Math.acosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21475,7 +21544,7 @@ return typeof Math.acosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.asinh</span><script data-source="
 return typeof Math.asinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21537,7 +21606,7 @@ return typeof Math.asinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.atanh</span><script data-source="
 return typeof Math.atanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21599,7 +21668,7 @@ return typeof Math.atanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.hypot</span><script data-source="
 return typeof Math.hypot === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\nreturn typeof Math.hypot === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nreturn typeof Math.hypot === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21661,7 +21730,7 @@ return typeof Math.hypot === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.trunc</span><script data-source="
 return typeof Math.trunc === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nreturn typeof Math.trunc === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn typeof Math.trunc === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21723,7 +21792,7 @@ return typeof Math.trunc === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.fround</span><script data-source="
 return typeof Math.fround === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn typeof Math.fround === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn typeof Math.fround === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21743,7 +21812,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="no obsolete" data-browser="firefox23">No</td>
 <td class="no obsolete" data-browser="firefox24">No</td>
 <td class="no obsolete" data-browser="firefox25">No</td>
-<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[21]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox28">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -21785,7 +21854,7 @@ return typeof Math.fround === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.cbrt</span><script data-source="
 return typeof Math.cbrt === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn typeof Math.cbrt === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nreturn typeof Math.cbrt === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21908,7 +21977,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.getPrototypeOf</span><script data-source="
 return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21970,7 +22039,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.getOwnPropertyDescriptor</span><script data-source="
 return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("337");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22034,7 +22103,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 var s = Object.getOwnPropertyNames(&apos;a&apos;);
 return s.length === 2 &amp;&amp;
   ((s[0] === &apos;length&apos; &amp;&amp; s[1] === &apos;0&apos;) || (s[0] === &apos;0&apos; &amp;&amp; s[1] === &apos;length&apos;));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("337");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("338");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22096,7 +22165,7 @@ return s.length === 2 &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.seal</span><script data-source="
 return Object.seal(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("338");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22158,7 +22227,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.freeze</span><script data-source="
 return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22220,7 +22289,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.preventExtensions</span><script data-source="
 return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22282,7 +22351,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isSealed</span><script data-source="
 return Object.isSealed(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22344,7 +22413,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isFrozen</span><script data-source="
 return Object.isFrozen(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22406,7 +22475,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isExtensible</span><script data-source="
 return Object.isExtensible(&apos;a&apos;) === false;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22469,7 +22538,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.keys</span><script data-source="
 var s = Object.keys(&apos;a&apos;);
 return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22591,7 +22660,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <tr class="subtest" data-parent="miscellaneous"><td><span>duplicate property names in strict mode</span><script data-source="
 &apos;use strict&apos;;
 return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22653,7 +22722,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>no semicolon needed after do-while</span><script data-source="
 do {} while (false) return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22720,7 +22789,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22786,7 +22855,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -22848,7 +22917,7 @@ try {
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>Invalid Date</span><script data-source="
 return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("351");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -22910,7 +22979,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>RegExp constructor can alter flags</span><script data-source="
 return new RegExp(/./im, &quot;g&quot;).global === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("351");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("352");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22987,7 +23056,7 @@ try {
   Date.prototype.valueOf(); return false;
 } catch(e) {}
 return Array.prototype.length === undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("352");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn Array.prototype.length === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn Array.prototype.length === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -23058,7 +23127,7 @@ return Array.prototype.length === undefined;
   function h() { return 2; }
 
 return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("354");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23118,7 +23187,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[22]</sup></a></span></td>
+<tr class="supertest"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[23]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
@@ -23180,7 +23249,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <tr class="subtest" data-parent="__proto___in_object_literals"><td><span>basic support</span><script data-source="
 return { __proto__ : [] } instanceof Array
   &amp;&amp; !({ __proto__ : null } instanceof Object);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("355");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("356");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23247,7 +23316,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("356");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23313,7 +23382,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var a = &quot;__proto__&quot;;
 return !({ [a] : [] } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23379,7 +23448,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var __proto__ = [];
 return !({ __proto__ } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23444,7 +23513,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 return !({ __proto__(){} } instanceof Function);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("360");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23566,7 +23635,7 @@ return !({ __proto__(){} } instanceof Function);
 <tr class="subtest" data-parent="Object.prototype.__proto__"><td><span>get prototype</span><script data-source="
 var A = function(){};
 return (new A()).__proto__ === A.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("361");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23630,7 +23699,7 @@ return (new A()).__proto__ === A.prototype;
 var o = {};
 o.__proto__ = Array.prototype;
 return o instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23699,7 +23768,7 @@ return (desc
   &amp;&amp; &quot;set&quot; in desc
   &amp;&amp; desc.configurable
   &amp;&amp; !desc.enumerable);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23768,7 +23837,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23830,7 +23899,7 @@ return true;
 </tr>
 <tr><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("366");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23898,7 +23967,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="6to5-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="compiler-iterable-note">  <sup>[7]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="fx-let-note">  <sup>[8]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[9]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="compiler-proto-note">  <sup>[10]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[11]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="fx-proxy-get-note">  <sup>[12]</sup> Firefox doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[13]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[14]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[15]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[16]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[17]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[18]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[19]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[20]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[21]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[22]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="6to5-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="compiler-iterable-note">  <sup>[7]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="fx-let-note">  <sup>[8]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[9]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="strict-required-note">  <sup>[10]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[11]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[12]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="fx-proxy-get-note">  <sup>[13]</sup> Firefox doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[14]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[15]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[16]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[17]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[18]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[19]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[20]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[21]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[22]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[23]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/node.js
+++ b/node.js
@@ -24,21 +24,21 @@ $('#body tbody tr').each(function (index) {
 	, asyncPassed = function asyncPassed () {
 	  results[index] = true
     }
-    , __createIterableObject = function(a, b, c) {
-      if (typeof Symbol === "function" && Symbol.iterator) {
-        var arr = [a, b, c, ,]
-          , iterable = {
-            next: function() {
-              return { value: arr.shift(), done: arr.length <= 0 }
-            }
+  global.__createIterableObject = function(a, b, c) {
+    if (typeof Symbol === "function" && Symbol.iterator) {
+      var arr = [a, b, c, ,]
+        , iterable = {
+          next: function() {
+            return { value: arr.shift(), done: arr.length <= 0 }
           }
-        iterable[Symbol.iterator] = function(){ return iterable; }
-        return iterable;
-      }
-      else {
-        return eval("(function*() { yield a; yield b; yield c; }())")
-      }
+        }
+      iterable[Symbol.iterator] = function(){ return iterable; }
+      return iterable;
     }
+    else {
+      return eval("(function*() { yield a; yield b; yield c; }())")
+    }
+  }
   
   results[index] = null
   


### PR DESCRIPTION
Specifically, this corrects several tests that used 'window' instead of 'global', and their corresponding results. This also marks the presence of class support in io.js by adding a footnote explaining that it's in strict mode only. This is not ideal (there's no way for the live tests to probe whether the presence or absence of strict mode affects a feature, without separate tests existing for each) but should provide more-correct information for now.

Also, this splits one of the super tests into two, handling statement and expression forms of super().
