### PR TITLE
Marked Rhino and Safari 6 as obsolete.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -26,13 +26,13 @@ exports.browsers = {
   },
   es6tr: {
     full: 'ES6 Transpiler',
-    short: 'ES6<br>Transpiler',
+    short: 'ES6<br>Trans-<br>piler',
     obsolete: false,
     platformtype: 'compiler',
   },
   closure: {
     full: 'Closure Compiler v20141120',
-    short: 'Closure<br>Compiler',
+    short: 'Closure',
     obsolete: false,
     platformtype: 'compiler',
   },
@@ -46,7 +46,7 @@ exports.browsers = {
   },
   typescript: {
     full: 'TypeScript 1.4',
-    short: 'TypeScript',
+    short: 'Type-<br>Script',
     obsolete: false,
     platformtype: 'compiler',
   },
@@ -257,11 +257,11 @@ exports.browsers = {
   safari6: {
     full: 'Safari',
     short: 'SF 6',
-    obsolete: false // EOLs together with OS X 10.8
+    obsolete: true
   },
   safari7: {
     full: 'Safari',
-    short: 'SF 7.0',
+    short: 'SF 6.1,<br>SF 7',
     obsolete: false
   },
   safari71_8: {
@@ -289,6 +289,7 @@ exports.browsers = {
     full: 'Rhino 1.7',
     short: 'RH',
     platformtype: 'engine',
+    obsolete: true,
   },
   phantom: {
     full: 'PhantomJS 1.9.7 AppleWebKit/534.34',

--- a/data-es7.js
+++ b/data-es7.js
@@ -93,6 +93,7 @@ exports.browsers = {
     full: 'Rhino 1.7',
     short: 'RH',
     platformtype: 'engine',
+    obsolete: true,
   },
   phantom: {
     full: 'PhantomJS 1.9.7 AppleWebKit/534.34',

--- a/es6/index.html
+++ b/es6/index.html
@@ -86,9 +86,9 @@
 
           <th colspan="7" class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers/polyfills</th>
 
-          <th colspan="16" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
 
-          <th colspan="5" class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
+          <th colspan="4" class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
 
           <th colspan="2" class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
 
@@ -104,10 +104,10 @@
           <!-- TABLE HEADERS -->
         <th class="platform tr compiler" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
 <th class="platform _6to5 compiler" data-browser="_6to5"><a href="#_6to5" class="browser-name"><abbr title="6to5">6to5 +<br><nobr>core-js</nobr></abbr><a href="#6to5-optional-note"><sup>[1]</sup></a></a></th>
-<th class="platform es6tr compiler" data-browser="es6tr"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Transpiler</abbr></a></th>
-<th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141120">Closure<br>Compiler</abbr></a></th>
+<th class="platform es6tr compiler" data-browser="es6tr"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Trans-<br>piler</abbr></a></th>
+<th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20141120">Closure</abbr></a></th>
 <th class="platform jsx compiler" data-browser="jsx"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[2]</sup></a></a></th>
-<th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.4">TypeScript</abbr></a></th>
+<th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.4">Type-<br>Script</abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-<br>shim</abbr></a></th>
 <th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
@@ -146,13 +146,13 @@
 <th class="platform chrome40 desktop" data-browser="chrome40"><a href="#chrome40" class="browser-name"><abbr title="Chrome, Opera">CH 40,<br>OP&#xA0;27</abbr><a href="#experimental-flag-note"><sup>[4]</sup></a></a></th>
 <th class="platform chrome41 desktop" data-browser="chrome41"><a href="#chrome41" class="browser-name"><abbr title="Chrome, Opera">CH 41,<br>OP&#xA0;28</abbr><a href="#experimental-flag-note"><sup>[4]</sup></a></a></th>
 <th class="platform safari51 desktop obsolete" data-browser="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></a></th>
-<th class="platform safari6 desktop" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
-<th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 7.0</abbr></a></th>
+<th class="platform safari6 desktop obsolete" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
+<th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
 <th class="platform safari71_8 desktop" data-browser="safari71_8"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></a></th>
 <th class="platform webkit desktop" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r178314">WK</abbr></a></th>
 <th class="platform opera desktop" data-browser="opera"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ 4.14</abbr><a href="#khtml-note"><sup>[5]</sup></a></a></th>
-<th class="platform rhino17 engine" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
+<th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></a></th>
 <th class="platform node engine" data-browser="node"><a href="#node" class="browser-name"><abbr title="Node 0.11.14">Node</abbr><a href="#harmony-flag-note"><sup>[6]</sup></a></a></th>
 <th class="platform iojs engine" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js 1.0.3">io.js</abbr><a href="#harmony-flag-note"><sup>[6]</sup></a></a></th>
@@ -220,13 +220,13 @@ return (function f(n){
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -281,13 +281,13 @@ return (function f(n){
 <td data-browser="chrome40" class="tally" data-tally="0">0/5</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/5</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/5</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/5</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/5</td>
@@ -343,13 +343,13 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -405,13 +405,13 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -467,13 +467,13 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -539,13 +539,13 @@ return (function(x = 1) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -606,13 +606,13 @@ return (function(a=function(){
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -665,13 +665,13 @@ return (function(a=function(){
 <td data-browser="chrome40" class="tally" data-tally="0">0/3</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/3</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/3</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/3</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/3</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/3</td>
 <td data-browser="opera" class="tally" data-tally="0">0/3</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/3</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/3</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/3</td>
 <td data-browser="node" class="tally" data-tally="0">0/3</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/3</td>
@@ -729,13 +729,13 @@ return (function (foo, ...args) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -791,13 +791,13 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -861,13 +861,13 @@ return (function (foo, ...args) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -920,13 +920,13 @@ return (function (foo, ...args) {
 <td data-browser="chrome40" class="tally" data-tally="0">0/8</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/8</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/8</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/8</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/8</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.25">2/8</td>
 <td data-browser="webkit" class="tally" data-tally="0.25">2/8</td>
 <td data-browser="opera" class="tally" data-tally="0">0/8</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/8</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/8</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/8</td>
 <td data-browser="node" class="tally" data-tally="0">0/8</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/8</td>
@@ -982,13 +982,13 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1044,13 +1044,13 @@ return [...[1, 2, 3]][2] === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1106,13 +1106,13 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1168,13 +1168,13 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1231,13 +1231,13 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1294,13 +1294,13 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1357,13 +1357,13 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1420,13 +1420,13 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1479,13 +1479,13 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="chrome40" class="tally" data-tally="0" data-flagged-tally="0.4">0/5</td>
 <td data-browser="chrome41" class="tally" data-tally="0.4">2/5</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="webkit" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/5</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
 <td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.4">0/5</td>
@@ -1542,13 +1542,13 @@ return ({ [x]: 1 }).y === 1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1605,13 +1605,13 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag</td>
@@ -1667,13 +1667,13 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag</td>
@@ -1730,13 +1730,13 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1799,13 +1799,13 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -1858,13 +1858,13 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome41" class="tally" data-tally="1">4/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.25">1/4</td>
 <td data-browser="webkit" class="tally" data-tally="0.25">1/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="1">4/4</td>
@@ -1922,13 +1922,13 @@ for (var item of arr)
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -1987,13 +1987,13 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2054,13 +2054,13 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2121,13 +2121,13 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2180,13 +2180,13 @@ return result === &quot;123&quot;;
 <td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome41" class="tally" data-tally="1">4/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="1">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="1">4/4</td>
@@ -2242,13 +2242,13 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2304,13 +2304,13 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2366,13 +2366,13 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2428,13 +2428,13 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2487,13 +2487,13 @@ return Number(&apos;0b1&apos;) === 1;
 <td data-browser="chrome40" class="tally" data-tally="0">0/2</td>
 <td data-browser="chrome41" class="tally" data-tally="0" data-flagged-tally="1">0/2</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/2</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/2</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/2</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/2</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/2</td>
 <td data-browser="opera" class="tally" data-tally="0">0/2</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/2</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/2</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/2</td>
 <td data-browser="node" class="tally" data-tally="0">0/2</td>
 <td data-browser="iojs" class="tally" data-tally="1">2/2</td>
@@ -2551,13 +2551,13 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2624,13 +2624,13 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -2683,13 +2683,13 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td data-browser="chrome40" class="tally" data-tally="0">0/2</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/2</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/2</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/2</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/2</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/2</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/2</td>
 <td data-browser="opera" class="tally" data-tally="0">0/2</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/2</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/2</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/2</td>
 <td data-browser="node" class="tally" data-tally="0">0/2</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/2</td>
@@ -2749,13 +2749,13 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;x&apos; &amp;&amp; re2.exec(&apos;x
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -2811,13 +2811,13 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -2870,13 +2870,13 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td data-browser="chrome40" class="tally" data-tally="0">0/15</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/15</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/15</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/15</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.4666666666666667">7/15</td>
 <td data-browser="webkit" class="tally" data-tally="0.5333333333333333">8/15</td>
 <td data-browser="opera" class="tally" data-tally="0">0/15</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/15</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/15</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/15</td>
 <td data-browser="node" class="tally" data-tally="0">0/15</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/15</td>
@@ -2933,13 +2933,13 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -2996,13 +2996,13 @@ return a === &quot;b&quot; &amp;&amp; b === &quot;a&quot; &amp;&amp; c === &quot
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3060,13 +3060,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3124,13 +3124,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3187,13 +3187,13 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3251,13 +3251,13 @@ return grault === &quot;garply&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3314,13 +3314,13 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3377,13 +3377,13 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3442,13 +3442,13 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3506,13 +3506,13 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3570,13 +3570,13 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3635,13 +3635,13 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3699,13 +3699,13 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3762,13 +3762,13 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3827,13 +3827,13 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5, z:f}) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3889,13 +3889,13 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -3950,13 +3950,13 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td data-browser="chrome40" class="tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
 <td data-browser="chrome41" class="tally" data-tally="0.625">5/8</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.125">1/8</td>
-<td data-browser="safari6" class="tally" data-tally="0.125">1/8</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.125">1/8</td>
 <td data-browser="safari7" class="tally" data-tally="0.125">1/8</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.125">1/8</td>
 <td data-browser="webkit" class="tally" data-tally="0.125">1/8</td>
 <td data-browser="opera" class="tally" data-tally="0.125">1/8</td>
 <td data-browser="konq49" class="tally" data-tally="0.25">2/8</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/8</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="phantom" class="tally" data-tally="0.125">1/8</td>
 <td data-browser="node" class="tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
 <td data-browser="iojs" class="tally" data-tally="0.625">5/8</td>
@@ -4013,13 +4013,13 @@ return (foo === 123);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4077,13 +4077,13 @@ return bar === 123;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4144,13 +4144,13 @@ try {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4208,13 +4208,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4272,13 +4272,13 @@ return (foo === 123);
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4337,13 +4337,13 @@ return bar === 123;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4405,13 +4405,13 @@ try {
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4470,13 +4470,13 @@ return passed;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4529,13 +4529,13 @@ return passed;
 <td data-browser="chrome40" class="tally" data-tally="0" data-flagged-tally="0.5">0/10</td>
 <td data-browser="chrome41" class="tally" data-tally="0.5">5/10</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/10</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/10</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/10</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/10</td>
 <td data-browser="opera" class="tally" data-tally="0">0/10</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/10</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/10</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/10</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
 <td data-browser="iojs" class="tally" data-tally="0.5">5/10</td>
@@ -4592,13 +4592,13 @@ return (foo === 123);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4656,13 +4656,13 @@ return bar === 123;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4720,13 +4720,13 @@ return baz === 1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4784,13 +4784,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4857,13 +4857,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -4921,13 +4921,13 @@ return (foo === 123);
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -4986,13 +4986,13 @@ return bar === 123;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -5051,13 +5051,13 @@ return baz === 1;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -5116,13 +5116,13 @@ return passed;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -5190,13 +5190,13 @@ return passed;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -5257,13 +5257,13 @@ return f() === 1;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -5318,13 +5318,13 @@ return f() === 1;
 <td data-browser="chrome40" class="tally" data-tally="0">0/9</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/9</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/9</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/9</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/9</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/9</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/9</td>
 <td data-browser="opera" class="tally" data-tally="0">0/9</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/9</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/9</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/9</td>
 <td data-browser="node" class="tally" data-tally="0">0/9</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/9</td>
@@ -5380,13 +5380,13 @@ return (() =&gt; 5)() === 5;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5443,13 +5443,13 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5506,13 +5506,13 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5570,13 +5570,13 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5634,13 +5634,13 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5698,13 +5698,13 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5761,13 +5761,13 @@ return f(6) === 5;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5825,13 +5825,13 @@ return (() =&gt; {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5888,13 +5888,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -5947,13 +5947,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td data-browser="chrome40" class="tally" data-tally="0">0/11</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/11</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/11</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/11</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/11</td>
 <td data-browser="opera" class="tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/11</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
 <td data-browser="node" class="tally" data-tally="0">0/11</td>
 <td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="1">0/11</td>
@@ -6010,13 +6010,13 @@ return typeof C === &quot;function&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6078,13 +6078,13 @@ return C === c1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6140,13 +6140,13 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6206,13 +6206,13 @@ return C.prototype.constructor === C
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6272,13 +6272,13 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6338,13 +6338,13 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6406,13 +6406,13 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6474,13 +6474,13 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6540,13 +6540,13 @@ return c();
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6606,13 +6606,13 @@ return c instanceof Array
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6672,13 +6672,13 @@ return !(c instanceof Object)
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6731,13 +6731,13 @@ return !(c instanceof Object)
 <td data-browser="chrome40" class="tally" data-tally="0">0/4</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.75">0/4</td>
@@ -6800,13 +6800,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -6867,13 +6867,13 @@ return new B(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -6934,13 +6934,13 @@ return new B().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -7005,13 +7005,13 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag<a href="#strict-required-note"><sup>[10]</sup></a></td>
@@ -7064,13 +7064,13 @@ return obj.qux() === &quot;barley&quot;;
 <td data-browser="chrome40" class="tally" data-tally="0.7692307692307693" data-flagged-tally="0.8461538461538461">10/13</td>
 <td data-browser="chrome41" class="tally" data-tally="0.8461538461538461">11/13</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/13</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/13</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/13</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/13</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/13</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/13</td>
 <td data-browser="opera" class="tally" data-tally="0">0/13</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/13</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/13</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/13</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/13</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5384615384615384">0/13</td>
 <td data-browser="iojs" class="tally" data-tally="0.6153846153846154" data-flagged-tally="0.6923076923076923">8/13</td>
@@ -7136,13 +7136,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7208,13 +7208,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7278,13 +7278,13 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7349,13 +7349,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7422,13 +7422,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7494,13 +7494,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -7563,13 +7563,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7634,13 +7634,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7705,13 +7705,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -7778,13 +7778,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="no" data-browser="iojs">No</td>
@@ -7851,13 +7851,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -7925,13 +7925,13 @@ return passed;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag</td>
@@ -8000,13 +8000,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -8061,13 +8061,13 @@ return passed;
 <td data-browser="chrome40" class="tally" data-tally="0.525">21/40</td>
 <td data-browser="chrome41" class="tally" data-tally="0.525">21/40</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.4">16/40</td>
-<td data-browser="safari6" class="tally" data-tally="0.45">18/40</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.45">18/40</td>
 <td data-browser="safari7" class="tally" data-tally="0.45">18/40</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.45">18/40</td>
 <td data-browser="webkit" class="tally" data-tally="0.45">18/40</td>
 <td data-browser="opera" class="tally" data-tally="0.45">18/40</td>
 <td data-browser="konq49" class="tally" data-tally="0.2">8/40</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/40</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/40</td>
 <td data-browser="phantom" class="tally" data-tally="0.4">16/40</td>
 <td data-browser="node" class="tally" data-tally="0.45">18/40</td>
 <td data-browser="iojs" class="tally" data-tally="0.525">21/40</td>
@@ -8125,13 +8125,13 @@ return view[0] === -0x80;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8189,13 +8189,13 @@ return view[0] === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8253,13 +8253,13 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8317,13 +8317,13 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8381,13 +8381,13 @@ return view[0] === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8445,13 +8445,13 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8509,13 +8509,13 @@ return view[0] === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8573,13 +8573,13 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8637,13 +8637,13 @@ return view[0] === 0.1;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8702,13 +8702,13 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8767,13 +8767,13 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8832,13 +8832,13 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8897,13 +8897,13 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -8962,13 +8962,13 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -9027,13 +9027,13 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -9092,13 +9092,13 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -9157,13 +9157,13 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -9227,13 +9227,13 @@ return typeof Int8Array.from === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9297,13 +9297,13 @@ return typeof Int8Array.of === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9367,13 +9367,13 @@ return typeof Int8Array.prototype.subarray === &quot;function&quot; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -9437,13 +9437,13 @@ return typeof Int8Array.prototype.join === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9507,13 +9507,13 @@ return typeof Int8Array.prototype.indexOf === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9577,13 +9577,13 @@ return typeof Int8Array.prototype.lastIndexOf === &quot;function&quot; &amp;&amp
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9647,13 +9647,13 @@ return typeof Int8Array.prototype.slice === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9717,13 +9717,13 @@ return typeof Int8Array.prototype.every === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9787,13 +9787,13 @@ return typeof Int8Array.prototype.filter === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9857,13 +9857,13 @@ return typeof Int8Array.prototype.forEach === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9927,13 +9927,13 @@ return typeof Int8Array.prototype.map === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -9997,13 +9997,13 @@ return typeof Int8Array.prototype.reduce === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10067,13 +10067,13 @@ return typeof Int8Array.prototype.reduceRight === &quot;function&quot; &amp;&amp
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10137,13 +10137,13 @@ return typeof Int8Array.prototype.reverse === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10207,13 +10207,13 @@ return typeof Int8Array.prototype.some === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10277,13 +10277,13 @@ return typeof Int8Array.prototype.sort === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10347,13 +10347,13 @@ return typeof Int8Array.prototype.copyWithin === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10417,13 +10417,13 @@ return typeof Int8Array.prototype.find === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10487,13 +10487,13 @@ return typeof Int8Array.prototype.findIndex === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10557,13 +10557,13 @@ return typeof Int8Array.prototype.fill === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -10627,13 +10627,13 @@ return typeof Int8Array.prototype.keys === &quot;function&quot; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -10697,13 +10697,13 @@ return typeof Int8Array.prototype.values === &quot;function&quot; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -10767,13 +10767,13 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -10826,13 +10826,13 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td data-browser="chrome40" class="tally" data-tally="1">11/11</td>
 <td data-browser="chrome41" class="tally" data-tally="1">11/11</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/11</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="webkit" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="opera" class="tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/11</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
 <td data-browser="iojs" class="tally" data-tally="1">11/11</td>
@@ -10893,13 +10893,13 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -10960,13 +10960,13 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11023,13 +11023,13 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11091,13 +11091,13 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11158,13 +11158,13 @@ return map.size === 1;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11220,13 +11220,13 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11282,13 +11282,13 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11344,13 +11344,13 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11406,13 +11406,13 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11468,13 +11468,13 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11530,13 +11530,13 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11589,13 +11589,13 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="1">11/11</td>
 <td data-browser="chrome41" class="tally" data-tally="1">11/11</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/11</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="webkit" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="opera" class="tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/11</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
 <td data-browser="iojs" class="tally" data-tally="1">11/11</td>
@@ -11657,13 +11657,13 @@ return set.has(123);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11723,13 +11723,13 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11786,13 +11786,13 @@ return set.add(0) === set;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11854,13 +11854,13 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11923,13 +11923,13 @@ return set.size === 2;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -11985,13 +11985,13 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12047,13 +12047,13 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12109,13 +12109,13 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12171,13 +12171,13 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12233,13 +12233,13 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12295,13 +12295,13 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12354,13 +12354,13 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome41" class="tally" data-tally="1">4/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="webkit" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="1">4/4</td>
@@ -12421,13 +12421,13 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12488,13 +12488,13 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12552,13 +12552,13 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12614,13 +12614,13 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12673,13 +12673,13 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome41" class="tally" data-tally="1">4/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="1">4/4</td>
@@ -12741,13 +12741,13 @@ return weakset.has(obj1);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12806,13 +12806,13 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12870,13 +12870,13 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12932,13 +12932,13 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -12991,13 +12991,13 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="0">0/20</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/20</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/20</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/20</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/20</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/20</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/20</td>
 <td data-browser="opera" class="tally" data-tally="0">0/20</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/20</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/20</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/20</td>
 <td data-browser="node" class="tally" data-tally="0">0/20</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/20</td>
@@ -13059,13 +13059,13 @@ return proxy.foo === 5;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13127,13 +13127,13 @@ return proxy.foo === 5;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13197,13 +13197,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13267,13 +13267,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13336,13 +13336,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13405,13 +13405,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13474,13 +13474,13 @@ var proxied = {};
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13549,13 +13549,13 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13623,13 +13623,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13692,13 +13692,13 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13766,13 +13766,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13837,13 +13837,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13909,13 +13909,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -13983,13 +13983,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14054,13 +14054,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14126,13 +14126,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14196,13 +14196,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14266,13 +14266,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14328,13 +14328,13 @@ return Array.isArray(new Proxy([], {}));
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14390,13 +14390,13 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14449,13 +14449,13 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td data-browser="chrome40" class="tally" data-tally="0">0/14</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/14</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/14</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/14</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/14</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/14</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/14</td>
 <td data-browser="opera" class="tally" data-tally="0">0/14</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/14</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/14</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/14</td>
 <td data-browser="node" class="tally" data-tally="0">0/14</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/14</td>
@@ -14511,13 +14511,13 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14575,13 +14575,13 @@ return obj.quux === 654;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14637,13 +14637,13 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14701,13 +14701,13 @@ return !(&quot;bar&quot; in obj);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14766,13 +14766,13 @@ return desc.value === 789 &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14830,13 +14830,13 @@ return obj.foo === 123;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14892,13 +14892,13 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -14956,13 +14956,13 @@ return obj instanceof Array;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15019,13 +15019,13 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15083,13 +15083,13 @@ return !Object.isExtensible(obj);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15154,13 +15154,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15217,13 +15217,13 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15279,13 +15279,13 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15343,13 +15343,13 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -15402,13 +15402,13 @@ return Reflect.construct(function(a, b, c) {
 <td data-browser="chrome40" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome41" class="tally" data-tally="1">3/3</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/3</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/3</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.3333333333333333">1/3</td>
 <td data-browser="webkit" class="tally" data-tally="1">3/3</td>
 <td data-browser="opera" class="tally" data-tally="0">0/3</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/3</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/3</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/3</td>
 <td data-browser="node" class="tally" data-tally="0">0/3</td>
 <td data-browser="iojs" class="tally" data-tally="1">3/3</td>
@@ -15485,13 +15485,13 @@ function check() {
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15561,13 +15561,13 @@ function check() {
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15637,13 +15637,13 @@ function check() {
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15696,13 +15696,13 @@ function check() {
 <td data-browser="chrome40" class="tally" data-tally="0.8888888888888888">8/9</td>
 <td data-browser="chrome41" class="tally" data-tally="0.8888888888888888">8/9</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/9</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/9</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/9</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/9</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/9</td>
 <td data-browser="opera" class="tally" data-tally="0">0/9</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/9</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/9</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/9</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.6666666666666666">0/9</td>
 <td data-browser="iojs" class="tally" data-tally="0.8888888888888888">8/9</td>
@@ -15762,13 +15762,13 @@ return object[symbol] === value;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15824,13 +15824,13 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15898,13 +15898,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -15969,13 +15969,13 @@ return passed;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16044,13 +16044,13 @@ return true;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16106,13 +16106,13 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16173,13 +16173,13 @@ try {
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16240,13 +16240,13 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -16304,13 +16304,13 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16363,13 +16363,13 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="chrome40" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
 <td data-browser="chrome41" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/7</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/7</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/7</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/7</td>
 <td data-browser="opera" class="tally" data-tally="0">0/7</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/7</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/7</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/7</td>
 <td data-browser="node" class="tally" data-tally="0">0/7</td>
 <td data-browser="iojs" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
@@ -16432,13 +16432,13 @@ return passed;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -16497,13 +16497,13 @@ return a[0] === b;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -16572,13 +16572,13 @@ return c === &quot;foo&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16636,13 +16636,13 @@ return RegExp[Symbol.species] === RegExp
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -16707,13 +16707,13 @@ return passed === 3;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -16771,13 +16771,13 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no flagged" data-browser="iojs">Flag</td>
@@ -16837,13 +16837,13 @@ with (a) {
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -16898,13 +16898,13 @@ with (a) {
 <td data-browser="chrome40" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="chrome41" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/4</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0.25">1/4</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/4</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0.25" data-flagged-tally="0.75">1/4</td>
 <td data-browser="iojs" class="tally" data-tally="0.75">3/4</td>
@@ -16961,13 +16961,13 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17025,13 +17025,13 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17090,13 +17090,13 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17152,13 +17152,13 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17211,13 +17211,13 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td data-browser="chrome40" class="tally" data-tally="0.125" data-flagged-tally="0.1875">2/16</td>
 <td data-browser="chrome41" class="tally" data-tally="0.1875">3/16</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="safari6" class="tally" data-tally="0.1875">3/16</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.1875">3/16</td>
 <td data-browser="safari7" class="tally" data-tally="0.1875">3/16</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.1875">3/16</td>
 <td data-browser="webkit" class="tally" data-tally="0.1875">3/16</td>
 <td data-browser="opera" class="tally" data-tally="0.125">2/16</td>
 <td data-browser="konq49" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="rhino17" class="tally" data-tally="0.1875">3/16</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0.1875">3/16</td>
 <td data-browser="phantom" class="tally" data-tally="0.1875">3/16</td>
 <td data-browser="node" class="tally" data-tally="0.125">2/16</td>
 <td data-browser="iojs" class="tally" data-tally="0.1875">3/16</td>
@@ -17275,13 +17275,13 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes" data-browser="rhino17">Yes</td>
+<td class="yes obsolete" data-browser="rhino17">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17338,13 +17338,13 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes" data-browser="rhino17">Yes</td>
+<td class="yes obsolete" data-browser="rhino17">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17400,13 +17400,13 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes" data-browser="rhino17">Yes</td>
+<td class="yes obsolete" data-browser="rhino17">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17464,13 +17464,13 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17528,13 +17528,13 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17594,13 +17594,13 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17659,13 +17659,13 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17722,13 +17722,13 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -17792,13 +17792,13 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17857,13 +17857,13 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17920,13 +17920,13 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -17987,13 +17987,13 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -18053,13 +18053,13 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -18116,13 +18116,13 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -18179,13 +18179,13 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -18244,13 +18244,13 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -18306,13 +18306,13 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18365,13 +18365,13 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="0" data-flagged-tally="0.5">0/2</td>
 <td data-browser="chrome41" class="tally" data-tally="0.5" data-flagged-tally="1">1/2</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/2</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/2</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/2</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/2</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/2</td>
 <td data-browser="opera" class="tally" data-tally="0">0/2</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/2</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/2</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/2</td>
 <td data-browser="node" class="tally" data-tally="0">0/2</td>
 <td data-browser="iojs" class="tally" data-tally="1">2/2</td>
@@ -18427,13 +18427,13 @@ return typeof String.raw === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18489,13 +18489,13 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18548,13 +18548,13 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td data-browser="chrome40" class="tally" data-tally="0.16666666666666666" data-flagged-tally="0.8333333333333334">1/6</td>
 <td data-browser="chrome41" class="tally" data-tally="1">6/6</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/6</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/6</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/6</td>
 <td data-browser="webkit" class="tally" data-tally="0.6666666666666666">4/6</td>
 <td data-browser="opera" class="tally" data-tally="0">0/6</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/6</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/6</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/6</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/6</td>
 <td data-browser="iojs" class="tally" data-tally="1">6/6</td>
@@ -18610,13 +18610,13 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18674,13 +18674,13 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18737,13 +18737,13 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18800,13 +18800,13 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18863,13 +18863,13 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18926,13 +18926,13 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no" data-browser="chrome40">No<a href="#string-contains-note"><sup>[17]</sup></a></td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -18985,13 +18985,13 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td data-browser="chrome40" class="tally" data-tally="0">0/5</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/5</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/5</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/5</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/5</td>
@@ -19047,13 +19047,13 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19109,13 +19109,13 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19171,13 +19171,13 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19233,13 +19233,13 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19295,13 +19295,13 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19354,13 +19354,13 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td data-browser="chrome40" class="tally" data-tally="0">0/6</td>
 <td data-browser="chrome41" class="tally" data-tally="0">0/6</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/6</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/6</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/6</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/6</td>
 <td data-browser="opera" class="tally" data-tally="0">0/6</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/6</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/6</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/6</td>
 <td data-browser="node" class="tally" data-tally="0">0/6</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/6</td>
@@ -19416,13 +19416,13 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19479,13 +19479,13 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19542,13 +19542,13 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19605,13 +19605,13 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19668,13 +19668,13 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19731,13 +19731,13 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19790,13 +19790,13 @@ return C.of(0) instanceof C;
 <td data-browser="chrome40" class="tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
 <td data-browser="chrome41" class="tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/8</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/8</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/8</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.625">5/8</td>
 <td data-browser="webkit" class="tally" data-tally="0.625">5/8</td>
 <td data-browser="opera" class="tally" data-tally="0">0/8</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/8</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/8</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/8</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td data-browser="iojs" class="tally" data-tally="0.375">3/8</td>
@@ -19852,13 +19852,13 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19914,13 +19914,13 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="no" data-browser="iojs">No</td>
@@ -19976,13 +19976,13 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="no" data-browser="iojs">No</td>
@@ -20038,13 +20038,13 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="no flagged" data-browser="chrome40">Flag</td>
 <td class="no flagged" data-browser="chrome41">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="no" data-browser="iojs">No</td>
@@ -20100,13 +20100,13 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20162,13 +20162,13 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no" data-browser="chrome40">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="no" data-browser="chrome41">No<a href="#array-prototype-iterator-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="no" data-browser="iojs">No</td>
@@ -20224,13 +20224,13 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20294,13 +20294,13 @@ return true;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20353,13 +20353,13 @@ return true;
 <td data-browser="chrome40" class="tally" data-tally="1">7/7</td>
 <td data-browser="chrome41" class="tally" data-tally="1">7/7</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/7</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/7</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/7</td>
 <td data-browser="webkit" class="tally" data-tally="1">7/7</td>
 <td data-browser="opera" class="tally" data-tally="0">0/7</td>
 <td data-browser="konq49" class="tally" data-tally="0.8571428571428571">6/7</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/7</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/7</td>
 <td data-browser="node" class="tally" data-tally="0.2857142857142857" data-flagged-tally="1">2/7</td>
 <td data-browser="iojs" class="tally" data-tally="1">7/7</td>
@@ -20415,13 +20415,13 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20477,13 +20477,13 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20539,13 +20539,13 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20601,13 +20601,13 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20663,13 +20663,13 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20725,13 +20725,13 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20787,13 +20787,13 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20846,13 +20846,13 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td data-browser="chrome40" class="tally" data-tally="1">17/17</td>
 <td data-browser="chrome41" class="tally" data-tally="1">17/17</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/17</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/17</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="safari7" class="tally" data-tally="0.058823529411764705">1/17</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.8823529411764706">15/17</td>
 <td data-browser="webkit" class="tally" data-tally="0.9411764705882353">16/17</td>
 <td data-browser="opera" class="tally" data-tally="0">0/17</td>
 <td data-browser="konq49" class="tally" data-tally="0.8235294117647058">14/17</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/17</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/17</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="1">0/17</td>
 <td data-browser="iojs" class="tally" data-tally="1">17/17</td>
@@ -20908,13 +20908,13 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -20970,13 +20970,13 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21032,13 +21032,13 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21094,13 +21094,13 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21156,13 +21156,13 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21218,13 +21218,13 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21280,13 +21280,13 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21342,13 +21342,13 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21404,13 +21404,13 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21466,13 +21466,13 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21528,13 +21528,13 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21590,13 +21590,13 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21652,13 +21652,13 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21714,13 +21714,13 @@ return typeof Math.hypot === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21776,13 +21776,13 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21838,13 +21838,13 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21900,13 +21900,13 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no flagged" data-browser="node">Flag</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -21961,13 +21961,13 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td data-browser="chrome40" class="tally" data-tally="0.2">2/10</td>
 <td data-browser="chrome41" class="tally" data-tally="0.2">2/10</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
-<td data-browser="safari6" class="tally" data-tally="0">0/10</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/10</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/10</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/10</td>
 <td data-browser="opera" class="tally" data-tally="0">0/10</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/10</td>
-<td data-browser="rhino17" class="tally" data-tally="0">0/10</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/10</td>
 <td data-browser="node" class="tally" data-tally="0">0/10</td>
 <td data-browser="iojs" class="tally" data-tally="0.2">2/10</td>
@@ -22023,13 +22023,13 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22085,13 +22085,13 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22149,13 +22149,13 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -22211,13 +22211,13 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22273,13 +22273,13 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22335,13 +22335,13 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22397,13 +22397,13 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22459,13 +22459,13 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22521,13 +22521,13 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22584,13 +22584,13 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -22643,13 +22643,13 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td data-browser="chrome40" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="chrome41" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="safari6" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="safari7" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="webkit" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="opera" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="konq49" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="rhino17" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="phantom" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="node" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="iojs" class="tally" data-tally="0.2857142857142857">2/7</td>
@@ -22706,13 +22706,13 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22768,13 +22768,13 @@ do {} while (false) return true;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="yes" data-browser="rhino17">Yes</td>
+<td class="yes obsolete" data-browser="rhino17">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -22835,13 +22835,13 @@ catch(e) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22901,13 +22901,13 @@ try {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -22963,13 +22963,13 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes" data-browser="rhino17">Yes</td>
+<td class="yes obsolete" data-browser="rhino17">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes" data-browser="node">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
@@ -23025,13 +23025,13 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -23102,13 +23102,13 @@ return Array.prototype.length === undefined;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="iojs">No</td>
@@ -23173,13 +23173,13 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">No</td>
@@ -23232,13 +23232,13 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td data-browser="chrome40" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="chrome41" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="safari6" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.2">1/5</td>
 <td data-browser="safari7" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.4">2/5</td>
 <td data-browser="webkit" class="tally" data-tally="0.4">2/5</td>
 <td data-browser="opera" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="konq49" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="rhino17" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
+<td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="0.2">1/5</td>
 <td data-browser="phantom" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
 <td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
 <td data-browser="iojs" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
@@ -23295,13 +23295,13 @@ return { __proto__ : [] } instanceof Array
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>
@@ -23362,13 +23362,13 @@ catch(e) {
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">No</td>
@@ -23428,13 +23428,13 @@ return !({ [a] : [] } instanceof Array);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">No</td>
@@ -23494,13 +23494,13 @@ return !({ __proto__ } instanceof Array);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">No</td>
@@ -23559,13 +23559,13 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no" data-browser="chrome40">No</td>
 <td class="no" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="no" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">No</td>
@@ -23618,13 +23618,13 @@ return !({ __proto__(){} } instanceof Function);
 <td data-browser="chrome40" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome41" class="tally" data-tally="1">3/3</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="safari6" class="tally" data-tally="1">3/3</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="safari7" class="tally" data-tally="1">3/3</td>
 <td data-browser="safari71_8" class="tally" data-tally="1">3/3</td>
 <td data-browser="webkit" class="tally" data-tally="1">3/3</td>
 <td data-browser="opera" class="tally" data-tally="1">3/3</td>
 <td data-browser="konq49" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="rhino17" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
+<td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="1">3/3</td>
 <td data-browser="phantom" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
 <td data-browser="iojs" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
@@ -23681,13 +23681,13 @@ return (new A()).__proto__ === A.prototype;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>
@@ -23745,13 +23745,13 @@ return o instanceof Array;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>
@@ -23814,13 +23814,13 @@ return (desc
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="no not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">No</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>
@@ -23883,13 +23883,13 @@ return true;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>
@@ -23945,13 +23945,13 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes" data-browser="chrome40">Yes</td>
 <td class="yes" data-browser="chrome41">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
-<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes obsolete" data-browser="safari6">Yes</td>
 <td class="yes" data-browser="safari7">Yes</td>
 <td class="yes" data-browser="safari71_8">Yes</td>
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes" data-browser="opera">Yes</td>
 <td class="yes" data-browser="konq49">Yes</td>
-<td class="yes not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="phantom" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="node" title="This feature is optional on non-browser platforms.">Yes</td>
 <td class="yes not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms.">Yes</td>

--- a/es6/skeleton.html
+++ b/es6/skeleton.html
@@ -84,8 +84,8 @@
         <tr>
           <th colspan="3"  class="platformtype"></th>
           <th colspan="7"  class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers/polyfills</th>
-          <th colspan="16" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
-          <th colspan="5"  class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
+          <th colspan="15" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
+          <th colspan="4"  class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
           <th colspan="2"  class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
         </tr>
         <tr>

--- a/es7/index.html
+++ b/es7/index.html
@@ -80,7 +80,7 @@
 <th class="platform safari78 desktop" data-browser="safari78"><a href="#safari78" class="browser-name"><abbr title="Safari 7.0, Safari 7.1, Safari 8">SF 7, SF 8</abbr></a></th>
 <th class="platform webkit desktop" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r168571">WK</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.13">KQ 4.13</abbr></a></th>
-<th class="platform rhino17 engine" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
+<th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">PH</abbr></a></th>
 <th class="platform node engine" data-browser="node"><a href="#node" class="browser-name"><abbr title="Node 0.10">Node</abbr></a></th>
 <th class="platform nodeharmony desktop" data-browser="nodeharmony"><a href="#nodeharmony" class="browser-name"><abbr title="Node 0.11.11 harmony">Node harmony</abbr><a href="#harmony-flag-note"><sup>[2]</sup></a></a></th>
@@ -112,7 +112,7 @@ return 2 ** 3 === 8;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -140,7 +140,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -168,7 +168,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -198,7 +198,7 @@ return (async function(){
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -226,7 +226,7 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -254,7 +254,7 @@ return typeof StructType !== &apos;undefined&apos;;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -282,7 +282,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="yes" data-browser="nodeharmony">Yes</td>
@@ -310,7 +310,7 @@ return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -338,7 +338,7 @@ return typeof Array.prototype.includes === &apos;function&apos;;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>
@@ -379,7 +379,7 @@ return true;
 <td class="no" data-browser="safari78">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="no" data-browser="konq49">No</td>
-<td class="no" data-browser="rhino17">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
 <td class="no" data-browser="nodeharmony">No</td>


### PR DESCRIPTION
OS X 10.8 was EOL'd some time last year (and even if it hasn't, SF 6.1 is the current version for 10.8). 

Also hyphenated certain platform names.
