### PR TITLE
Improve TypeScript build time

### DIFF
--- a/build.js
+++ b/build.js
@@ -51,6 +51,7 @@ process.nextTick(function () {
   var esnext     = require('esnext');
   var traceur    = require('traceur');
   var reacttools = require('react-tools');
+  var tss        = require('typescript-simple');
   [
     {
       name: 'es6-shim',
@@ -147,15 +148,7 @@ process.nextTick(function () {
       target_file: 'es6/compilers/typescript.html',
       polyfills: [],
       compiler: function(code) {
-        var fpath = os.tmpDir() + path.sep + 'temp.ts';
-        var file = fs.writeFileSync(fpath, code);
-        try {
-          child_process.execSync('node_modules/typescript/bin/tsc -t ES5 ' + fpath);
-        } catch(e) {
-          throw new Error('\n' + e.stdout.toString().split(fpath).join(''));
-        }
-        var output = fs.readFileSync(fpath.slice(0, -2) + 'js', 'utf-8');
-        return output;
+        return tss(code);
       },
     },
   ].forEach(function(e){

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chalk": "~0.5.0-1",
     "cheerio": "~0.18.0",
     "object-assign": "~1.0.0",
+    "typescript-simple": "^0.2.0",
 
     "6to5":           "*",
     "esnext":         "*",


### PR DESCRIPTION
Currently, building TypeScript tests is too slow because it calls `child_process.execSync` for each test.
TypeScript 1.4 publishes [Compiler API](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API) and [typescript-simple](https://github.com/teppeis/typescript-simple) uses it to compile without child process.
- Current: 293.6s
- Improved: 1.8s
