### PR TITLE
Traceur does not allow line breaks between params and =>

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -522,6 +522,7 @@ exports.tests = [
         })();
       */},
       res: {
+        tr: true
       },
     },
     'no "prototype" property': {

--- a/es6/index.html
+++ b/es6/index.html
@@ -5813,7 +5813,7 @@ return f() === 1;
 <tr class="category"><td colspan="59">Functions</td>
 </tr>
 <tr class="supertest"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.7777777777777778">7/9</td>
+<td data-browser="tr" class="tally" data-tally="0.8888888888888888">8/9</td>
 <td data-browser="_6to5" class="tally" data-tally="0.7777777777777778">7/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6666666666666666">6/9</td>
 <td data-browser="closure" class="tally" data-tally="0.7777777777777778">7/9</td>
@@ -6320,7 +6320,7 @@ return (() =&gt; {
 })();
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");return Function("asyncTestPassed","\nreturn (() => {\n  try { Function(\"x\\n => 2\")(); } catch(e) { return true; }\n})();\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="tr">Yes</td>
 <td class="no" data-browser="_6to5">No</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>


### PR DESCRIPTION
See https://google.github.io/traceur-compiler/demo/repl.html#x%0A%3D%3E%202

This had to be manually updated as far as I could tell.
