### PR TITLE
Fixed "symbol keys are hidden to pre-ES6 code" test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -4857,9 +4857,10 @@ exports.tests = [
         var object = {};
         var symbol = Symbol();
         object[symbol] = 1;
-
-        for (var x in object){}
-        var passed = (x !== symbol);
+        var passed = 1;
+        for (var x in object) {
+          passed = 0;
+        }
 
         if (Object.keys && Object.getOwnPropertyNames) {
           passed &= Object.keys(object).length === 0
@@ -4870,7 +4871,6 @@ exports.tests = [
       */},
       res: {
         _6to5:       true,
-        tr:          true,
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -16259,7 +16259,7 @@ function check() {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.4444444444444444">4/9</td>
+<td data-browser="tr" class="tally" data-tally="0.3333333333333333">3/9</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5555555555555556" data-flagged-tally="0.6666666666666666">5/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
@@ -16449,9 +16449,10 @@ return typeof Symbol() === &quot;symbol&quot;;
 var object = {};
 var symbol = Symbol();
 object[symbol] = 1;
-
-for (var x in object){}
-var passed = (x !== symbol);
+var passed = 1;
+for (var x in object) {
+  passed = 0;
+}
 
 if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
   passed &amp;= Object.keys(object).length === 0
@@ -16459,9 +16460,9 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = (x !== symbol);\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\nvar passed = 1;\nfor (var x in object) {\n  passed = 0;\n}\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>


### PR DESCRIPTION
In Traceur symbols are not hidden from `for-in` loop, [try in browser without native `Symbol`](http://google.github.io/traceur-compiler/demo/repl.html#var%20object%20%3D%20%7B%7D%3B%0Avar%20symbol%20%3D%20Symbol%28%29%3B%0Aobject%5Bsymbol%5D%20%3D%201%3B%0A%0Afor%20%28var%20x%20in%20object%29%20alert%28x%29%3B), but passes this test.

The problem in strict comparison - Core-js and Traceur `Symbol` returns object, but `for-in` enumerates object keys as primitives.
