### PR TITLE
Add tests for some IE bugs

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -3001,6 +3001,27 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'Support frozen objects as keys': {
+      exec: function () {/*
+        var f = Object.freeze({});
+        var m = new WeakMap;
+        m.set(f, 42);
+        return m.get(f) === 42;
+      */},
+      res: {
+        _6to5:       true,
+        ejs:         true,
+        ie11tp:      true,
+        firefox11:   true,
+        chrome21dev: flag,
+        chrome36:    true,
+        safari71_8:  true,
+        ios8:        true,
+        webkit:      true,
+        node:        flag,
+        iojs:        true,
+      },
+    },
   },
 },
 {
@@ -3570,8 +3591,9 @@ exports.tests = [
         var obj = { foo: 1, bar: 2 };
         var iterator = Reflect.enumerate(obj);
 
+        var passed = Symbol.iterator in item;
         var item = iterator.next();
-        var passed = item.value === "foo" && item.done === false;
+        passed    &= item.value === "foo" && item.done === false;
         item = iterator.next();
         passed    &= item.value === "bar" && item.done === false;
         item = iterator.next();
@@ -3581,7 +3603,6 @@ exports.tests = [
       res: {
         _6to5:       true,
         ejs:         true,
-        ie11tp:      true,
       },
     },
     'Reflect.ownKeys': {
@@ -5717,22 +5738,6 @@ exports.tests = [
         iojs:        true,
         ios8:        true,
       },
-      'hypot': {
-        ejs:         true,
-        _6to5:       true,
-        tr:          true,
-        es6shim:     true,
-        ie11tp:      true,
-        firefox27:   true,
-        chrome34:    flag,
-        chrome38:    true,
-        safari71_8:  true,
-        webkit:      true,
-        konq49:      true,
-        node:        flag,
-        iojs:        true,
-        ios8:        true,
-      },
       'trunc': {
         ejs:         true,
         _6to5:       true,
@@ -5796,6 +5801,26 @@ exports.tests = [
         res: methods[m]
       }
     };
+    obj['Math.hypot'] = {
+      exec: function(){/*
+        return Math.hypot(1) === 1 && Math.hypot(9, 12, 20) === 25
+      */},
+      res: {
+        ejs:         true,
+        _6to5:       true,
+        tr:          true,
+        es6shim:     true,
+        firefox27:   true,
+        chrome34:    flag,
+        chrome38:    true,
+        safari71_8:  true,
+        webkit:      true,
+        konq49:      true,
+        node:        flag,
+        iojs:        true,
+        ios8:        true,
+      }
+    }
     return obj;
   }()),
 },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3590,8 +3590,10 @@ exports.tests = [
       exec: function() {/*
         var obj = { foo: 1, bar: 2 };
         var iterator = Reflect.enumerate(obj);
-        var passed = 1
-        if(typeof Symbol != undefined && 'iterator' in Symbol)passed &= Symbol.iterator in iterator;
+        var passed = 1;
+        if (typeof Symbol != undefined && 'iterator' in Symbol) {
+          passed &= Symbol.iterator in iterator;
+        }
         var item = iterator.next();
         passed    &= item.value === "foo" && item.done === false;
         item = iterator.next();
@@ -5803,7 +5805,9 @@ exports.tests = [
     };
     obj['Math.hypot'] = {
       exec: function(){/*
-        return Math.hypot(1) === 1 && Math.hypot(9, 12, 20) === 25
+        return Math.hypot() === 0 && 
+          Math.hypot(1) === 1 &&
+          Math.hypot(9, 12, 20) === 25;
       */},
       res: {
         ejs:         true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -3590,8 +3590,8 @@ exports.tests = [
       exec: function() {/*
         var obj = { foo: 1, bar: 2 };
         var iterator = Reflect.enumerate(obj);
-
-        var passed = Symbol.iterator in item;
+        var passed = 1
+        if(typeof Symbol != undefined && 'iterator' in Symbol)passed &= Symbol.iterator in iterator;
         var item = iterator.next();
         passed    &= item.value === "foo" && item.done === false;
         item = iterator.next();

--- a/es6/index.html
+++ b/es6/index.html
@@ -15504,8 +15504,8 @@ return !Object.isExtensible(obj);
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.enumerate</span><script data-source="
 var obj = { foo: 1, bar: 2 };
 var iterator = Reflect.enumerate(obj);
-
-var passed = Symbol.iterator in item;
+var passed = 1
+if(typeof Symbol != undefined &amp;&amp; &apos;iterator&apos; in Symbol)passed &amp;= Symbol.iterator in iterator;
 var item = iterator.next();
 passed    &amp;= item.value === &quot;foo&quot; &amp;&amp; item.done === false;
 item = iterator.next();
@@ -15513,7 +15513,7 @@ passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar passed = Symbol.iterator in item;\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1\nif(typeof Symbol != undefined && 'iterator' in Symbol)passed &= Symbol.iterator in iterator;\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -15504,8 +15504,10 @@ return !Object.isExtensible(obj);
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.enumerate</span><script data-source="
 var obj = { foo: 1, bar: 2 };
 var iterator = Reflect.enumerate(obj);
-var passed = 1
-if(typeof Symbol != undefined &amp;&amp; &apos;iterator&apos; in Symbol)passed &amp;= Symbol.iterator in iterator;
+var passed = 1;
+if (typeof Symbol != undefined &amp;&amp; &apos;iterator&apos; in Symbol) {
+  passed &amp;= Symbol.iterator in iterator;
+}
 var item = iterator.next();
 passed    &amp;= item.value === &quot;foo&quot; &amp;&amp; item.done === false;
 item = iterator.next();
@@ -15513,7 +15515,7 @@ passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1\nif(typeof Symbol != undefined && 'iterator' in Symbol)passed &= Symbol.iterator in iterator;\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1;\nif (typeof Symbol != undefined && 'iterator' in Symbol) {\n  passed &= Symbol.iterator in iterator;\n}\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22258,8 +22260,10 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.hypot</span><script data-source="
-return Math.hypot(1) === 1 &amp;&amp; Math.hypot(9, 12, 20) === 25
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nreturn Math.hypot(1) === 1 && Math.hypot(9, 12, 20) === 25\n      ")(asyncTestPassed);}catch(e){return false;}}());
+return Math.hypot() === 0 &amp;&amp; 
+  Math.hypot(1) === 1 &amp;&amp;
+  Math.hypot(9, 12, 20) === 25;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nreturn Math.hypot() === 0 && \n  Math.hypot(1) === 1 &&\n  Math.hypot(9, 12, 20) === 25;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -12649,63 +12649,63 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/4</td>
-<td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
-<td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
-<td data-browser="closure" class="tally" data-tally="0">0/4</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/4</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/4</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie11" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="ie11tp" class="tally" data-tally="1">4/4</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox35" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox36" class="tally" data-tally="1">4/4</td>
-<td data-browser="firefox37" class="tally" data-tally="1">4/4</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="1">4/4</td>
-<td data-browser="chrome39" class="tally" data-tally="1">4/4</td>
-<td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
-<td data-browser="chrome41" class="tally" data-tally="1">4/4</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/4</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="webkit" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="opera" class="tally" data-tally="0">0/4</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/4</td>
-<td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="iojs" class="tally" data-tally="1">4/4</td>
-<td data-browser="ejs" class="tally" data-tally="1">4/4</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/4</td>
-<td data-browser="ios8" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="tr" class="tally" data-tally="0">0/5</td>
+<td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
+<td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
+<td data-browser="closure" class="tally" data-tally="0">0/5</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/5</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/5</td>
+<td data-browser="es6shim" class="tally" data-tally="0">0/5</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/5</td>
+<td data-browser="ie11" class="tally" data-tally="0.4">2/5</td>
+<td data-browser="ie11tp" class="tally" data-tally="1">5/5</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.8">4/5</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8">4/5</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="firefox36" class="tally" data-tally="1">5/5</td>
+<td data-browser="firefox37" class="tally" data-tally="1">5/5</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/5</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/5</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="1">5/5</td>
+<td data-browser="chrome39" class="tally" data-tally="1">5/5</td>
+<td data-browser="chrome40" class="tally" data-tally="1">5/5</td>
+<td data-browser="chrome41" class="tally" data-tally="1">5/5</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/5</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="webkit" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="opera" class="tally" data-tally="0">0/5</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/5</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/5</td>
+<td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td data-browser="iojs" class="tally" data-tally="1">5/5</td>
+<td data-browser="ejs" class="tally" data-tally="1">5/5</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/5</td>
+<td data-browser="ios8" class="tally" data-tally="0.8">4/5</td>
 </tr>
 <tr class="subtest" data-parent="WeakMap"><td><span>basic functionality</span><script data-source="
 var key = {};
@@ -12967,6 +12967,71 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
+<tr class="subtest" data-parent="WeakMap"><td><span>Support frozen objects as keys</span><script data-source="
+var f = Object.freeze({});
+var m = new WeakMap;
+m.set(f, 42);
+return m.get(f) === 42;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");return Function("asyncTestPassed","\nvar f = Object.freeze({});\nvar m = new WeakMap;\nm.set(f, 42);\nreturn m.get(f) === 42;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="ie11tp">Yes</td>
+<td class="yes obsolete" data-browser="firefox11">Yes</td>
+<td class="yes obsolete" data-browser="firefox13">Yes</td>
+<td class="yes obsolete" data-browser="firefox16">Yes</td>
+<td class="yes obsolete" data-browser="firefox17">Yes</td>
+<td class="yes obsolete" data-browser="firefox18">Yes</td>
+<td class="yes obsolete" data-browser="firefox23">Yes</td>
+<td class="yes obsolete" data-browser="firefox24">Yes</td>
+<td class="yes obsolete" data-browser="firefox25">Yes</td>
+<td class="yes obsolete" data-browser="firefox27">Yes</td>
+<td class="yes obsolete" data-browser="firefox28">Yes</td>
+<td class="yes obsolete" data-browser="firefox29">Yes</td>
+<td class="yes obsolete" data-browser="firefox30">Yes</td>
+<td class="yes" data-browser="firefox31">Yes</td>
+<td class="yes obsolete" data-browser="firefox32">Yes</td>
+<td class="yes obsolete" data-browser="firefox33">Yes</td>
+<td class="yes obsolete" data-browser="firefox34">Yes</td>
+<td class="yes" data-browser="firefox35">Yes</td>
+<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox37">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no flagged obsolete" data-browser="chrome21dev">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome30">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome31">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome33">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome34">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome35">Flag</td>
+<td class="yes obsolete" data-browser="chrome36">Yes</td>
+<td class="yes obsolete" data-browser="chrome37">Yes</td>
+<td class="yes obsolete" data-browser="chrome38">Yes</td>
+<td class="yes" data-browser="chrome39">Yes</td>
+<td class="yes" data-browser="chrome40">Yes</td>
+<td class="yes" data-browser="chrome41">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="yes" data-browser="safari71_8">Yes</td>
+<td class="yes" data-browser="webkit">Yes</td>
+<td class="no" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no flagged" data-browser="node">Flag</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="yes" data-browser="ejs">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="yes" data-browser="ios8">Yes</td>
+</tr>
 <tr class="supertest"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
@@ -13034,7 +13099,7 @@ weakset.add(obj1);
 weakset.add(obj1);
 
 return weakset.has(obj1);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13099,7 +13164,7 @@ var obj1 = {}, obj2 = {};
 var weakset = new WeakSet([obj1, obj2]);
 
 return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13163,7 +13228,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 var weakset = new WeakSet();
 var obj = {};
 return weakset.add(obj) === weakset;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13225,7 +13290,7 @@ return weakset.add(obj) === weakset;
 </tr>
 <tr class="subtest" data-parent="WeakSet"><td><span>WeakSet.prototype.delete</span><script data-source="
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -13352,7 +13417,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13420,7 +13485,7 @@ var proxy = Object.create(new Proxy(proxied, {
   }
 }));
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13490,7 +13555,7 @@ var proxy = new Proxy(proxied, {
 });
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13560,7 +13625,7 @@ var proxy = Object.create(new Proxy(proxied, {
 }));
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13629,7 +13694,7 @@ var passed = false;
   }
 });
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13698,7 +13763,7 @@ var passed = false;
   }
 }));
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13767,7 +13832,7 @@ var proxied = {};
     }
   }).foo;
   return passed;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13842,7 +13907,7 @@ return (returnedDesc.value     === fakeDesc.value
   &amp;&amp; returnedDesc.configurable === fakeDesc.configurable
   &amp;&amp; returnedDesc.writable     === false
   &amp;&amp; returnedDesc.enumerable   === false);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13916,7 +13981,7 @@ Object.defineProperty(
   { value: 5, configurable: true }
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -13985,7 +14050,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return Object.getPrototypeOf(proxy) === fakeProto;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14059,7 +14124,7 @@ Object.setPrototypeOf(
   newProto
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14130,7 +14195,7 @@ Object.isExtensible(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14202,7 +14267,7 @@ Object.preventExtensions(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14276,7 +14341,7 @@ for (var i in
   })
 ) { }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14347,7 +14412,7 @@ Object.keys(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("217");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14419,7 +14484,7 @@ var host = {
 };
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("217");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14489,7 +14554,7 @@ new new Proxy(proxied, {
   }
 })(&quot;foo&quot;,&quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14559,7 +14624,7 @@ try {
   passed &amp;= e instanceof TypeError;
 }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14621,7 +14686,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>Array.isArray support</span><script data-source="
 return Array.isArray(new Proxy([], {}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14683,7 +14748,7 @@ return Array.isArray(new Proxy([], {}));
 </tr>
 <tr class="subtest" data-parent="Proxy"><td><span>JSON.stringify support</span><script data-source="
 return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quot;]&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -14753,7 +14818,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td data-browser="es6shim" class="tally" data-tally="0">0/14</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/14</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/14</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.9285714285714286">13/14</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8571428571428571">12/14</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/14</td>
@@ -14804,7 +14869,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.get</span><script data-source="
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14868,7 +14933,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 var obj = {};
 Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14930,7 +14995,7 @@ return obj.quux === 654;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.has</span><script data-source="
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -14994,7 +15059,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 var obj = { bar: 456 };
 Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15059,7 +15124,7 @@ var obj = { baz: 789 };
 var desc = Reflect.getOwnPropertyDescriptor(obj, &quot;baz&quot;);
 return desc.value === 789 &amp;&amp;
   desc.configurable &amp;&amp; desc.writable &amp;&amp; desc.enumerable;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15123,7 +15188,7 @@ return desc.value === 789 &amp;&amp;
 var obj = {};
 Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15185,7 +15250,7 @@ return obj.foo === 123;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.getPrototypeOf</span><script data-source="
 return Reflect.getPrototypeOf([]) === Array.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15249,7 +15314,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 var obj = {};
 Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("231");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
@@ -15312,7 +15377,7 @@ return obj instanceof Array;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.isExtensible</span><script data-source="
 return Reflect.isExtensible({}) &amp;&amp;
   !Reflect.isExtensible(Object.preventExtensions({}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("231");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15376,7 +15441,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 var obj = {};
 Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15440,14 +15505,15 @@ return !Object.isExtensible(obj);
 var obj = { foo: 1, bar: 2 };
 var iterator = Reflect.enumerate(obj);
 
+var passed = Symbol.iterator in item;
 var item = iterator.next();
-var passed = item.value === &quot;foo&quot; &amp;&amp; item.done === false;
+passed    &amp;= item.value === &quot;foo&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar item = iterator.next();\nvar passed = item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\n\nvar passed = Symbol.iterator in item;\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15458,7 +15524,7 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="ie11tp">Yes</td>
+<td class="no" data-browser="ie11tp">No</td>
 <td class="no obsolete" data-browser="firefox11">No</td>
 <td class="no obsolete" data-browser="firefox13">No</td>
 <td class="no obsolete" data-browser="firefox16">No</td>
@@ -15510,7 +15576,7 @@ return passed;
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.ownKeys</span><script data-source="
 var obj = { foo: 1, bar: 2 };
 return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nreturn Reflect.ownKeys(obj) + \"\" === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15572,7 +15638,7 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 </tr>
 <tr class="subtest" data-parent="Reflect"><td><span>Reflect.apply</span><script data-source="
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15636,7 +15702,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 return Reflect.construct(function(a, b, c) {
   this.qux = a + b + c;
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15778,7 +15844,7 @@ p1.then(function() {
 function check() {
   if (score === 4) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15854,7 +15920,7 @@ rejects.catch(function(result) { score += (result === &quot;qux&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -15930,7 +15996,7 @@ rejects.catch(function(result) { score += (result === &quot;baz&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16055,7 +16121,7 @@ var symbol = Symbol();
 var value = {};
 object[symbol] = value;
 return object[symbol] === value;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16117,7 +16183,7 @@ return object[symbol] === value;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>typeof support</span><script data-source="
 return typeof Symbol() === &quot;symbol&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no flagged" data-browser="_6to5">Flag</td>
@@ -16191,7 +16257,7 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16262,7 +16328,7 @@ if (Object.defineProperty) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16337,7 +16403,7 @@ try {
 } catch(e) {}
 
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16399,7 +16465,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Symbol"><td><span>can convert with String()</span><script data-source="
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16466,7 +16532,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16533,7 +16599,7 @@ var symbolObject = Object(symbol);
 return typeof symbolObject === &quot;object&quot; &amp;&amp;
   symbolObject == symbol &amp;&amp;
   symbolObject.valueOf() === symbol;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16597,7 +16663,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 var symbol = Symbol.for(&apos;foo&apos;);
 return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
    Symbol.keyFor(symbol) === &apos;foo&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16725,7 +16791,7 @@ Object.defineProperty(C, Symbol.hasInstance, {
 });
 obj instanceof C;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16790,7 +16856,7 @@ var a = [], b = [];
 b[Symbol.isConcatSpreadable] = false;
 a = a.concat(b);
 return a[0] === b;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -16865,7 +16931,7 @@ b[Symbol.iterator] = function() {
 var c;
 for (c of b) {}
 return c === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");return Function("asyncTestPassed","\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nvar a = 0, b = {};\nb[Symbol.iterator] = function() {\n  return {\n    next: function() {\n      return {\n        done: a++ === 1,\n        value: \"foo\"\n      };\n    }\n  };\n};\nvar c;\nfor (c of b) {}\nreturn c === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -16929,7 +16995,7 @@ return c === &quot;foo&quot;;
 return RegExp[Symbol.species] === RegExp
   &amp;&amp; Array[Symbol.species] === Array
   &amp;&amp; !(Symbol.species in Object);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17000,7 +17066,7 @@ a &gt;= 0;
 b in {};
 c == 0;
 return passed === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17064,7 +17130,7 @@ return passed === 3;
 var a = {};
 a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17130,7 +17196,7 @@ a[Symbol.unscopables] = { bar: true };
 with (a) {
   return foo === 1 &amp;&amp; typeof bar === &quot;undefined&quot;;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17254,7 +17320,7 @@ with (a) {
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.assign</span><script data-source="
 var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot; in o;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17318,7 +17384,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 return typeof Object.is === &apos;function&apos; &amp;&amp;
   Object.is(NaN, NaN) &amp;&amp;
  !Object.is(-0, 0);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17383,7 +17449,7 @@ var o = {};
 var sym = Symbol();
 o[sym] = &quot;foo&quot;;
 return Object.getOwnPropertySymbols(o)[0] === sym;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17445,7 +17511,7 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods"><td><span>Object.setPrototypeOf</span><script data-source="
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
@@ -17568,7 +17634,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 function foo(){};
 return foo.name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17631,7 +17697,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>function expressions</span><script data-source="
 return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -17693,7 +17759,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="function_name_property"><td><span>new Function</span><script data-source="
 return (new Function).name === &quot;anonymous&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17757,7 +17823,7 @@ return (new Function).name === &quot;anonymous&quot;;
 function foo() {};
 return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
   (function(){}).bind({}).name === &quot;bound &quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17821,7 +17887,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 var foo = function() {};
 var bar = function baz() {};
 return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17887,7 +17953,7 @@ o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -17952,7 +18018,7 @@ var o = { get foo(){}, set foo(x){} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
        descriptor.set.name === &quot;set foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18015,7 +18081,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>shorthand methods</span><script data-source="
 var o = { foo(){} };
 return o.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18085,7 +18151,7 @@ var o = {
 
 return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
        o[sym2].name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18150,7 +18216,7 @@ class foo {};
 class bar { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
   typeof bar.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18213,7 +18279,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class expressions</span><script data-source="
 return class foo {}.name === &quot;foo&quot; &amp;&amp;
   typeof class bar { static name() {} }.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18280,7 +18346,7 @@ var qux = class { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
        bar.name === &quot;baz&quot; &amp;&amp;
        typeof qux.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18346,7 +18412,7 @@ o.qux = class {};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18409,7 +18475,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property"><td><span>class prototype methods</span><script data-source="
 class C { foo(){} };
 return (new C).foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18472,7 +18538,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <tr class="subtest" data-parent="function_name_property"><td><span>class static methods</span><script data-source="
 class C { static foo(){} };
 return C.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18537,7 +18603,7 @@ var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;
 return descriptor.enumerable   === false &amp;&amp;
        descriptor.writable     === false &amp;&amp;
        descriptor.configurable === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18599,7 +18665,7 @@ return descriptor.enumerable   === false &amp;&amp;
 </tr>
 <tr><td id="Function.prototype.toMethod"><span><a class="anchor" href="#Function.prototype.toMethod">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-function.prototype.tomethod">Function.prototype.toMethod</a></span><script data-source="
 return typeof Function.prototype.toMethod === &quot;function&quot;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nreturn typeof Function.prototype.toMethod === \"function\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -18720,7 +18786,7 @@ return typeof Function.prototype.toMethod === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.raw</span><script data-source="
 return typeof String.raw === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18782,7 +18848,7 @@ return typeof String.raw === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods"><td><span>String.fromCodePoint</span><script data-source="
 return typeof String.fromCodePoint === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("285");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18903,7 +18969,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.codePointAt</span><script data-source="
 return typeof String.prototype.codePointAt === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("286");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -18967,7 +19033,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 return typeof String.prototype.normalize === &quot;function&quot;
   &amp;&amp; &quot;c\u0327\u0301&quot;.normalize(&quot;NFC&quot;) === &quot;\u1e09&quot;
   &amp;&amp; &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19030,7 +19096,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.repeat</span><script data-source="
 return typeof String.prototype.repeat === &apos;function&apos;
   &amp;&amp; &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19093,7 +19159,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.startsWith</span><script data-source="
 return typeof String.prototype.startsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.startsWith(&quot;foo&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19156,7 +19222,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.endsWith</span><script data-source="
 return typeof String.prototype.endsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.endsWith(&quot;bar&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19219,7 +19285,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods"><td><span>String.prototype.includes</span><script data-source="
 return typeof String.prototype.includes === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.includes(&quot;oba&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("292");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19340,7 +19406,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype.flags</span><script data-source="
 return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("293");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19402,7 +19468,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.match]</span><script data-source="
 return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19464,7 +19530,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.replace]</span><script data-source="
 return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19526,7 +19592,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.split]</span><script data-source="
 return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19588,7 +19654,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties"><td><span>RegExp.prototype[Symbol.search]</span><script data-source="
 return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -19709,7 +19775,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, array-like objects</span><script data-source="
 return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos;&apos; === &quot;foo,bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("299");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19772,7 +19838,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, generic iterables</span><script data-source="
 var iterable = global.__createIterableObject(1, 2, 3);
 return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19835,7 +19901,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.from, instances of generic iterables</span><script data-source="
 var iterable = global.__createIterableObject(1, 2, 3);
 return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject(1, 2, 3);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -19898,7 +19964,7 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array subclass .from</span><script data-source="
 class C extends Array {}
 return C.from({ length: 0 }) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
@@ -19961,7 +20027,7 @@ return C.from({ length: 0 }) instanceof C;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array.of</span><script data-source="
 return typeof Array.of === &apos;function&apos; &amp;&amp;
   Array.of(2)[0] === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20024,7 +20090,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <tr class="subtest" data-parent="Array_static_methods"><td><span>Array subclass .of</span><script data-source="
 class C extends Array {}
 return C.of(0) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="_6to5">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
@@ -20145,7 +20211,7 @@ return C.of(0) instanceof C;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.copyWithin</span><script data-source="
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20207,7 +20273,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.find</span><script data-source="
 return typeof Array.prototype.find === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20269,7 +20335,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.findIndex</span><script data-source="
 return typeof Array.prototype.findIndex === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("309");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20331,7 +20397,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.fill</span><script data-source="
 return typeof Array.prototype.fill === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("309");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20393,7 +20459,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.keys</span><script data-source="
 return typeof Array.prototype.keys === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20455,7 +20521,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.values</span><script data-source="
 return typeof Array.prototype.values === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20517,7 +20583,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.entries</span><script data-source="
 return typeof Array.prototype.entries === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20587,7 +20653,7 @@ for (var i = 0; i &lt; ns.length; i++) {
   if (Array.prototype[ns[i]] &amp;&amp; !unscopables[ns[i]]) return false;
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20708,7 +20774,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isFinite</span><script data-source="
 return typeof Number.isFinite === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20770,7 +20836,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isInteger</span><script data-source="
 return typeof Number.isInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20832,7 +20898,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isSafeInteger</span><script data-source="
 return typeof Number.isSafeInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20894,7 +20960,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.isNaN</span><script data-source="
 return typeof Number.isNaN === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -20956,7 +21022,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.EPSILON</span><script data-source="
 return typeof Number.EPSILON === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21018,7 +21084,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MIN_SAFE_INTEGER</span><script data-source="
 return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21080,7 +21146,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties"><td><span>Number.MAX_SAFE_INTEGER</span><script data-source="
 return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21150,7 +21216,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td data-browser="es6shim" class="tally" data-tally="1">17/17</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/17</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/17</td>
-<td data-browser="ie11tp" class="tally" data-tally="1">17/17</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.9411764705882353">16/17</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/17</td>
@@ -21201,7 +21267,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.clz32</span><script data-source="
 return typeof Math.clz32 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("323");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21263,7 +21329,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.imul</span><script data-source="
 return typeof Math.imul === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21325,7 +21391,7 @@ return typeof Math.imul === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sign</span><script data-source="
 return typeof Math.sign === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21387,7 +21453,7 @@ return typeof Math.sign === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log10</span><script data-source="
 return typeof Math.log10 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21449,7 +21515,7 @@ return typeof Math.log10 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log2</span><script data-source="
 return typeof Math.log2 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21511,7 +21577,7 @@ return typeof Math.log2 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.log1p</span><script data-source="
 return typeof Math.log1p === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21573,7 +21639,7 @@ return typeof Math.log1p === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.expm1</span><script data-source="
 return typeof Math.expm1 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21635,7 +21701,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.cosh</span><script data-source="
 return typeof Math.cosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21697,7 +21763,7 @@ return typeof Math.cosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.sinh</span><script data-source="
 return typeof Math.sinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21759,7 +21825,7 @@ return typeof Math.sinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.tanh</span><script data-source="
 return typeof Math.tanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21821,7 +21887,7 @@ return typeof Math.tanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.acosh</span><script data-source="
 return typeof Math.acosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21883,7 +21949,7 @@ return typeof Math.acosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.asinh</span><script data-source="
 return typeof Math.asinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21945,7 +22011,7 @@ return typeof Math.asinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.atanh</span><script data-source="
 return typeof Math.atanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -21965,68 +22031,6 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="no obsolete" data-browser="firefox23">No</td>
 <td class="no obsolete" data-browser="firefox24">No</td>
 <td class="yes obsolete" data-browser="firefox25">Yes</td>
-<td class="yes obsolete" data-browser="firefox27">Yes</td>
-<td class="yes obsolete" data-browser="firefox28">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
-<td class="yes" data-browser="firefox37">Yes</td>
-<td class="no obsolete" data-browser="chrome">No</td>
-<td class="no obsolete" data-browser="chrome19dev">No</td>
-<td class="no obsolete" data-browser="chrome21dev">No</td>
-<td class="no obsolete" data-browser="chrome30">No</td>
-<td class="no obsolete" data-browser="chrome31">No</td>
-<td class="no obsolete" data-browser="chrome33">No</td>
-<td class="no flagged obsolete" data-browser="chrome34">Flag</td>
-<td class="no flagged obsolete" data-browser="chrome35">Flag</td>
-<td class="no flagged obsolete" data-browser="chrome36">Flag</td>
-<td class="no flagged obsolete" data-browser="chrome37">Flag</td>
-<td class="yes obsolete" data-browser="chrome38">Yes</td>
-<td class="yes" data-browser="chrome39">Yes</td>
-<td class="yes" data-browser="chrome40">Yes</td>
-<td class="yes" data-browser="chrome41">Yes</td>
-<td class="no obsolete" data-browser="safari51">No</td>
-<td class="no obsolete" data-browser="safari6">No</td>
-<td class="no" data-browser="safari7">No</td>
-<td class="yes" data-browser="safari71_8">Yes</td>
-<td class="yes" data-browser="webkit">Yes</td>
-<td class="no" data-browser="opera">No</td>
-<td class="yes" data-browser="konq49">Yes</td>
-<td class="no obsolete" data-browser="rhino17">No</td>
-<td class="no" data-browser="phantom">No</td>
-<td class="no flagged" data-browser="node">Flag</td>
-<td class="yes" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="ejs">Yes</td>
-<td class="no" data-browser="ios7">No</td>
-<td class="yes" data-browser="ios8">Yes</td>
-</tr>
-<tr class="subtest" data-parent="Math_methods"><td><span>Math.hypot</span><script data-source="
-return typeof Math.hypot === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nreturn typeof Math.hypot === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
-</script></td>
-<td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="_6to5">Yes</td>
-<td class="no" data-browser="es6tr">No</td>
-<td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="typescript">No</td>
-<td class="yes" data-browser="es6shim">Yes</td>
-<td class="no" data-browser="ie10">No</td>
-<td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="ie11tp">Yes</td>
-<td class="no obsolete" data-browser="firefox11">No</td>
-<td class="no obsolete" data-browser="firefox13">No</td>
-<td class="no obsolete" data-browser="firefox16">No</td>
-<td class="no obsolete" data-browser="firefox17">No</td>
-<td class="no obsolete" data-browser="firefox18">No</td>
-<td class="no obsolete" data-browser="firefox23">No</td>
-<td class="no obsolete" data-browser="firefox24">No</td>
-<td class="no obsolete" data-browser="firefox25">No</td>
 <td class="yes obsolete" data-browser="firefox27">Yes</td>
 <td class="yes obsolete" data-browser="firefox28">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
@@ -22253,6 +22257,68 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
+<tr class="subtest" data-parent="Math_methods"><td><span>Math.hypot</span><script data-source="
+return Math.hypot(1) === 1 &amp;&amp; Math.hypot(9, 12, 20) === 25
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nreturn Math.hypot(1) === 1 && Math.hypot(9, 12, 20) === 25\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="yes" data-browser="_6to5">Yes</td>
+<td class="no" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no" data-browser="ie11tp">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="yes obsolete" data-browser="firefox27">Yes</td>
+<td class="yes obsolete" data-browser="firefox28">Yes</td>
+<td class="yes obsolete" data-browser="firefox29">Yes</td>
+<td class="yes obsolete" data-browser="firefox30">Yes</td>
+<td class="yes" data-browser="firefox31">Yes</td>
+<td class="yes obsolete" data-browser="firefox32">Yes</td>
+<td class="yes obsolete" data-browser="firefox33">Yes</td>
+<td class="yes obsolete" data-browser="firefox34">Yes</td>
+<td class="yes" data-browser="firefox35">Yes</td>
+<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox37">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no flagged obsolete" data-browser="chrome34">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome35">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome36">Flag</td>
+<td class="no flagged obsolete" data-browser="chrome37">Flag</td>
+<td class="yes obsolete" data-browser="chrome38">Yes</td>
+<td class="yes" data-browser="chrome39">Yes</td>
+<td class="yes" data-browser="chrome40">Yes</td>
+<td class="yes" data-browser="chrome41">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="yes" data-browser="safari71_8">Yes</td>
+<td class="yes" data-browser="webkit">Yes</td>
+<td class="no" data-browser="opera">No</td>
+<td class="yes" data-browser="konq49">Yes</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no flagged" data-browser="node">Flag</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="yes" data-browser="ejs">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="yes" data-browser="ios8">Yes</td>
+</tr>
 <tr class="category"><td colspan="59">Misc</td>
 </tr>
 <tr class="supertest"><td id="Object_static_methods_accept_primitives"><span><a class="anchor" href="#Object_static_methods_accept_primitives">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods accept primitives</a></span></td>
@@ -22316,7 +22382,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.getPrototypeOf</span><script data-source="
 return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22378,7 +22444,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.getOwnPropertyDescriptor</span><script data-source="
 return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22442,7 +22508,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 var s = Object.getOwnPropertyNames(&apos;a&apos;);
 return s.length === 2 &amp;&amp;
   ((s[0] === &apos;length&apos; &amp;&amp; s[1] === &apos;0&apos;) || (s[0] === &apos;0&apos; &amp;&amp; s[1] === &apos;length&apos;));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22504,7 +22570,7 @@ return s.length === 2 &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.seal</span><script data-source="
 return Object.seal(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22566,7 +22632,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.freeze</span><script data-source="
 return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22628,7 +22694,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.preventExtensions</span><script data-source="
 return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22690,7 +22756,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isSealed</span><script data-source="
 return Object.isSealed(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22752,7 +22818,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isFrozen</span><script data-source="
 return Object.isFrozen(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22814,7 +22880,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.isExtensible</span><script data-source="
 return Object.isExtensible(&apos;a&apos;) === false;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22877,7 +22943,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives"><td><span>Object.keys</span><script data-source="
 var s = Object.keys(&apos;a&apos;);
 return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("351");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -22999,7 +23065,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <tr class="subtest" data-parent="miscellaneous"><td><span>duplicate property names in strict mode</span><script data-source="
 &apos;use strict&apos;;
 return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("352");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -23061,7 +23127,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>no semicolon needed after do-while</span><script data-source="
 do {} while (false) return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("354");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -23128,7 +23194,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("354");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("355");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -23194,7 +23260,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("355");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("356");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -23256,7 +23322,7 @@ try {
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>Invalid Date</span><script data-source="
 return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("356");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -23318,7 +23384,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>RegExp constructor can alter flags</span><script data-source="
 return new RegExp(/./im, &quot;g&quot;).global === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
@@ -23395,7 +23461,7 @@ try {
   Date.prototype.valueOf(); return false;
 } catch(e) {}
 return Array.prototype.length === undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn Array.prototype.length === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn Array.prototype.length === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="_6to5">No</td>
@@ -23466,7 +23532,7 @@ return Array.prototype.length === undefined;
   function h() { return 2; }
 
 return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("360");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23588,7 +23654,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <tr class="subtest" data-parent="__proto___in_object_literals"><td><span>basic support</span><script data-source="
 return { __proto__ : [] } instanceof Array
   &amp;&amp; !({ __proto__ : null } instanceof Object);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("361");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23655,7 +23721,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23721,7 +23787,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var a = &quot;__proto__&quot;;
 return !({ [a] : [] } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23787,7 +23853,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var __proto__ = [];
 return !({ __proto__ } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23852,7 +23918,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 return !({ __proto__(){} } instanceof Function);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("366");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -23974,7 +24040,7 @@ return !({ __proto__(){} } instanceof Function);
 <tr class="subtest" data-parent="Object.prototype.__proto__"><td><span>get prototype</span><script data-source="
 var A = function(){};
 return (new A()).__proto__ === A.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("367");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("368");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -24038,7 +24104,7 @@ return (new A()).__proto__ === A.prototype;
 var o = {};
 o.__proto__ = Array.prototype;
 return o instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("368");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("369");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -24107,7 +24173,7 @@ return (desc
   &amp;&amp; &quot;set&quot; in desc
   &amp;&amp; desc.configurable
   &amp;&amp; !desc.enumerable);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("369");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("370");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -24176,7 +24242,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("370");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("371");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>
@@ -24238,7 +24304,7 @@ return true;
 </tr>
 <tr><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("371");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("372");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms.">No</td>
 <td class="no not-applicable" data-browser="_6to5" title="This feature is optional on non-browser platforms.">No</td>


### PR DESCRIPTION
- IE 11 `WeakMap` not support frozen objects as keys
- IE TP `Math.hypot` accepts only 2 or 3 arguments
- IE TP `Reflect.enumerate` returns not iterable iterator
