### PR TITLE
Updated capabilities for TypeScript in light of upcoming 1.5 alpha

### DIFF
--- a/build.js
+++ b/build.js
@@ -333,8 +333,12 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
       // Create the cell, and add classes and attributes
       var cell = $('<td></td>');
       cell.addClass(result === true ? "yes" : result !== null ? "no" : "");
-      if(result === "flagged") {
+      if (result === "flagged") {
         cell.addClass("flagged");
+      }
+      else if (result === "needs-polyfill-or-native") {
+        cell.attr('title', "Requires native support or a polyfill.");
+        cell.addClass("needs-polyfill-or-native");
       }
       cell.attr('data-browser', browserId).addClass(
         browsers[browserId].obsolete ? "obsolete" :
@@ -353,6 +357,7 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
       if (result !== null) {
         cell.text(result === "flagged" ? "Flag" : result === true ? "Yes" : "No");
       }
+
       if (footnote) {
         cell.append(footnote);
       }

--- a/data-es6.js
+++ b/data-es6.js
@@ -2995,6 +2995,10 @@ exports.tests = [
         node:        true,
         iojs:        true,
         ios7:        true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       }),
     },
     'Uint8Array': {
@@ -3023,6 +3027,10 @@ exports.tests = [
         node:        true,
         iojs:        true,
         ios7:        true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'Int16Array': {
@@ -3092,6 +3100,10 @@ exports.tests = [
         node:        true,
         iojs:        true,
         ios7:        true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       }),
     },
     'DataView (Uint8)': {
@@ -3199,6 +3211,8 @@ exports.tests = [
     var eqFn = ' === "function"';
     var obj = {};
     for (var m in methods) {
+      methods[m].typescript = { val: needsPolyfill, note_id: "typescript-es6", },
+
       obj['%TypedArray%' + m] = {
         exec: eval('0,function(){/*\n  return typeof '
           + [
@@ -3236,6 +3250,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3261,6 +3279,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3283,6 +3305,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'Map.prototype.set returns this': {
@@ -3293,6 +3319,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3317,6 +3347,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         es6shim:     true,
         ie11tp:      true,
         firefox29:   true,
@@ -3338,6 +3372,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3358,6 +3396,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3378,6 +3420,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3398,6 +3444,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3418,6 +3468,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3438,6 +3492,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3458,6 +3516,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3492,6 +3554,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3516,6 +3582,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3541,6 +3611,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'Set.prototype.add returns this': {
@@ -3551,6 +3625,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3576,6 +3654,10 @@ exports.tests = [
       res: {
         babel:       true,
         es6shim:     true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox29:   true,
         chrome39:    true,
@@ -3598,6 +3680,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3618,6 +3704,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3638,6 +3728,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3658,6 +3752,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11:        true,
@@ -3678,6 +3776,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3697,6 +3799,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3717,6 +3823,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -3750,6 +3860,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11:        true,
         firefox11:   true,
         chrome21dev: flag,
@@ -3773,6 +3887,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox36:   true,
         chrome38:    true,
@@ -3793,6 +3911,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'WeakMap.prototype.set returns this': {
@@ -3803,6 +3925,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         chrome38:    true,
@@ -3821,6 +3947,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11:        true,
         firefox11:   true,
         chrome21dev: flag,
@@ -3842,6 +3972,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox11:   true,
         chrome21dev: flag,
@@ -3873,6 +4007,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox34:   true,
@@ -3891,6 +4029,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox34:   true,
@@ -3911,6 +4053,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'WeakSet.prototype.add returns this': {
@@ -3921,6 +4067,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         chrome38:    true,
@@ -3935,6 +4085,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox34:   true,
@@ -3964,6 +4118,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -3980,6 +4138,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   {
           val: false,
@@ -4003,6 +4165,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4021,6 +4187,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox37:   true,
       },
@@ -4038,6 +4208,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4055,6 +4229,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4072,6 +4250,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4095,6 +4277,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   {
           val: false,
@@ -4123,6 +4309,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4140,6 +4330,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
       },
     },
@@ -4161,6 +4355,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
       },
     },
@@ -4178,6 +4376,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         firefox31:   true,
         ie11tp:      true,
       },
@@ -4197,6 +4399,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         firefox23:   true,
         ie11tp:      true,
       },
@@ -4218,6 +4424,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox37:   true,
       },
@@ -4236,6 +4446,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         firefox18:   {
           val: false,
           note_id: 'fx-proxy-ownkeys',
@@ -4260,6 +4474,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4277,6 +4495,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox18:   true,
       },
@@ -4294,6 +4516,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox34:   true,
       },
@@ -4303,6 +4529,10 @@ exports.tests = [
         return Array.isArray(new Proxy([], {}));
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         firefox18: true,
       },
     },
@@ -4311,6 +4541,10 @@ exports.tests = [
         return JSON.stringify(new Proxy(['foo'], {})) === '["foo"]';
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         firefox18: true,  // a bug in FF18
         firefox23: false,
       },
@@ -4330,6 +4564,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4343,6 +4581,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4354,6 +4596,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4367,6 +4613,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4381,6 +4631,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4394,6 +4648,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4405,6 +4663,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4417,6 +4679,7 @@ exports.tests = [
       */},
       res: {
         babel:       { val: false, note_id: 'compiler-proto' },
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         ejs:         true,
         ie11tp:      true,
         es6shim:     { val: false, note_id: 'compiler-proto' },
@@ -4430,6 +4693,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4443,6 +4710,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         es6shim:     true,
       },
@@ -4465,6 +4736,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
       },
@@ -4476,6 +4751,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
       },
@@ -4486,6 +4765,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         es6shim:     true,
@@ -4499,6 +4782,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         es6shim:     true,
@@ -4513,6 +4800,10 @@ exports.tests = [
         }, ["foo", "bar", "baz"], Object).qux === "foobarbaz";
       */},
       res: {
+          typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+          },
       },
     },
   },
@@ -5082,6 +5373,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -5115,6 +5410,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -5148,6 +5447,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         es6shim:     true,
         ie11tp:      true,
@@ -5975,6 +6278,10 @@ exports.tests = [
         tr:          true,
         ejs:         true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox36:   true,
         chrome30:    flag, // Actually Chrome 29
@@ -5989,6 +6296,10 @@ exports.tests = [
       */},
       res: {
         babel:       flag,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -6016,6 +6327,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -6040,6 +6355,10 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         babel:       true,
         ie11tp:      true,
@@ -6069,6 +6388,7 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  true,
         ie11tp:      true,
         firefox36:   true,
         chrome38:    true,
@@ -6082,6 +6402,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         chrome39:    true,
         firefox36:   true,
@@ -6101,6 +6425,7 @@ exports.tests = [
         ejs:        true,
         tr:         true,
         babel:      true,
+        typescript: true,
         ie11tp:     true,
         firefox36:  true,
         chrome35:   flag,
@@ -6120,6 +6445,10 @@ exports.tests = [
           symbolObject.valueOf() === symbol;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:     true,
         firefox36:  true,
         chrome30:   flag,
@@ -6134,6 +6463,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -6163,6 +6496,10 @@ exports.tests = [
         return passed;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
       },
     },
@@ -6174,6 +6511,10 @@ exports.tests = [
         return a[0] === b;
       */},
       res: {
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
        ejs:         true,
       },
     },
@@ -6197,6 +6538,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox36:   true,
         chrome37:    flag,
@@ -6215,6 +6560,10 @@ exports.tests = [
       res: {
         ejs:         true,
         babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'Symbol.toPrimitive': {
@@ -6232,6 +6581,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'Symbol.toStringTag': {
@@ -6243,6 +6596,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         chrome40:    flag,
         iojs:        flag,
       },
@@ -6263,6 +6620,10 @@ exports.tests = [
           note_id: 'ejs-no-with',
           note_html: '<code>with</code> is not supported in ejs'
         },
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         node:        true,
         iojs:        true,
       },
@@ -6282,6 +6643,10 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         es6shim:     true,
         firefox37:   true,
       },
@@ -6292,6 +6657,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'RegExp.prototype[Symbol.replace]': {
@@ -6300,6 +6669,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'RegExp.prototype[Symbol.split]': {
@@ -6308,6 +6681,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
     'RegExp.prototype[Symbol.search]': {
@@ -6316,6 +6693,10 @@ exports.tests = [
       */},
       res: {
         ejs:         true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
   }

--- a/data-es6.js
+++ b/data-es6.js
@@ -2098,6 +2098,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -2121,6 +2122,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         ejs:         true,
         closure:     true,
         ie11tp:      true,
@@ -2141,6 +2143,11 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:   {
+            val: false,
+            note_id: "typescript-es6",
+            note_html: "TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill."
+        },
         ejs:         true,
         ie11tp:      true,
         firefox17:   true,
@@ -2162,6 +2169,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         es6tr:       { val: true, note_id: 'compiler-iterable' },
         ejs:         true,
         ie11tp:      true,
@@ -2184,6 +2195,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         es6tr:       { val: true, note_id: 'compiler-iterable' },
         ie11tp:      true,
         firefox36:   true,
@@ -2204,6 +2219,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
       },
     },
     'iterator closing, throw': {
@@ -2219,6 +2238,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
       },
     },
   },
@@ -4530,7 +4553,6 @@ exports.tests = [
         typescript:   {
             val: notApplicable,
             note_id: "typescript-es6",
-            note_html: "TypeScript recognizes the existence of runtime entities for ES6 under the <code>--target ES6</code> flag, but does not supply a runtime polyfill."
         },
         firefox34:    true,
         babel:        true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -4,6 +4,7 @@ Object.assign = require('object-assign');
 
 var temp = {};
 var flag = "flagged";
+var notApplicable = "NA";
 
 exports.name = 'ES6';
 exports.target_file = 'es6/index.html';
@@ -4473,6 +4474,7 @@ exports.tests = [
         jsx:         true,
         ejs:         true,
         closure:     true,
+        typescript:  true,
         firefox11:   true,
         safari71_8:  true,
         webkit:      true,
@@ -4494,6 +4496,7 @@ exports.tests = [
         jsx:         true,
         ejs:         true,
         closure:     true,
+        typescript:  true,
         firefox11:   true,
         safari71_8:  true,
         webkit:      true,
@@ -4509,6 +4512,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         ejs:         true,
         firefox34:   true,
       },
@@ -4523,6 +4527,11 @@ exports.tests = [
       */},
       res: {
         tr:           true,
+        typescript:   {
+            val: notApplicable,
+            note_id: "typescript-es6",
+            note_html: "TypeScript recognizes the existence of runtime entities for ES6 under the <code>--target ES6</code> flag, but does not supply a runtime polyfill."
+        },
         firefox34:    true,
         babel:        true,
       },
@@ -4538,6 +4547,10 @@ exports.tests = [
       res: {
         tr:           true,
         babel:        true,
+        typescript:   {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         firefox36:    true,
       },
     },
@@ -4550,6 +4563,10 @@ exports.tests = [
         return closed;
       */},
       res: {
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
       },
     },
     'iterable destructuring expression': {
@@ -4560,6 +4577,7 @@ exports.tests = [
       res: {
         tr:           true,
         babel:        true,
+        typescript:   true,
         jsx:          true,
         es6tr:        true,
         firefox11:    true,
@@ -4577,6 +4595,7 @@ exports.tests = [
       res: {
         tr:           true,
         babel:        true,
+        typescript:   true,
         jsx:          true,
         es6tr:        true,
         firefox11:    true,
@@ -4664,6 +4683,7 @@ exports.tests = [
       res: {
         tr:           true,
         babel:        true,
+        typescript:   true,
         jsx:          true,
         es6tr:        true,
         firefox16:    true,
@@ -4682,6 +4702,7 @@ exports.tests = [
         tr:           true,
         firefox16:    true,
         babel:        true,
+        typescript:   true,
         es6tr:        true,
         webkit:       true,
         safari71_8:   true,
@@ -4724,6 +4745,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -4751,6 +4773,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -4772,6 +4795,10 @@ exports.tests = [
         safari71_8:  true,
         webkit:      true,
         ios8:        true,
+        typescript:   {
+            val: false,
+            note_id: "typescript-es6",
+        },
       },
     },
     'in parameters, function \'length\' property': {
@@ -4781,6 +4808,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -4816,6 +4844,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         closure:     true,
         firefox13:   true,
@@ -4834,6 +4863,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         closure:     true,
@@ -4859,6 +4889,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         closure:     true,
       },
@@ -4873,6 +4904,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         closure:     true,
       },
@@ -4891,7 +4923,11 @@ exports.tests = [
         return a === 1 && b === 2;
       */},
       res: {
-        babel: flag
+        babel: flag,
+        typescript:   {
+            val: false,
+            note_id: "typescript-es6",
+        },
       },
     },
     'defaults in parameters, separate scope': {
@@ -4915,6 +4951,10 @@ exports.tests = [
         )({b:2, c:undefined, x:4});
       */},
       res: {
+        typescript:   {
+            val: false,
+            note_id: "typescript-es6",
+        },
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -7473,6 +7473,7 @@ exports.tests = [
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" }
       },
     },
     'Array.prototype.slice': {
@@ -7483,6 +7484,7 @@ exports.tests = [
         return c.slice(1,2) instanceof C;
       */},
       res: {
+          typescript:  { val: needsPolyfill, note_id: "typescript-es6" }
       }
     },
     'Array.from': {
@@ -7493,6 +7495,7 @@ exports.tests = [
       res: {
         tr:          { val: false, note_id: 'compiler-proto' },
         babel:       { val: false, note_id: 'compiler-proto' },
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         ie11tp:      true,
       }
     },
@@ -7504,6 +7507,7 @@ exports.tests = [
       res: {
         tr:          { val: false, note_id: 'compiler-proto' },
         babel:       { val: false, note_id: 'compiler-proto' },
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         ie11tp:      true,
       }
     },
@@ -7522,6 +7526,7 @@ exports.tests = [
         return r.global && r.source === "baz";
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
       },
@@ -7533,6 +7538,7 @@ exports.tests = [
         return r.exec("foobarbaz")[0] === "baz" && r.lastIndex === 9;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
       },
@@ -7544,6 +7550,7 @@ exports.tests = [
         return r.test("foobarbaz");
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
       },
@@ -7563,6 +7570,7 @@ exports.tests = [
         return c() === 'foo';
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
     },
@@ -7574,6 +7582,7 @@ exports.tests = [
         return new c().bar === 2 && new c().baz === 3;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
     },
@@ -7584,6 +7593,7 @@ exports.tests = [
         return c.call({bar:1}, 2) === 3;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
     },
@@ -7594,6 +7604,7 @@ exports.tests = [
         return c.apply({bar:1}, [2]) === 3;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
     },
@@ -7604,6 +7615,7 @@ exports.tests = [
         return c(6) === 9 && c instanceof C;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
       },
     },
   },
@@ -7643,6 +7655,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
       },
     },
     'Promise.all': {
@@ -7667,6 +7680,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
       },
     },
     'Promise.race': {
@@ -7691,6 +7705,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
       },
     },
   },
@@ -7709,6 +7724,7 @@ exports.tests = [
           && c == true;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         webkit:      true,
       },
     },
@@ -7720,6 +7736,7 @@ exports.tests = [
           && +c === 6;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         webkit:      true,
       },
     },
@@ -7733,6 +7750,7 @@ exports.tests = [
           && c.length === 5;
       */},
       res: {
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         webkit:      true,
       },
     },
@@ -7749,6 +7767,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         webkit:      true,
       },
     },
@@ -7766,6 +7785,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" },
         webkit:      true,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -4,7 +4,7 @@ Object.assign = require('object-assign');
 
 var temp = {};
 var flag = "flagged";
-var needsPolyfill = "needs-polyfill-or-native"
+var needsPolyfill = "needs-polyfill-or-native";
 
 exports.name = 'ES6';
 exports.target_file = 'es6/index.html';

--- a/data-es6.js
+++ b/data-es6.js
@@ -5888,6 +5888,7 @@ exports.tests = [
       */},
       res: {
         babel:        true,
+        typescript:   true,
         firefox34:    true,
         ie11tp:       true,
         chrome41:     flag,

--- a/data-es6.js
+++ b/data-es6.js
@@ -1196,6 +1196,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -1213,6 +1214,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -7415,6 +7417,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  true,
         ie10:        true,
         firefox11:   true,
         chrome:      true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -4,7 +4,6 @@ Object.assign = require('object-assign');
 
 var temp = {};
 var flag = "flagged";
-var notApplicable = "NA";
 var needsPolyfill = "needs-polyfill-or-native"
 
 exports.name = 'ES6';
@@ -1842,6 +1841,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         jsx:         true,
+        typescript:  true,
         closure:     true,
         es6tr:       true,
         ejs:         true,
@@ -1849,7 +1849,6 @@ exports.tests = [
         webkit:      true,
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'expression in constructors': {
@@ -1866,13 +1865,13 @@ exports.tests = [
         tr:          true,
         babel:       true,
         jsx:         true,
+        typescript:  true,
         closure:     true,
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
         webkit:      true,
         chrome43:    { val: flag, note_id: 'strict-required' },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'in methods': {
@@ -1889,6 +1888,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         jsx:         true,
+        typescript:  true,
         closure:     true,
         es6tr:       true,
         ejs:         true,
@@ -1896,7 +1896,6 @@ exports.tests = [
         webkit:      true,
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'is statically bound': {
@@ -1917,13 +1916,13 @@ exports.tests = [
         tr:          true,
         babel:       true,
         jsx:         true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
         webkit:      true,
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -1879,6 +1879,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -1948,6 +1949,7 @@ exports.tests = [
         tr:          true,
         closure:     true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         firefox34:   true,
         webkit:      true,
@@ -1966,6 +1968,10 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  {
+            val: false,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         tr:          true,
         es6tr:       true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -5,6 +5,7 @@ Object.assign = require('object-assign');
 var temp = {};
 var flag = "flagged";
 var notApplicable = "NA";
+var needsPolyfill = "needs-polyfill-or-native"
 
 exports.name = 'ES6';
 exports.target_file = 'es6/index.html';
@@ -377,7 +378,12 @@ exports.tests = [
           note_id: 'tr-tco',
           note_html: 'Requires the <code>properTailCalls</code> compile option.'
         },
-        babel:       true
+        babel:       true,
+        typescript:  {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+            note_html: "TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill."
+        }
       },
     },
     'mutual recursion': {
@@ -399,6 +405,7 @@ exports.tests = [
       */},
       res: {
         tr:          { val: flag, note_id: 'tr-tco' },
+        typescript:  { val: needsPolyfill, note_id: "typescript-es6" }
       },
     }
   }
@@ -660,7 +667,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         es6tr:       true,
@@ -679,7 +686,7 @@ exports.tests = [
       res: {
         babel:       flag,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ie11:        true,
@@ -744,7 +751,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         es6tr:       true,
@@ -768,7 +775,7 @@ exports.tests = [
       res: {
         babel:       flag,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ie11:        true,
@@ -850,7 +857,7 @@ exports.tests = [
       res: {
         babel:       flag,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ejs:         true,
@@ -877,7 +884,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ejs:         true,
@@ -959,7 +966,7 @@ exports.tests = [
       res: {
         babel:       flag,
         typescript:  {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ejs:         true,
@@ -991,7 +998,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ejs:         true,
@@ -2013,7 +2020,7 @@ exports.tests = [
       res: {
         babel:       true,
         typescript:  {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         ie11tp:      true,
@@ -2193,10 +2200,9 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
-        typescript:   {
-            val: false,
+        typescript:  {
+            val: needsPolyfill,
             note_id: "typescript-es6",
-            note_html: "TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill."
         },
         ejs:         true,
         ie11tp:      true,
@@ -2220,7 +2226,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         es6tr:       { val: true, note_id: 'compiler-iterable' },
@@ -2246,7 +2252,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         es6tr:       { val: true, note_id: 'compiler-iterable' },
@@ -2270,7 +2276,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },
@@ -2289,7 +2295,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },
@@ -4601,7 +4607,7 @@ exports.tests = [
       res: {
         tr:           true,
         typescript:   {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         firefox34:    true,
@@ -4620,7 +4626,7 @@ exports.tests = [
         tr:           true,
         babel:        true,
         typescript:   {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
         firefox36:    true,
@@ -4636,7 +4642,7 @@ exports.tests = [
       */},
       res: {
         typescript:  {
-            val: notApplicable,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },
@@ -4867,8 +4873,8 @@ exports.tests = [
         safari71_8:  true,
         webkit:      true,
         ios8:        true,
-        typescript:   {
-            val: false,
+        typescript:  {
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },
@@ -4995,9 +5001,9 @@ exports.tests = [
         return a === 1 && b === 2;
       */},
       res: {
-        babel: flag,
+        babel:        flag,
         typescript:   {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },
@@ -5024,7 +5030,7 @@ exports.tests = [
       */},
       res: {
         typescript:   {
-            val: false,
+            val: needsPolyfill,
             note_id: "typescript-es6",
         },
       },

--- a/data-es6.js
+++ b/data-es6.js
@@ -5850,6 +5850,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -1098,6 +1098,10 @@ exports.tests = [
         )(3);
       */},
       res: {
+        typescript: {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
       },
     },
   }
@@ -2851,6 +2855,10 @@ exports.tests = [
       res: {
         ejs:         true,
         babel:       true,
+        typescript: {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox36:   true,
         chrome30:    flag,
@@ -2867,6 +2875,10 @@ exports.tests = [
       res: {
         ejs:         true,
         babel:       true,
+        typescript: {
+            val: needsPolyfill,
+            note_id: "typescript-es6",
+        },
         ie11tp:      true,
         firefox36:   true,
         chrome30:    flag,

--- a/data-es6.js
+++ b/data-es6.js
@@ -551,6 +551,7 @@ exports.tests = [
       res: {
         babel:       true,
         tr:          true,
+        typescript:  true,
         ie11tp:      true,
         firefox39:   true,
       },
@@ -589,7 +590,7 @@ exports.tests = [
         closure:     true,
         es6tr:       true,
         jsx:         true,
-        typescript:  { val: flag, note_id: 'typescript-class' },
+        typescript:  true,
         ie11tp:      true,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -613,6 +613,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -637,6 +638,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         tr:          true,
         ejs:         true,
@@ -657,6 +659,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: false,
+            note_id: "typescript-es6",
+        },
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -672,6 +678,10 @@ exports.tests = [
       */},
       res: {
         babel:       flag,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         ie11:        true,
         firefox36:   true,
       },
@@ -685,6 +695,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -706,6 +717,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         tr:          true,
         ejs:         true,
@@ -731,6 +743,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -751,6 +767,10 @@ exports.tests = [
       */},
       res: {
         babel:       flag,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         ie11:        true,
         firefox36:   true,
         chrome19dev: flag,
@@ -775,6 +795,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -795,6 +816,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -813,6 +835,7 @@ exports.tests = [
         ejs:         true,
         es6tr:       true,
         babel:       true,
+        typescript:  true,
         closure:     true,
         ie11:        true,
         firefox11:   { val: flag, note_id: 'fx-let', },
@@ -826,6 +849,10 @@ exports.tests = [
       */},
       res: {
         babel:       flag,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11:        true,
         firefox35:   { val: flag, note_id: 'fx-let', },
@@ -849,6 +876,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: notApplicable,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         closure:     true,
       },
@@ -862,6 +893,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -883,6 +915,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -904,6 +937,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -924,6 +958,10 @@ exports.tests = [
       */},
       res: {
         babel:       flag,
+        typescript:  {
+            val: false,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         ie11:        true,
         firefox35:   { val: flag, note_id: 'fx-let', },
@@ -952,6 +990,10 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  {
+            val: false,
+            note_id: "typescript-es6",
+        },
         ejs:         true,
         closure:     true,
         chrome37:    flag,

--- a/data-es6.js
+++ b/data-es6.js
@@ -45,8 +45,8 @@ exports.browsers = {
     note_html: 'Have to be enabled via <code>harmony</code> option'
   },
   typescript: {
-    full: 'TypeScript 1.4',
-    short: 'Type-<br>Script',
+    full: 'TypeScript 1.5-alpha',
+    short: 'Type-<br />Script',
     obsolete: false,
     platformtype: 'compiler',
   },
@@ -2834,6 +2834,7 @@ exports.tests = [
         es6tr:       true,
         jsx:         true,
         closure:     true,
+        typescript:  true,
         ie11tp:      true,
         firefox34:   true,
         chrome41:    true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -1361,7 +1361,7 @@ exports.tests = [
         iojs:        { val: flag, note_id: 'strict-required', note_html: 'Support for this feature incorrectly requires strict mode.' },
         chrome41:    { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', note_html: 'Requires the <code>constructor</code> function to always be explicitly defined.' },
-        typescript:  { val: flag, note_id: 'typescript-class', note_html: 'TypeScript only supports class statements at script or module top-level.' },
+        typescript:  true,
       },
     },
     'is block-scoped': {
@@ -1390,6 +1390,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -1428,6 +1429,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -1437,7 +1439,6 @@ exports.tests = [
         chrome41:    { val: flag, note_id: 'strict-required' },
         iojs:        { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'prototype methods': {
@@ -1451,6 +1452,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -1460,7 +1462,6 @@ exports.tests = [
         chrome41:    { val: flag, note_id: 'strict-required' },
         iojs:        { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'string-keyed methods': {
@@ -1474,6 +1475,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -1495,6 +1497,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -1513,6 +1516,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         jsx:         true,
         ejs:         true,
@@ -1522,7 +1526,6 @@ exports.tests = [
         chrome41:    { val: flag, note_id: 'strict-required' },
         iojs:        { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'computed static methods': {
@@ -1537,6 +1540,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         closure:     true,
@@ -1557,6 +1561,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         jsx:         true,
         es6tr:       true,
         ejs:         true,
@@ -1565,7 +1570,6 @@ exports.tests = [
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'computed accessor properties': {
@@ -1581,6 +1585,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
@@ -1600,6 +1605,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         jsx:         true,
         es6tr:       true,
         ejs:         true,
@@ -1607,7 +1613,6 @@ exports.tests = [
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  { val: flag, note_id: 'typescript-class' },
       },
     },
     'computed static accessor properties': {
@@ -1623,6 +1628,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ejs:         true,
         ie11tp:      true,
@@ -1641,6 +1647,7 @@ exports.tests = [
       res: {
         tr:          true,
         babel:       true,
+        typescript:  true,
         es6tr:       true,
         ie11tp:      true,
         chrome41:    { val: flag, note_id: 'strict-required' },
@@ -1708,6 +1715,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        typescript:  true,
         webkit:      true,
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
@@ -1728,6 +1736,10 @@ exports.tests = [
         },
         babel:       { val: false, note_id: 'compiler-proto' },
         tr:          { val: false, note_id: 'compiler-proto' },
+        typescript:  {
+          val: false,
+          note_id: 'typescript-extends',
+          note_html: 'TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).'},
         ejs:         true,
         closure:     {
           val: false,
@@ -1740,10 +1752,6 @@ exports.tests = [
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome41:    { val: flag, note_id: 'strict-required' },
         firefox39:   { val: true, note_id: 'constructor-required', },
-        typescript:  {
-          val: false,
-          note_id: 'typescript-extends',
-          note_html: 'TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).'},
       }),
     },
     'extends expressions': {
@@ -1758,6 +1766,10 @@ exports.tests = [
         es6tr:       { val: false, note_id: 'compiler-proto' },
         babel:       { val: false, note_id: 'compiler-proto' },
         tr:          { val: false, note_id: 'compiler-proto' },
+        typescript:  {
+          val: false,
+          note_id: 'typescript-extends',
+        },
         ejs:         true,
         jsx:         { val: false, note_id: 'compiled-extends' },
         ie11tp:      true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -12168,7 +12168,7 @@ return view[0] === -0x80;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12236,7 +12236,7 @@ return view[0] === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12304,7 +12304,7 @@ return view[0] === 0xFF;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -12372,7 +12372,7 @@ return view[0] === -0x8000;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12440,7 +12440,7 @@ return view[0] === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12508,7 +12508,7 @@ return view[0] === -0x80000000;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12576,7 +12576,7 @@ return view[0] === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12644,7 +12644,7 @@ return view[0] === 0.10000000149011612;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12712,7 +12712,7 @@ return view[0] === 0.1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12781,7 +12781,7 @@ return view.getInt8(0) === -0x80;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12850,7 +12850,7 @@ return view.getUint8(0) === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12919,7 +12919,7 @@ return view.getInt16(0) === -0x8000;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -12988,7 +12988,7 @@ return view.getUint16(0) === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -13057,7 +13057,7 @@ return view.getInt32(0) === -0x80000000;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -13126,7 +13126,7 @@ return view.getUint32(0) === 0;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -13195,7 +13195,7 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -13264,7 +13264,7 @@ return view.getFloat64(0) === 0.1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -13338,7 +13338,7 @@ return typeof Int8Array.from === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13412,7 +13412,7 @@ return typeof Int8Array.of === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13486,7 +13486,7 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13560,7 +13560,7 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13634,7 +13634,7 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13708,7 +13708,7 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13782,7 +13782,7 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13856,7 +13856,7 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -13930,7 +13930,7 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14004,7 +14004,7 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14078,7 +14078,7 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14152,7 +14152,7 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14226,7 +14226,7 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &amp;&amp
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14300,7 +14300,7 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14374,7 +14374,7 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14448,7 +14448,7 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14522,7 +14522,7 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14596,7 +14596,7 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14670,7 +14670,7 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14744,7 +14744,7 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14818,7 +14818,7 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14892,7 +14892,7 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -14966,7 +14966,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15100,7 +15100,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -15171,7 +15171,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15243,7 +15243,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15310,7 +15310,7 @@ return map.set(0, 0) === map;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15382,7 +15382,7 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15453,7 +15453,7 @@ return map.size === 1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -15519,7 +15519,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -15585,7 +15585,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -15651,7 +15651,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -15717,7 +15717,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15783,7 +15783,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15849,7 +15849,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -15984,7 +15984,7 @@ return set.has(123);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16054,7 +16054,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16129,7 +16129,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16196,7 +16196,7 @@ return set.add(0) === set;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16268,7 +16268,7 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16341,7 +16341,7 @@ return set.size === 2;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16407,7 +16407,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16473,7 +16473,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16539,7 +16539,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16605,7 +16605,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16671,7 +16671,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16737,7 +16737,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -16871,7 +16871,7 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -16942,7 +16942,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17014,7 +17014,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17082,7 +17082,7 @@ return weakmap.set(key, 0) === weakmap;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17148,7 +17148,7 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -17217,7 +17217,7 @@ return m.get(f) === 42;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17352,7 +17352,7 @@ return weakset.has(obj1);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17421,7 +17421,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17493,7 +17493,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17561,7 +17561,7 @@ return weakset.add(obj) === weakset;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17627,7 +17627,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17762,7 +17762,7 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17834,7 +17834,7 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17908,7 +17908,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -17982,7 +17982,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18055,7 +18055,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18128,7 +18128,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18201,7 +18201,7 @@ var proxied = {};
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18280,7 +18280,7 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18358,7 +18358,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18431,7 +18431,7 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18509,7 +18509,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18584,7 +18584,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18660,7 +18660,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18738,7 +18738,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18813,7 +18813,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18889,7 +18889,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -18963,7 +18963,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19037,7 +19037,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19103,7 +19103,7 @@ return Array.isArray(new Proxy([], {}));
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19169,7 +19169,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19298,7 +19298,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19366,7 +19366,7 @@ return obj.quux === 654;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19432,7 +19432,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19500,7 +19500,7 @@ return !(&quot;bar&quot; in obj);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19569,7 +19569,7 @@ return desc.value === 789 &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19637,7 +19637,7 @@ return obj.foo === 123;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19703,7 +19703,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19771,7 +19771,7 @@ return obj instanceof Array;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19838,7 +19838,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19906,7 +19906,7 @@ return !Object.isExtensible(obj);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -19984,7 +19984,7 @@ return passed === 1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20051,7 +20051,7 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20117,7 +20117,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20185,7 +20185,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20255,7 +20255,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20405,7 +20405,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20485,7 +20485,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20565,7 +20565,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20628,7 +20628,7 @@ function check() {
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/9</td>
+<td data-browser="typescript" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/9</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/9</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/9</td>
@@ -20698,7 +20698,7 @@ return object[symbol] === value;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20764,7 +20764,7 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20842,7 +20842,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20917,7 +20917,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -20996,7 +20996,7 @@ return true;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21062,7 +21062,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21133,7 +21133,7 @@ try {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21205,7 +21205,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21273,7 +21273,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21409,7 +21409,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21478,7 +21478,7 @@ return a[0] === b;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21557,7 +21557,7 @@ return c === &quot;foo&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21625,7 +21625,7 @@ return RegExp[Symbol.species] === RegExp
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21700,7 +21700,7 @@ return passed === 3;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21768,7 +21768,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -21838,7 +21838,7 @@ with (a) {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -24189,7 +24189,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -24255,7 +24255,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -24321,7 +24321,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -24387,7 +24387,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -24453,7 +24453,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -127,7 +127,7 @@
 <th class="platform es6tr compiler obsolete" data-browser="es6tr"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Trans-<br>piler</abbr></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141120">Closure</abbr></a></th>
 <th class="platform jsx compiler" data-browser="jsx"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[2]</sup></a></a></th>
-<th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.4">Type-<br>Script</abbr></a></th>
+<th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.5-alpha">Type-<br>Script</abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-<br>shim</abbr></a></th>
 <th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
@@ -3375,7 +3375,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td data-browser="es6tr" class="obsolete tally" data-tally="1">2/2</td>
 <td data-browser="closure" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="1">2/2</td>
-<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="typescript" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/2</td>
@@ -3520,7 +3520,7 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -2495,7 +2495,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td data-browser="closure" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/7</td>
+<td data-browser="typescript" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/7</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/7</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/7</td>
@@ -2563,7 +2563,7 @@ for (var item of arr)
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2632,7 +2632,7 @@ return str === &quot;foo&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2701,7 +2701,7 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2772,7 +2772,7 @@ return result === &quot;123&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2843,7 +2843,7 @@ return result === &quot;123&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2913,7 +2913,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2985,7 +2985,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3723,7 +3723,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes unstable" data-browser="ie11tp">Yes<a href="#ie-regexp-u-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="ie11tp">Yes<a href="#ie-regexp-u-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="firefox11">No</td>
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
@@ -4060,7 +4060,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4130,7 +4130,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4200,7 +4200,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5164,7 +5164,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5714,7 +5714,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5854,7 +5854,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -31831,7 +31831,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[9]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="typescript-es6-note">  <sup>[10]</sup> TypeScript recognizes the existence of runtime entities for ES6 under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="typescript-es6-note">  <sup>[9]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es6/index.html
+++ b/es6/index.html
@@ -2026,7 +2026,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="es6tr" class="obsolete tally" data-tally="1">6/6</td>
 <td data-browser="closure" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td data-browser="jsx" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
-<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="typescript" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/6</td>
@@ -2093,7 +2093,7 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2359,7 +2359,7 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2432,7 +2432,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -8382,7 +8382,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6956521739130435" style="background-color:hsl(83,55%,50%)">16/23</td>
 <td data-browser="closure" class="tally" data-tally="0.2608695652173913" style="background-color:hsl(31,74%,50%)">6/23</td>
 <td data-browser="jsx" class="tally" data-tally="0.5652173913043478" style="background-color:hsl(67,61%,50%)">13/23</td>
-<td data-browser="typescript" class="tally" data-tally="0" data-flagged-tally="0.2608695652173913">0/23</td>
+<td data-browser="typescript" class="tally" data-tally="0.6086956521739131" style="background-color:hsl(73,59%,50%)">14/23</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/23</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/23</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/23</td>
@@ -8449,7 +8449,7 @@ return typeof C === &quot;function&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8587,7 +8587,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8723,7 +8723,7 @@ return C.prototype.constructor === C
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8793,7 +8793,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8863,7 +8863,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8934,7 +8934,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9004,7 +9004,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9075,7 +9075,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9147,7 +9147,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9219,7 +9219,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9291,7 +9291,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9363,7 +9363,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9434,7 +9434,7 @@ return C === undefined &amp;&amp; M();
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9717,7 +9717,7 @@ catch(e) {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9857,7 +9857,7 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -31831,7 +31831,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[9]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[9]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> undefined</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es6/index.html
+++ b/es6/index.html
@@ -1299,7 +1299,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td data-browser="closure" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/10</td>
+<td data-browser="typescript" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/10</td>
@@ -1365,7 +1365,7 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1431,7 +1431,7 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -29905,7 +29905,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td data-browser="closure" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td data-browser="jsx" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="typescript" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="typescript" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
 <td data-browser="es6shim" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
 <td data-browser="ie10" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
 <td data-browser="ie11" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
@@ -30109,7 +30109,7 @@ do {} while (false) return true;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -825,7 +825,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3246,7 +3246,7 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3312,7 +3312,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
@@ -79,7 +79,7 @@
     <input id="show-obsolete" type="checkbox">
     
     <label for="show-unstable">Show unstable platforms?</label>
-    <input id="show-unstable" type="checkbox" checked>
+    <input id="show-unstable" type="checkbox">
 
     <div class="legend">
       <span><span class="swatch" style="background-color:hsla(79, 100%, 37%, .8)"></span>V8</span>

--- a/es6/index.html
+++ b/es6/index.html
@@ -10069,7 +10069,7 @@ return passed;
 <td data-browser="es6tr" class="obsolete tally" data-tally="1">4/4</td>
 <td data-browser="closure" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="jsx" class="tally" data-tally="1">4/4</td>
-<td data-browser="typescript" class="tally" data-tally="0" data-flagged-tally="1">0/4</td>
+<td data-browser="typescript" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/4</td>
@@ -10143,7 +10143,7 @@ return passed;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10215,7 +10215,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10287,7 +10287,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10363,7 +10363,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -268,7 +268,7 @@ return (function f(n){
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -347,7 +347,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1759,7 +1759,7 @@ return Math.max(...iterable) === 3;
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1826,7 +1826,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1893,7 +1893,7 @@ return Math.max(...Object.create(iterable)) === 3;
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -1960,7 +1960,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
@@ -2432,7 +2432,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2701,7 +2701,7 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2769,10 +2769,10 @@ return result === &quot;123&quot;;
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2840,10 +2840,10 @@ return result === &quot;123&quot;;
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
-<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2913,7 +2913,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -2985,7 +2985,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4060,7 +4060,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4130,7 +4130,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4200,7 +4200,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5164,7 +5164,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5714,7 +5714,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5854,7 +5854,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6321,7 +6321,7 @@ try {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6389,7 +6389,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6598,7 +6598,7 @@ try {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6667,7 +6667,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7001,7 +7001,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7078,7 +7078,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7353,7 +7353,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7431,7 +7431,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -31831,7 +31831,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="typescript-es6-note">  <sup>[9]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[9]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es6/index.html
+++ b/es6/index.html
@@ -22236,7 +22236,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/17</td>
+<td data-browser="typescript" class="tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/17</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/17</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/17</td>
@@ -22846,7 +22846,7 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -3782,7 +3782,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">20/30</td>
 <td data-browser="closure" class="tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">16/30</td>
 <td data-browser="jsx" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">15/30</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/30</td>
+<td data-browser="typescript" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">20/30</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/30</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/30</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/30</td>
@@ -3852,7 +3852,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3922,7 +3922,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -3990,7 +3990,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4060,7 +4060,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4130,7 +4130,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4200,7 +4200,7 @@ return closed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4267,7 +4267,7 @@ return ([a, b] = iterable) === iterable;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4335,7 +4335,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4402,7 +4402,7 @@ return a === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4472,13 +4472,13 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="ie11tp">No</td>
-<td class="yes obsolete" data-browser="firefox11">Yes<a href="#ff11-object-destructuring-note"><sup>[10]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox13">Yes<a href="#ff11-object-destructuring-note"><sup>[10]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox11">Yes<a href="#ff11-object-destructuring-note"><sup>[11]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox13">Yes<a href="#ff11-object-destructuring-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox16">Yes</td>
 <td class="yes obsolete" data-browser="firefox17">Yes</td>
 <td class="yes obsolete" data-browser="firefox18">Yes</td>
@@ -4517,8 +4517,8 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
-<td class="yes" data-browser="safari71_8">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
-<td class="yes unstable" data-browser="webkit">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
+<td class="yes" data-browser="safari71_8">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
+<td class="yes unstable" data-browser="webkit">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -4527,7 +4527,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined
 <td class="no" data-browser="iojs">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
-<td class="yes" data-browser="ios8">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
+<td class="yes" data-browser="ios8">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="destructuring" id="destructuring_object_destructuring_with_primitives"><td><span><a class="anchor" href="#destructuring_object_destructuring_with_primitives">&#xA7;</a>object destructuring with primitives</span><script data-source="
 var {toFixed} = 2;
@@ -4546,7 +4546,7 @@ return toFixed === Number.prototype.toFixed
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4591,8 +4591,8 @@ return toFixed === Number.prototype.toFixed
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
-<td class="yes" data-browser="safari71_8">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
-<td class="yes unstable" data-browser="webkit">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
+<td class="yes" data-browser="safari71_8">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
+<td class="yes unstable" data-browser="webkit">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -4601,7 +4601,7 @@ return toFixed === Number.prototype.toFixed
 <td class="no" data-browser="iojs">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
-<td class="yes" data-browser="ios8">Yes<a href="#webkit-object-destructuring-note"><sup>[11]</sup></a></td>
+<td class="yes" data-browser="ios8">Yes<a href="#webkit-object-destructuring-note"><sup>[12]</sup></a></td>
 </tr>
 <tr class="subtest" data-parent="destructuring" id="destructuring_trailing_commas_in_object_patterns"><td><span><a class="anchor" href="#destructuring_trailing_commas_in_object_patterns">&#xA7;</a>trailing commas in object patterns</span><script data-source="
 var {a,} = {a:1};
@@ -4613,7 +4613,7 @@ return a === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4680,7 +4680,7 @@ return ({a,b} = obj) === obj;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4748,7 +4748,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4822,7 +4822,7 @@ return true;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -4957,7 +4957,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5026,7 +5026,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5095,7 +5095,7 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5164,7 +5164,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5230,7 +5230,7 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5366,7 +5366,7 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5435,7 +5435,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5570,7 +5570,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5639,7 +5639,7 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5714,7 +5714,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -5854,7 +5854,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}&quot;,
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -6802,27 +6802,27 @@ return (foo === 123);
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -6870,27 +6870,27 @@ return bar === 123;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -6938,27 +6938,27 @@ return baz === 1;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -7022,11 +7022,11 @@ return passed;
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox33">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -7151,27 +7151,27 @@ return (foo === 123);
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no flagged obsolete" data-browser="chrome19dev">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome21dev">Flag</td>
@@ -7220,27 +7220,27 @@ return bar === 123;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no flagged obsolete" data-browser="chrome19dev">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome21dev">Flag</td>
@@ -7289,27 +7289,27 @@ return baz === 1;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox11">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox13">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox16">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox17">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox18">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox23">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox24">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox25">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox27">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox28">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox29">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox30">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox32">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox33">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox34">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no flagged obsolete" data-browser="chrome19dev">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome21dev">Flag</td>
@@ -7374,11 +7374,11 @@ return passed;
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox33">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
-<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox35">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged" data-browser="firefox36">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox37">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no flagged obsolete" data-browser="chrome19dev">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome21dev">Flag</td>
@@ -7488,7 +7488,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr significance="0.25"><td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[13]</sup></a></span><script data-source="
+<tr significance="0.25"><td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[14]</sup></a></span><script data-source="
 &apos;use strict&apos;;
 function f() { return 1; }
 {
@@ -8250,7 +8250,7 @@ return arrow() === &quot;quux&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8449,7 +8449,7 @@ return typeof C === &quot;function&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8474,7 +8474,7 @@ return typeof C === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8488,9 +8488,9 @@ return typeof C === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8501,7 +8501,7 @@ return typeof C === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8546,7 +8546,7 @@ return C === c1;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8560,9 +8560,9 @@ return C === c1;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8573,7 +8573,7 @@ return C === c1;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8612,7 +8612,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8626,9 +8626,9 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8639,7 +8639,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8678,7 +8678,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8692,9 +8692,9 @@ return typeof class {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8705,7 +8705,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8723,7 +8723,7 @@ return C.prototype.constructor === C
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8748,7 +8748,7 @@ return C.prototype.constructor === C
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8762,9 +8762,9 @@ return C.prototype.constructor === C
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8775,7 +8775,7 @@ return C.prototype.constructor === C
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8793,7 +8793,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8818,7 +8818,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8832,9 +8832,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8845,7 +8845,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8888,7 +8888,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8902,9 +8902,9 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8915,7 +8915,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8959,7 +8959,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9004,7 +9004,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9029,7 +9029,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9043,9 +9043,9 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9056,7 +9056,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9100,7 +9100,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9147,7 +9147,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9172,7 +9172,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9186,9 +9186,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9199,7 +9199,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9244,7 +9244,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9291,7 +9291,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9316,7 +9316,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9330,9 +9330,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9343,7 +9343,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9388,7 +9388,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9459,7 +9459,7 @@ return C === undefined &amp;&amp; M();
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9473,9 +9473,9 @@ return C === undefined &amp;&amp; M();
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9486,7 +9486,7 @@ return C === undefined &amp;&amp; M();
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9531,7 +9531,7 @@ try {
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9616,8 +9616,8 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9670,7 +9670,7 @@ return (0,C.method)();
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9684,9 +9684,9 @@ return (0,C.method)();
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9697,7 +9697,7 @@ return (0,C.method)();
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9758,7 +9758,7 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9782,12 +9782,12 @@ return new C() instanceof B
   &amp;&amp; B.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");return Function("asyncTestPassed","\nclass B {}\nclass C extends B {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C)\n  && B.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9812,7 +9812,7 @@ return new C() instanceof B
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9826,9 +9826,9 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9839,7 +9839,7 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9852,11 +9852,11 @@ return new C() instanceof B
   &amp;&amp; B.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");return Function("asyncTestPassed","\nvar B;\nclass C extends (B = class {}) {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C)\n  && B.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
@@ -9882,7 +9882,7 @@ return new C() instanceof B
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9896,9 +9896,9 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9909,7 +9909,7 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9954,7 +9954,7 @@ return !(c instanceof Object)
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9968,9 +9968,9 @@ return !(c instanceof Object)
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9981,7 +9981,7 @@ return !(c instanceof Object)
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10143,7 +10143,7 @@ return passed;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10182,9 +10182,9 @@ return passed;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10195,7 +10195,7 @@ return passed;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10215,7 +10215,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10256,7 +10256,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10287,7 +10287,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10326,9 +10326,9 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10339,7 +10339,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10363,7 +10363,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[14]</sup></a></td>
+<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10402,9 +10402,9 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10415,7 +10415,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -11981,7 +11981,7 @@ return passed;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -11995,9 +11995,9 @@ return passed;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -12008,7 +12008,7 @@ return passed;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -12060,7 +12060,7 @@ return passed;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -17843,21 +17843,21 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
 <td class="yes unstable" data-browser="firefox38">Yes</td>
 <td class="yes unstable" data-browser="firefox39">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
@@ -18289,13 +18289,13 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
 <td class="yes" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox32">Yes</td>
@@ -18822,16 +18822,16 @@ return passed;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox33">Yes</td>
 <td class="yes obsolete" data-browser="firefox34">Yes</td>
 <td class="yes obsolete" data-browser="firefox35">Yes</td>
@@ -19767,12 +19767,12 @@ return obj instanceof Array;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
@@ -21891,7 +21891,7 @@ with (a) {
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
-<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[23]</sup></a></td>
+<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
@@ -22169,12 +22169,12 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
@@ -23289,7 +23289,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -23356,7 +23356,7 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -24069,36 +24069,36 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no unstable" data-browser="firefox38">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no unstable" data-browser="firefox39">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no unstable" data-browser="firefox38">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no unstable" data-browser="firefox39">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
-<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome39">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="chrome40">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome39">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome40">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes unstable" data-browser="chrome42">Yes</td>
 <td class="yes unstable" data-browser="chrome43">Yes</td>
@@ -24111,7 +24111,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
-<td class="no flagged" data-browser="node">Flag<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no flagged" data-browser="node">Flag<a href="#string-contains-note"><sup>[25]</sup></a></td>
 <td class="yes" data-browser="iojs">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
@@ -25528,24 +25528,24 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox11">No</td>
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
-<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no unstable" data-browser="firefox38">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no unstable" data-browser="firefox39">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no unstable" data-browser="firefox38">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no unstable" data-browser="firefox39">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -25556,12 +25556,12 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome35">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome36">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome37">Flag</td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no unstable" data-browser="chrome42">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
-<td class="no unstable" data-browser="chrome43">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no unstable" data-browser="chrome42">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no unstable" data-browser="chrome43">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -26408,7 +26408,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes unstable" data-browser="firefox39">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
-<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[28]</sup></a></td>
+<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome30">Yes</td>
 <td class="yes obsolete" data-browser="chrome31">Yes</td>
 <td class="yes obsolete" data-browser="chrome33">Yes</td>
@@ -27251,7 +27251,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="no obsolete" data-browser="firefox23">No</td>
 <td class="no obsolete" data-browser="firefox24">No</td>
 <td class="no obsolete" data-browser="firefox25">No</td>
-<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[30]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox28">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -27551,7 +27551,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -27562,7 +27562,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -27641,8 +27641,8 @@ class C extends Array {}
 return C.from({ length: 0 }) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("396");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27708,8 +27708,8 @@ class C extends Array {}
 return C.of(0) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("397");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27885,7 +27885,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -27953,7 +27953,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28021,7 +28021,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28152,7 +28152,7 @@ return c() === &apos;foo&apos;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28221,7 +28221,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28289,7 +28289,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28357,7 +28357,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -30595,7 +30595,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest annex_b" significance="0.25"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[30]</sup></a></span></td>
+<tr class="supertest annex_b" significance="0.25"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[31]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="0">0/5</td>
@@ -31831,7 +31831,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[9]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[10]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[11]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[12]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[13]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[14]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[15]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[16]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[17]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[18]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[19]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[20]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[21]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[22]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[23]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[24]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[25]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[26]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[27]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[28]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[29]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[30]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="compiler-iterable-note">  <sup>[8]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[9]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="typescript-es6-note">  <sup>[10]</sup> TypeScript recognizes the existence of runtime entities for ES6 under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> TypeScript only supports class statements at script or module top-level.</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es6/index.html
+++ b/es6/index.html
@@ -7567,7 +7567,7 @@ return f() === 1;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td data-browser="closure" class="tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
 <td data-browser="jsx" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
-<td data-browser="typescript" class="tally" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)" data-flagged-tally="0.6363636363636364">6/11</td>
+<td data-browser="typescript" class="tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/11</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/11</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/11</td>
@@ -8106,7 +8106,7 @@ return (() =&gt; {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8250,7 +8250,7 @@ return arrow() === &quot;quux&quot;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
-<td class="no flagged" data-browser="typescript">Flag<a href="#typescript-class-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -8474,7 +8474,7 @@ return typeof C === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8488,9 +8488,9 @@ return typeof C === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8501,7 +8501,7 @@ return typeof C === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8546,7 +8546,7 @@ return C === c1;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8560,9 +8560,9 @@ return C === c1;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8573,7 +8573,7 @@ return C === c1;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8612,7 +8612,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8626,9 +8626,9 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8639,7 +8639,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8678,7 +8678,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8692,9 +8692,9 @@ return typeof class {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8705,7 +8705,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8748,7 +8748,7 @@ return C.prototype.constructor === C
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8762,9 +8762,9 @@ return C.prototype.constructor === C
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8775,7 +8775,7 @@ return C.prototype.constructor === C
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8818,7 +8818,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8832,9 +8832,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8845,7 +8845,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8888,7 +8888,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -8902,9 +8902,9 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -8915,7 +8915,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -8959,7 +8959,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9029,7 +9029,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9043,9 +9043,9 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9056,7 +9056,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9100,7 +9100,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9172,7 +9172,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9186,9 +9186,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9199,7 +9199,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9244,7 +9244,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9316,7 +9316,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9330,9 +9330,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9343,7 +9343,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9388,7 +9388,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9459,7 +9459,7 @@ return C === undefined &amp;&amp; M();
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9473,9 +9473,9 @@ return C === undefined &amp;&amp; M();
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9486,7 +9486,7 @@ return C === undefined &amp;&amp; M();
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9531,7 +9531,7 @@ try {
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9616,8 +9616,8 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9670,7 +9670,7 @@ return (0,C.method)();
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9684,9 +9684,9 @@ return (0,C.method)();
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9697,7 +9697,7 @@ return (0,C.method)();
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9758,7 +9758,7 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9782,12 +9782,12 @@ return new C() instanceof B
   &amp;&amp; B.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");return Function("asyncTestPassed","\nclass B {}\nclass C extends B {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C)\n  && B.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9812,7 +9812,7 @@ return new C() instanceof B
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9826,9 +9826,9 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9839,7 +9839,7 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9852,12 +9852,12 @@ return new C() instanceof B
   &amp;&amp; B.prototype.isPrototypeOf(C.prototype);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");return Function("asyncTestPassed","\nvar B;\nclass C extends (B = class {}) {}\nreturn new C() instanceof B\n  && B.isPrototypeOf(C)\n  && B.prototype.isPrototypeOf(C.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -9882,7 +9882,7 @@ return new C() instanceof B
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9896,9 +9896,9 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9909,7 +9909,7 @@ return new C() instanceof B
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -9954,7 +9954,7 @@ return !(c instanceof Object)
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -9968,9 +9968,9 @@ return !(c instanceof Object)
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -9981,7 +9981,7 @@ return !(c instanceof Object)
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10182,9 +10182,9 @@ return passed;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10195,7 +10195,7 @@ return passed;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10256,7 +10256,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10326,9 +10326,9 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10339,7 +10339,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -10402,9 +10402,9 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -10415,7 +10415,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -11981,7 +11981,7 @@ return passed;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -11995,9 +11995,9 @@ return passed;
 <td class="no obsolete" data-browser="chrome38">No</td>
 <td class="no obsolete" data-browser="chrome39">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
-<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="chrome41">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome42">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -12008,7 +12008,7 @@ return passed;
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -12060,7 +12060,7 @@ return passed;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -17843,21 +17843,21 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#fx-proxy-get-note"><sup>[20]</sup></a></td>
 <td class="yes unstable" data-browser="firefox38">Yes</td>
 <td class="yes unstable" data-browser="firefox39">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
@@ -18289,13 +18289,13 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-getown-note"><sup>[21]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
 <td class="yes" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox32">Yes</td>
@@ -18822,16 +18822,16 @@ return passed;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-proxy-ownkeys-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox33">Yes</td>
 <td class="yes obsolete" data-browser="firefox34">Yes</td>
 <td class="yes obsolete" data-browser="firefox35">Yes</td>
@@ -19767,12 +19767,12 @@ return obj instanceof Array;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
@@ -21891,7 +21891,7 @@ with (a) {
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
-<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[24]</sup></a></td>
+<td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[23]</sup></a></td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
@@ -22169,12 +22169,12 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes unstable" data-browser="ie11tp">Yes</td>
@@ -23289,7 +23289,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -23356,7 +23356,7 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="firefox36">No</td>
 <td class="no unstable" data-browser="firefox37">No</td>
 <td class="no unstable" data-browser="firefox38">No</td>
-<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[16]</sup></a></td>
+<td class="yes unstable" data-browser="firefox39">Yes<a href="#constructor-required-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -24069,36 +24069,36 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
 <td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no unstable" data-browser="firefox38">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no unstable" data-browser="firefox39">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no unstable" data-browser="firefox38">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no unstable" data-browser="firefox39">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
-<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome39">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
-<td class="no obsolete" data-browser="chrome40">No<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="chrome30">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome31">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome33">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome34">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome35">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome36">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome37">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome39">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="chrome40">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes unstable" data-browser="chrome42">Yes</td>
 <td class="yes unstable" data-browser="chrome43">Yes</td>
@@ -24111,7 +24111,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
-<td class="no flagged" data-browser="node">Flag<a href="#string-contains-note"><sup>[25]</sup></a></td>
+<td class="no flagged" data-browser="node">Flag<a href="#string-contains-note"><sup>[24]</sup></a></td>
 <td class="yes" data-browser="iojs">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
@@ -25528,24 +25528,24 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox11">No</td>
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
-<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no obsolete" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[27]</sup></a></td>
-<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no unstable" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no unstable" data-browser="firefox38">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no unstable" data-browser="firefox39">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="firefox17">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox18">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox23">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox24">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox25">No<a href="#fx-array-prototype-values-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="firefox27">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox28">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox29">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox30">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox32">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox33">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox34">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox35">No<a href="#fx-array-prototype-values-2-note"><sup>[26]</sup></a></td>
+<td class="no" data-browser="firefox36">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no unstable" data-browser="firefox37">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no unstable" data-browser="firefox38">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no unstable" data-browser="firefox39">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
 <td class="no obsolete" data-browser="chrome21dev">No</td>
@@ -25556,12 +25556,12 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome35">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome36">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome37">Flag</td>
-<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no obsolete" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no obsolete" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no unstable" data-browser="chrome42">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
-<td class="no unstable" data-browser="chrome43">No<a href="#array-prototype-iterator-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="chrome38">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="chrome39">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no unstable" data-browser="chrome42">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
+<td class="no unstable" data-browser="chrome43">No<a href="#array-prototype-iterator-note"><sup>[27]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -26408,7 +26408,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes unstable" data-browser="firefox39">Yes</td>
 <td class="no obsolete" data-browser="chrome">No</td>
 <td class="no obsolete" data-browser="chrome19dev">No</td>
-<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="chrome21dev">Yes<a href="#chromu-imul-note"><sup>[28]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome30">Yes</td>
 <td class="yes obsolete" data-browser="chrome31">Yes</td>
 <td class="yes obsolete" data-browser="chrome33">Yes</td>
@@ -27251,7 +27251,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="no obsolete" data-browser="firefox23">No</td>
 <td class="no obsolete" data-browser="firefox24">No</td>
 <td class="no obsolete" data-browser="firefox25">No</td>
-<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[30]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox27">Yes<a href="#fx-fround-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox28">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -27551,7 +27551,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -27562,7 +27562,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -27641,8 +27641,8 @@ class C extends Array {}
 return C.from({ length: 0 }) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("396");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27708,8 +27708,8 @@ class C extends Array {}
 return C.of(0) instanceof C;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("397");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27885,7 +27885,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -27953,7 +27953,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28021,7 +28021,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28152,7 +28152,7 @@ return c() === &apos;foo&apos;;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28221,7 +28221,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28289,7 +28289,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -28357,7 +28357,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no unstable" data-browser="chrome42">No</td>
-<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[17]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome43">Flag<a href="#strict-required-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
@@ -30595,7 +30595,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest annex_b" significance="0.25"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[31]</sup></a></span></td>
+<tr class="supertest annex_b" significance="0.25"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[30]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="0">0/5</td>
@@ -31831,7 +31831,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
         <script>document.write("<pre>" + __createIterableObject + "</pre>");</script>
       </div>
       <!-- FOOTNOTES -->
-    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[9]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="typescript-class-note">  <sup>[15]</sup> undefined</p><p id="constructor-required-note">  <sup>[16]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[17]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[18]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[19]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[20]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[21]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[22]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[23]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[24]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[25]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[26]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[27]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[28]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[29]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[30]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[31]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
+    <p><p id="babel-optional-note">  <sup>[1]</sup> Flagged features require an optional transformer setting.</p><p id="jsx-flag-note">  <sup>[2]</sup> Have to be enabled via <code>harmony</code> option</p><p id="ie-experimental-flag-note">  <sup>[3]</sup> Have to be enabled via &quot;Experimental Web Platform Features&quot; flag</p><p id="experimental-flag-note">  <sup>[4]</sup> Flagged features have to be enabled via &quot;Experimental Javascript features&quot; flag</p><p id="khtml-note">  <sup>[5]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript recognizes the existence of these runtime entities and constructs for ES6 and emits them under the <code>--target ES6</code> flag, but does not supply a runtime polyfill.</p><p id="compiler-iterable-note">  <sup>[9]</sup> This compiler requires generic iterables have a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="ie-regexp-u-note">  <sup>[10]</sup> RegExps such as <code>/./u</code> will still select halves of surrogate pairs.</p><p id="ff11-object-destructuring-note">  <sup>[11]</sup> Firefox &lt; 16 incorrectly treats <code>({f,g} = {f:9,g:10})</code> as assigning to global variables instead of locals.</p><p id="webkit-object-destructuring-note">  <sup>[12]</sup> WebKit doesn&apos;t support parenthesised object destructuring patterns (e.g. <code>({f,g}) = {f:9,g:10}</code>).</p><p id="fx-let-note">  <sup>[13]</sup> Available for code in a <code>&lt;script type=&quot;application/javascript;version=1.7&quot;&gt;</code> (or <code>version=1.8</code>) tag.</p><p id="block-level-function-note">  <sup>[14]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="constructor-required-note">  <sup>[15]</sup> Requires the <code>constructor</code> function to always be explicitly defined.</p><p id="strict-required-note">  <sup>[16]</sup> Support for this feature incorrectly requires strict mode.</p><p id="compiler-proto-note">  <sup>[17]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[18]</sup> This compiler transforms <code>extends</code> into code that copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[19]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="fx-proxy-get-note">  <sup>[20]</sup> Firefox 18 up to 37 doesn&apos;t allow a proxy&apos;s &quot;get&quot; handler to be triggered via the prototype chain, unless the proxied object does possess the named property (or the proxy&apos;s &quot;has&quot; handler reports it as present).</p><p id="fx-proxy-getown-note">  <sup>[21]</sup> From Firefox 18 up to 29, the <code>getOwnPropertyDescriptor</code> handler can only report non-existent properties if the proxy target is non-extensible rather than extensible</p><p id="fx-proxy-ownkeys-note">  <sup>[22]</sup> Available from Firefox 18 up to 33 as the draft standard <code>keys</code> handler</p><p id="ejs-no-with-note">  <sup>[23]</sup> <code>with</code> is not supported in ejs</p><p id="string-contains-note">  <sup>[24]</sup> Available as the draft standard <code>String.prototype.contains</code></p><p id="fx-array-prototype-values-note">  <sup>[25]</sup> Available from Firefox 17 up to 27 as the non-standard <code>Array.prototype.iterator</code></p><p id="fx-array-prototype-values-2-note">  <sup>[26]</sup> Available from Firefox 27 up to 35 as the non-standard <code>Array.prototype[&quot;@@iterator&quot;]</code></p><p id="array-prototype-iterator-note">  <sup>[27]</sup> Available as <code>Array.prototype[Symbol.iterator]</code></p><p id="chromu-imul-note">  <sup>[28]</sup> Available since Chrome 28</p><p id="fx-fround-note">  <sup>[29]</sup> Available since Firefox 26</p><p id="proto-in-object-literals-note">  <sup>[30]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es6/index.html
+++ b/es6/index.html
@@ -27510,7 +27510,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27579,7 +27579,7 @@ return c.slice(1,2) instanceof C;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27646,7 +27646,7 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27713,7 +27713,7 @@ return C.of(0) instanceof C;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27844,7 +27844,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27912,7 +27912,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -27980,7 +27980,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28111,7 +28111,7 @@ return c() === &apos;foo&apos;;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28180,7 +28180,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28248,7 +28248,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28316,7 +28316,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28384,7 +28384,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28535,7 +28535,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28616,7 +28616,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28697,7 +28697,7 @@ function check() {
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28829,7 +28829,7 @@ return c instanceof Boolean
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28898,7 +28898,7 @@ return c instanceof Number
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -28969,7 +28969,7 @@ return c instanceof String
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -29041,7 +29041,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -29114,7 +29114,7 @@ return set.has(123);
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -6115,7 +6115,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="closure" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/8</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/8</td>
+<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie11" class="tally" data-tally="1">8/8</td>
@@ -6182,7 +6182,7 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6250,7 +6250,7 @@ return bar === 123;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6321,7 +6321,7 @@ try {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6389,7 +6389,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6457,7 +6457,7 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6526,7 +6526,7 @@ return bar === 123;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6598,7 +6598,7 @@ try {
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6667,7 +6667,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6730,7 +6730,7 @@ return passed;
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td data-browser="closure" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/10</td>
+<td data-browser="typescript" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
@@ -6797,7 +6797,7 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6865,7 +6865,7 @@ return bar === 123;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -6933,7 +6933,7 @@ return baz === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7001,7 +7001,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7078,7 +7078,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -7146,7 +7146,7 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7215,7 +7215,7 @@ return bar === 123;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7284,7 +7284,7 @@ return baz === 1;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7353,7 +7353,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
@@ -7431,7 +7431,7 @@ return passed;
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="typescript">No<a href="#typescript-es6-note"><sup>[9]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -5917,7 +5917,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}&quot;,
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="closure" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/2</td>
+<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/2</td>
@@ -5983,7 +5983,7 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>

--- a/master.css
+++ b/master.css
@@ -201,6 +201,11 @@ td:first-child, td:not([class]) {
     background: hsl(120,  14%,  67%); background: #9fb79f; cursor: help;
 }
 
+/*needs a polyfill or native support*/
+.needs-polyfill-or-native {
+    background: hsl(24,77%,50%); background:#E16B1D; cursor: help;
+}
+
 /* non-standard no */
 .non-standard .no {
     background: #4444ac;


### PR DESCRIPTION
Because TypeScript has an ES6 emit target, we technically support many of the capabilities; however, because most of them are runtime dependent on a valid ES6 implementation, I've left a note on them.

I'm not sure what would be the best thing to do. If this is acceptable, great; however, please let us know what would be the most appropriate.
