### PR TITLE
Added feature significance weightings to supertests

### DIFF
--- a/build.js
+++ b/build.js
@@ -290,6 +290,9 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
 
     var testRow = $('<tr></tr>')
       .addClass("subtests" in t ? 'supertest' : '')
+      .attr("significance",
+        t.significance === "small" ? 0.25 :
+        t.significance === "medium" ? 0.5 : 1)
       .addClass(t.category === "annex b" ? 'annex_b' : '')
       .append($('<td></td>')
         .attr('id',id)

--- a/data-es6.js
+++ b/data-es6.js
@@ -339,6 +339,7 @@ exports.tests = [
 {
   name: 'proper tail calls (tail call optimisation)',
   category: 'optimisation',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls',
   subtests: {
     'direct recursion': {
@@ -382,6 +383,7 @@ exports.tests = [
 {
   name: 'arrow functions',
   category: 'functions',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions',
   subtests: {
     '0 parameters': {
@@ -575,6 +577,7 @@ exports.tests = [
 {
   name: 'const',
   category: 'bindings',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations',
   subtests: {
     'basic support': {
@@ -737,6 +740,7 @@ exports.tests = [
 {
   name: 'let',
   category: 'bindings',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations',
   subtests: {
     'basic support': {
@@ -937,6 +941,7 @@ exports.tests = [
 {
   name: 'default function parameters',
   category: 'syntax',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
   subtests: {
     'basic functionality': {
@@ -1018,6 +1023,7 @@ exports.tests = [
 {
   name: 'rest parameters',
   category: 'syntax',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions',
   subtests: {
     'basic functionality': {
@@ -1075,6 +1081,7 @@ exports.tests = [
 {
   name: 'spread (...) operator',
   category: 'syntax',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation',
   subtests: {
     'with arrays, in function calls': {
@@ -1216,6 +1223,7 @@ exports.tests = [
 {
   name: 'class',
   category: 'functions',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions',
   subtests: {
     'class statement': {
@@ -1498,6 +1506,7 @@ exports.tests = [
 {
   name: 'super',
   category: 'functions',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword',
   subtests: {
     'statement in constructors': {
@@ -1593,6 +1602,7 @@ exports.tests = [
 {
   name: 'object literal extensions',
   category: 'syntax',
+  significance: 'large',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser',
   subtests: {
     'computed properties': {
@@ -1688,6 +1698,7 @@ exports.tests = [
 {
   name: 'hoisted block-level function declaration',
   category: 'annex b',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics',
   exec: function () {/*
     // Note: only available outside of strict mode.
@@ -1708,6 +1719,7 @@ exports.tests = [
 {
   name: '__proto__ in object literals',
   category: 'annex b',
+  significance: 'small',
   note_id: 'proto-in-object-literals',
   note_html: 'Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers',
@@ -1789,6 +1801,7 @@ exports.tests = [
 {
   name: 'for..of loops',
   category: 'syntax',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements',
   subtests: {
     'with arrays': {
@@ -1900,6 +1913,7 @@ exports.tests = [
 {
   name: 'generators',
   category: 'functions',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions',
   subtests: {
     'basic functionality': {
@@ -2236,6 +2250,7 @@ exports.tests = [
 {
   name: 'octal and binary literals',
   category: 'syntax',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals',
   subtests: {
     'octal literals': {
@@ -2307,6 +2322,7 @@ exports.tests = [
 {
   name: 'template strings',
   category: 'syntax',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals',
   subtests: {
     'basic functionality': {
@@ -2361,6 +2377,7 @@ exports.tests = [
 {
   name: 'RegExp "y" and "u" flags',
   category: 'syntax',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky',
   subtests: {
     '"y" flag': {
@@ -2392,6 +2409,7 @@ exports.tests = [
 {
   name: 'typed arrays',
   category: 'built-ins',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects',
   subtests: Object.assign({
     'Int8Array': {
@@ -2639,6 +2657,7 @@ exports.tests = [
 {
   name: 'Map',
   category: 'built-ins',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects',
   subtests: {
     'basic functionality': {
@@ -2877,6 +2896,7 @@ exports.tests = [
 {
   name: 'Set',
   category: 'built-ins',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects',
   subtests: {
     'basic functionality': {
@@ -3116,6 +3136,7 @@ exports.tests = [
 {
   name: 'WeakMap',
   category: 'built-ins',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects',
   subtests: {
     'basic functionality': {
@@ -3223,6 +3244,7 @@ exports.tests = [
 {
   name: 'WeakSet',
   category: 'built-ins',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects',
   subtests: {
     'basic functionality': {
@@ -3299,6 +3321,7 @@ exports.tests = [
 {
   name: 'Proxy',
   category: 'built-ins',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots',
   subtests: {
     '"get" handler': {
@@ -3668,6 +3691,7 @@ exports.tests = [
 {
   name: 'Reflect',
   category: 'built-ins',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection',
   subtests: {
     'Reflect.get': {
@@ -3853,6 +3877,7 @@ exports.tests = [
 {
   name: 'block-level function declaration',
   category: 'bindings',
+  significance: 'small',
   note_id: 'block-level-function',
   note_html: 'Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation',
@@ -3878,6 +3903,7 @@ exports.tests = [
 {
   name: 'destructuring',
   category: 'syntax',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment',
   subtests: {
     'with arrays': {
@@ -4254,6 +4280,7 @@ exports.tests = [
 {
   name: 'Promise',
   category: 'built-ins',
+  significance: 'large',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects',
   subtests: {
     'basic functionality': {
@@ -4367,6 +4394,7 @@ exports.tests = [
 {
   name: 'Object static methods',
   category: 'built-in extensions',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor',
   subtests: {
     'Object.assign': {
@@ -4439,6 +4467,7 @@ exports.tests = [
 {
   name: 'Object static methods accept primitives',
   category: 'misc',
+  significance: 'small',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor',
   subtests: {
     'Object.getPrototypeOf': {
@@ -4544,6 +4573,7 @@ exports.tests = [
 {
   name: 'Object.prototype.__proto__',
   category: 'annex b',
+  significance: 'small',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__',
   subtests: {
     'get prototype': {
@@ -4604,6 +4634,7 @@ exports.tests = [
 {
   name: 'function "name" property',
   category: 'built-in extensions',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname',
   subtests: {
     'function statements': {
@@ -4789,6 +4820,7 @@ exports.tests = [
 {
   name: 'String static methods',
   category: 'built-in extensions',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-constructor',
   subtests: {
     'String.raw': {
@@ -4828,6 +4860,7 @@ exports.tests = [
 {
   name: 'String.prototype methods',
   category: 'built-in extensions',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object',
   subtests: {
     'String.prototype.codePointAt': {
@@ -4946,6 +4979,7 @@ exports.tests = [
 {
   name: 'String.prototype HTML methods',
   category: 'annex b',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor',
   exec: function () {/*
     var i, names = ["anchor", "big", "bold", "fixed", "fontcolor", "fontsize",
@@ -4978,6 +5012,7 @@ exports.tests = [
 {
   name: 'Unicode code point escapes',
   category: 'syntax',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals',
   exec: function () {/*
     return '\u{1d306}' == '\ud834\udf06';
@@ -4994,6 +5029,7 @@ exports.tests = [
 {
   name: 'Symbol',
   category: 'built-ins',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor',
   subtests: {
     'basic functionality': {
@@ -5188,6 +5224,7 @@ exports.tests = [
 {
   name: 'well-known symbols',
   category: 'built-ins',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols',
   subtests: {
     'Symbol.hasInstance': {
@@ -5310,6 +5347,7 @@ exports.tests = [
 {
   name: 'RegExp.prototype properties',
   category: 'built-in extensions',
+  significance: 'small',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype',
   subtests: {
     'RegExp.prototype.flags': {
@@ -5361,6 +5399,7 @@ exports.tests = [
 {
   name: 'RegExp.prototype.compile',
   category: 'annex b',
+  significance: 'small',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile',
   exec: function () {/*
     return typeof RegExp.prototype.compile === 'function';
@@ -5386,6 +5425,7 @@ exports.tests = [
 {
   name: 'Array static methods',
   category: 'built-in extensions',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor',
   subtests: {
     'Array.from, array-like objects': {
@@ -5449,6 +5489,7 @@ exports.tests = [
 {
   name: 'Array.prototype methods',
   category: 'built-in extensions',
+  significance: 'medium',
   link: 'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object',
   subtests: {
     'Array.prototype.copyWithin': {
@@ -5612,6 +5653,7 @@ exports.tests = [
 {
   name: 'Number properties',
   category: 'built-in extensions',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isfinite-number',
   subtests: {
     'Number.isFinite': {
@@ -5744,6 +5786,7 @@ exports.tests = [
 {
   name: 'Math methods',
   category: 'built-in extensions',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-math',
   subtests: (function(){
     var methods = {
@@ -6044,6 +6087,7 @@ exports.tests = [
 {
   name: 'Array is subclassable',
   category: 'subclassing',
+  significance: 'medium',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-constructor',
   subtests: {
     'basic functionality': {
@@ -6098,6 +6142,7 @@ exports.tests = [
   name: 'RegExp is subclassable',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp-constructor',
   category: 'subclassing',
+  significance: 'small',
   subtests: {
     'basic functionality': {
       exec: function () {/*
@@ -6132,6 +6177,7 @@ exports.tests = [
   name: 'Function is subclassable',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor',
   category: 'subclassing',
+  significance: 'small',
   subtests: {
     'can be called': {
       exec: function () {/*
@@ -6185,6 +6231,7 @@ exports.tests = [
   name: 'Promise is subclassable',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor',
   category: 'subclassing',
+  significance: 'small',
   subtests: {
     'basic functionality': {
       exec: function () {/*
@@ -6271,6 +6318,7 @@ exports.tests = [
   name: 'miscellaneous subclassables',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor',
   category: 'subclassing',
+  significance: 'small',
   subtests: {
     'Boolean is subclassable': {
       exec: function () {/*
@@ -6309,6 +6357,7 @@ exports.tests = [
 {
   name: 'miscellaneous',
   category: 'misc',
+  significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions',
   subtests: {
     'duplicate property names in strict mode': {

--- a/es5/index.html
+++ b/es5/index.html
@@ -119,7 +119,7 @@
         </thead>
         <tbody>
           <!-- TABLE BODY -->
-        <tr><td id="Object.create"><span><a class="anchor" href="#Object.create">&#xA7;</a>Object.create</span><script data-source="function () {
+        <tr significance="1"><td id="Object.create"><span><a class="anchor" href="#Object.create">&#xA7;</a>Object.create</span><script data-source="function () {
 return typeof Object.create == &apos;function&apos;;
   }">test(
 function () {
@@ -158,7 +158,7 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.defineProperty"><span><a class="anchor" href="#Object.defineProperty">&#xA7;</a>Object.defineProperty</span><script data-source="function () {
+<tr significance="1"><td id="Object.defineProperty"><span><a class="anchor" href="#Object.defineProperty">&#xA7;</a>Object.defineProperty</span><script data-source="function () {
 return typeof Object.defineProperty == &apos;function&apos;;
   }">test(
 function () {
@@ -197,7 +197,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.defineProperties"><span><a class="anchor" href="#Object.defineProperties">&#xA7;</a>Object.defineProperties</span><script data-source="function () {
+<tr significance="1"><td id="Object.defineProperties"><span><a class="anchor" href="#Object.defineProperties">&#xA7;</a>Object.defineProperties</span><script data-source="function () {
 return typeof Object.defineProperties == &apos;function&apos;;
   }">test(
 function () {
@@ -236,7 +236,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.getPrototypeOf"><span><a class="anchor" href="#Object.getPrototypeOf">&#xA7;</a>Object.getPrototypeOf</span><script data-source="function () {
+<tr significance="1"><td id="Object.getPrototypeOf"><span><a class="anchor" href="#Object.getPrototypeOf">&#xA7;</a>Object.getPrototypeOf</span><script data-source="function () {
 return typeof Object.getPrototypeOf == &apos;function&apos;;
   }">test(
 function () {
@@ -275,7 +275,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.keys"><span><a class="anchor" href="#Object.keys">&#xA7;</a>Object.keys</span><script data-source="function () {
+<tr significance="1"><td id="Object.keys"><span><a class="anchor" href="#Object.keys">&#xA7;</a>Object.keys</span><script data-source="function () {
 return typeof Object.keys == &apos;function&apos;;
   }">test(
 function () {
@@ -314,7 +314,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.seal"><span><a class="anchor" href="#Object.seal">&#xA7;</a>Object.seal</span><script data-source="function () {
+<tr significance="1"><td id="Object.seal"><span><a class="anchor" href="#Object.seal">&#xA7;</a>Object.seal</span><script data-source="function () {
 return typeof Object.seal == &apos;function&apos;;
   }">test(
 function () {
@@ -353,7 +353,7 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.freeze"><span><a class="anchor" href="#Object.freeze">&#xA7;</a>Object.freeze</span><script data-source="function () {
+<tr significance="1"><td id="Object.freeze"><span><a class="anchor" href="#Object.freeze">&#xA7;</a>Object.freeze</span><script data-source="function () {
 return typeof Object.freeze == &apos;function&apos;;
   }">test(
 function () {
@@ -392,7 +392,7 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.preventExtensions"><span><a class="anchor" href="#Object.preventExtensions">&#xA7;</a>Object.preventExtensions</span><script data-source="function () {
+<tr significance="1"><td id="Object.preventExtensions"><span><a class="anchor" href="#Object.preventExtensions">&#xA7;</a>Object.preventExtensions</span><script data-source="function () {
 return typeof Object.preventExtensions == &apos;function&apos;;
   }">test(
 function () {
@@ -431,7 +431,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.isSealed"><span><a class="anchor" href="#Object.isSealed">&#xA7;</a>Object.isSealed</span><script data-source="function () {
+<tr significance="1"><td id="Object.isSealed"><span><a class="anchor" href="#Object.isSealed">&#xA7;</a>Object.isSealed</span><script data-source="function () {
 return typeof Object.isSealed == &apos;function&apos;;
   }">test(
 function () {
@@ -470,7 +470,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.isFrozen"><span><a class="anchor" href="#Object.isFrozen">&#xA7;</a>Object.isFrozen</span><script data-source="function () {
+<tr significance="1"><td id="Object.isFrozen"><span><a class="anchor" href="#Object.isFrozen">&#xA7;</a>Object.isFrozen</span><script data-source="function () {
 return typeof Object.isFrozen == &apos;function&apos;;
   }">test(
 function () {
@@ -509,7 +509,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.isExtensible"><span><a class="anchor" href="#Object.isExtensible">&#xA7;</a>Object.isExtensible</span><script data-source="function () {
+<tr significance="1"><td id="Object.isExtensible"><span><a class="anchor" href="#Object.isExtensible">&#xA7;</a>Object.isExtensible</span><script data-source="function () {
 return typeof Object.isExtensible == &apos;function&apos;;
   }">test(
 function () {
@@ -548,7 +548,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.getOwnPropertyDescriptor"><span><a class="anchor" href="#Object.getOwnPropertyDescriptor">&#xA7;</a>Object.getOwnPropertyDescriptor</span><script data-source="function () {
+<tr significance="1"><td id="Object.getOwnPropertyDescriptor"><span><a class="anchor" href="#Object.getOwnPropertyDescriptor">&#xA7;</a>Object.getOwnPropertyDescriptor</span><script data-source="function () {
 return typeof Object.getOwnPropertyDescriptor == &apos;function&apos;;
   }">test(
 function () {
@@ -587,7 +587,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Object.getOwnPropertyNames"><span><a class="anchor" href="#Object.getOwnPropertyNames">&#xA7;</a>Object.getOwnPropertyNames</span><script data-source="function () {
+<tr significance="1"><td id="Object.getOwnPropertyNames"><span><a class="anchor" href="#Object.getOwnPropertyNames">&#xA7;</a>Object.getOwnPropertyNames</span><script data-source="function () {
 return typeof Object.getOwnPropertyNames == &apos;function&apos;;
   }">test(
 function () {
@@ -628,7 +628,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 </tr>
 <tr><th colspan="35" class="separator"></th>
 </tr>
-<tr><td id="Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&#xA7;</a>Date.prototype.toISOString</span><script data-source="function () {
+<tr significance="1"><td id="Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&#xA7;</a>Date.prototype.toISOString</span><script data-source="function () {
 return typeof Date.prototype.toISOString == &apos;function&apos;;
   }">test(
 function () {
@@ -667,7 +667,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="no" data-browser="ejs">No</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Date.now"><span><a class="anchor" href="#Date.now">&#xA7;</a>Date.now</span><script data-source="function () {
+<tr significance="1"><td id="Date.now"><span><a class="anchor" href="#Date.now">&#xA7;</a>Date.now</span><script data-source="function () {
 return typeof Date.now == &apos;function&apos;;
   }">test(
 function () {
@@ -706,7 +706,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.isArray"><span><a class="anchor" href="#Array.isArray">&#xA7;</a>Array.isArray</span><script data-source="function () {
+<tr significance="1"><td id="Array.isArray"><span><a class="anchor" href="#Array.isArray">&#xA7;</a>Array.isArray</span><script data-source="function () {
 return typeof Array.isArray == &apos;function&apos;;
   }">test(
 function () {
@@ -745,7 +745,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="JSON"><span><a class="anchor" href="#JSON">&#xA7;</a>JSON</span><script data-source="function () {
+<tr significance="1"><td id="JSON"><span><a class="anchor" href="#JSON">&#xA7;</a>JSON</span><script data-source="function () {
 return typeof JSON == &apos;object&apos;;
   }">test(
 function () {
@@ -784,7 +784,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Function.prototype.bind"><span><a class="anchor" href="#Function.prototype.bind">&#xA7;</a>Function.prototype.bind</span><script data-source="function () {
+<tr significance="1"><td id="Function.prototype.bind"><span><a class="anchor" href="#Function.prototype.bind">&#xA7;</a>Function.prototype.bind</span><script data-source="function () {
 return typeof Function.prototype.bind == &apos;function&apos;;
   }">test(
 function () {
@@ -823,7 +823,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="String.prototype.trim"><span><a class="anchor" href="#String.prototype.trim">&#xA7;</a>String.prototype.trim</span><script data-source="function () {
+<tr significance="1"><td id="String.prototype.trim"><span><a class="anchor" href="#String.prototype.trim">&#xA7;</a>String.prototype.trim</span><script data-source="function () {
 return typeof String.prototype.trim == &apos;function&apos;;
   }">test(
 function () {
@@ -864,7 +864,7 @@ return typeof String.prototype.trim == 'function';
 </tr>
 <tr><th colspan="35" class="separator"></th>
 </tr>
-<tr><td id="Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&#xA7;</a>Array.prototype.indexOf</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&#xA7;</a>Array.prototype.indexOf</span><script data-source="function () {
 return typeof Array.prototype.indexOf == &apos;function&apos;;
   }">test(
 function () {
@@ -903,7 +903,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.lastIndexOf"><span><a class="anchor" href="#Array.prototype.lastIndexOf">&#xA7;</a>Array.prototype.lastIndexOf</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.lastIndexOf"><span><a class="anchor" href="#Array.prototype.lastIndexOf">&#xA7;</a>Array.prototype.lastIndexOf</span><script data-source="function () {
 return typeof Array.prototype.lastIndexOf == &apos;function&apos;;
   }">test(
 function () {
@@ -942,7 +942,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.every"><span><a class="anchor" href="#Array.prototype.every">&#xA7;</a>Array.prototype.every</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.every"><span><a class="anchor" href="#Array.prototype.every">&#xA7;</a>Array.prototype.every</span><script data-source="function () {
 return typeof Array.prototype.every == &apos;function&apos;;
   }">test(
 function () {
@@ -981,7 +981,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.some"><span><a class="anchor" href="#Array.prototype.some">&#xA7;</a>Array.prototype.some</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.some"><span><a class="anchor" href="#Array.prototype.some">&#xA7;</a>Array.prototype.some</span><script data-source="function () {
 return typeof Array.prototype.some == &apos;function&apos;;
   }">test(
 function () {
@@ -1020,7 +1020,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.forEach"><span><a class="anchor" href="#Array.prototype.forEach">&#xA7;</a>Array.prototype.forEach</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.forEach"><span><a class="anchor" href="#Array.prototype.forEach">&#xA7;</a>Array.prototype.forEach</span><script data-source="function () {
 return typeof Array.prototype.forEach == &apos;function&apos;;
   }">test(
 function () {
@@ -1059,7 +1059,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.map"><span><a class="anchor" href="#Array.prototype.map">&#xA7;</a>Array.prototype.map</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.map"><span><a class="anchor" href="#Array.prototype.map">&#xA7;</a>Array.prototype.map</span><script data-source="function () {
 return typeof Array.prototype.map == &apos;function&apos;;
   }">test(
 function () {
@@ -1098,7 +1098,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.filter"><span><a class="anchor" href="#Array.prototype.filter">&#xA7;</a>Array.prototype.filter</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.filter"><span><a class="anchor" href="#Array.prototype.filter">&#xA7;</a>Array.prototype.filter</span><script data-source="function () {
 return typeof Array.prototype.filter == &apos;function&apos;;
   }">test(
 function () {
@@ -1137,7 +1137,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.reduce"><span><a class="anchor" href="#Array.prototype.reduce">&#xA7;</a>Array.prototype.reduce</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.reduce"><span><a class="anchor" href="#Array.prototype.reduce">&#xA7;</a>Array.prototype.reduce</span><script data-source="function () {
 return typeof Array.prototype.reduce == &apos;function&apos;;
   }">test(
 function () {
@@ -1176,7 +1176,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Array.prototype.reduceRight"><span><a class="anchor" href="#Array.prototype.reduceRight">&#xA7;</a>Array.prototype.reduceRight</span><script data-source="function () {
+<tr significance="1"><td id="Array.prototype.reduceRight"><span><a class="anchor" href="#Array.prototype.reduceRight">&#xA7;</a>Array.prototype.reduceRight</span><script data-source="function () {
 return typeof Array.prototype.reduceRight == &apos;function&apos;;
   }">test(
 function () {
@@ -1217,7 +1217,7 @@ return typeof Array.prototype.reduceRight == 'function';
 </tr>
 <tr><th colspan="35" class="separator"></th>
 </tr>
-<tr><td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&#xA7;</a>Getter in property initializer</span><script data-source="
+<tr significance="1"><td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&#xA7;</a>Getter in property initializer</span><script data-source="
 return ({ get x(){ return 1 } }).x === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");return Function("asyncTestPassed","\nreturn ({ get x(){ return 1 } }).x === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -1254,7 +1254,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Setter_in_property_initializer"><span><a class="anchor" href="#Setter_in_property_initializer">&#xA7;</a>Setter in property initializer</span><script data-source="
+<tr significance="1"><td id="Setter_in_property_initializer"><span><a class="anchor" href="#Setter_in_property_initializer">&#xA7;</a>Setter in property initializer</span><script data-source="
 var value = 0;
 ({ set x(v){ value = v; } }).x = 1;
 return value === 1;
@@ -1295,7 +1295,7 @@ return value === 1;
 </tr>
 <tr><th colspan="35" class="separator"></th>
 </tr>
-<tr><td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&#xA7;</a>Property access on strings</span><script data-source="function () {
+<tr significance="1"><td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&#xA7;</a>Property access on strings</span><script data-source="function () {
 return &quot;foobar&quot;[3] === &quot;b&quot;;
   }">test(
 function () {
@@ -1334,7 +1334,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
+<tr significance="1"><td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
 return ({ if: 1 }).if === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");return Function("asyncTestPassed","\nreturn ({ if: 1 }).if === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -1373,7 +1373,7 @@ return ({ if: 1 }).if === 1;
 </tr>
 <tr><th colspan="35" class="separator"></th>
 </tr>
-<tr><td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
+<tr significance="1"><td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
 var _\u200c\u200d = true;
 return _\u200c\u200d;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");return Function("asyncTestPassed","\nvar _\\u200c\\u200d = true;\nreturn _\\u200c\\u200d;\n  ")(asyncTestPassed);}catch(e){return false;}}());
@@ -1411,7 +1411,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="parseInt()_ignores_leading_zeros"><span><a class="anchor" href="#parseInt()_ignores_leading_zeros">&#xA7;</a>parseInt() ignores leading zeros</span><script data-source="function () {
+<tr significance="1"><td id="parseInt()_ignores_leading_zeros"><span><a class="anchor" href="#parseInt()_ignores_leading_zeros">&#xA7;</a>parseInt() ignores leading zeros</span><script data-source="function () {
 return parseInt(&apos;010&apos;) === 10;
   }">test(
 function () {
@@ -1450,7 +1450,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Immutable_undefined"><span><a class="anchor" href="#Immutable_undefined">&#xA7;</a>Immutable undefined</span><script data-source="
+<tr significance="1"><td id="Immutable_undefined"><span><a class="anchor" href="#Immutable_undefined">&#xA7;</a>Immutable undefined</span><script data-source="
 undefined = 12345;
 var result = typeof undefined == &apos;undefined&apos;;
 undefined = void 0;
@@ -1490,7 +1490,7 @@ return result;
 <td class="no" data-browser="ejs">No</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&#xA7;</a><a href="../strict-mode/">Strict mode</a></span><script data-source="function () {
+<tr significance="1"><td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&#xA7;</a><a href="../strict-mode/">Strict mode</a></span><script data-source="function () {
 &quot;use strict&quot;;
 return !this;
   }">test(

--- a/es6/index.html
+++ b/es6/index.html
@@ -179,7 +179,7 @@
         <!-- TABLE BODY -->
       <tr class="category"><td colspan="60">Optimisation</td>
 </tr>
-<tr class="supertest"><td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
+<tr class="supertest" significance="0.5"><td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">1/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
@@ -386,7 +386,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 </tr>
 <tr class="category"><td colspan="60">Syntax</td>
 </tr>
-<tr class="supertest"><td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
+<tr class="supertest" significance="0.5"><td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.6">3/5</td>
 <td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">3/5</td>
@@ -776,7 +776,7 @@ return (function(a=function(){
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
+<tr class="supertest" significance="0.5"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6666666666666666">2/3</td>
@@ -1035,7 +1035,7 @@ return (function (foo, ...args) {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
+<tr class="supertest" significance="1"><td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">10/10</td>
 <td data-browser="_6to5" class="tally" data-tally="1">10/10</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">6/10</td>
@@ -1729,7 +1729,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser">object literal extensions</a></span></td>
+<tr class="supertest" significance="1"><td id="object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object-initialiser">object literal extensions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">5/5</td>
 <td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="tally" data-tally="1">5/5</td>
@@ -2114,7 +2114,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="for..of_loops"><span><a class="anchor" href="#for..of_loops">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
+<tr class="supertest" significance="1"><td id="for..of_loops"><span><a class="anchor" href="#for..of_loops">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">5/5</td>
 <td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">3/5</td>
@@ -2507,7 +2507,7 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
+<tr class="supertest" significance="0.25"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0.5">2/4</td>
@@ -2819,7 +2819,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="template_strings"><span><a class="anchor" href="#template_strings">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">template strings</a></span></td>
+<tr class="supertest" significance="1"><td id="template_strings"><span><a class="anchor" href="#template_strings">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-template-literals">template strings</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="tally" data-tally="1">2/2</td>
@@ -3018,7 +3018,7 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky">RegExp &quot;y&quot; and &quot;u&quot; flags</a></span></td>
+<tr class="supertest" significance="0.5"><td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky">RegExp &quot;y&quot; and &quot;u&quot; flags</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5">1/2</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">1/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
@@ -3208,7 +3208,7 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
+<tr class="supertest" significance="1"><td id="destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9166666666666666">22/24</td>
 <td data-browser="_6to5" class="tally" data-tally="0.9583333333333334" data-flagged-tally="1">23/24</td>
 <td data-browser="es6tr" class="tally" data-tally="0.7083333333333334">17/24</td>
@@ -4852,7 +4852,7 @@ return (function({a=function(){
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span><script data-source="
+<tr significance="0.25"><td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-string-literals">Unicode code point escapes</a></span><script data-source="
 return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");return Function("asyncTestPassed","\nreturn '\\u{1d306}' == '\\ud834\\udf06';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -4917,7 +4917,7 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 </tr>
 <tr class="category"><td colspan="60">Bindings</td>
 </tr>
-<tr class="supertest"><td id="const"><span><a class="anchor" href="#const">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">const</a></span></td>
+<tr class="supertest" significance="0.5"><td id="const"><span><a class="anchor" href="#const">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">const</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="_6to5" class="tally" data-tally="0.75" data-flagged-tally="1">6/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0.75">6/8</td>
@@ -5505,7 +5505,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="let"><span><a class="anchor" href="#let">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">let</a></span></td>
+<tr class="supertest" significance="0.5"><td id="let"><span><a class="anchor" href="#let">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">let</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8">8/10</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8" data-flagged-tally="1">8/10</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">6/10</td>
@@ -6236,7 +6236,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span><script data-source="
+<tr significance="0.25"><td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[11]</sup></a></span><script data-source="
 &apos;use strict&apos;;
 function f() { return 1; }
 {
@@ -6306,7 +6306,7 @@ return f() === 1;
 </tr>
 <tr class="category"><td colspan="60">Functions</td>
 </tr>
-<tr class="supertest"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
+<tr class="supertest" significance="1"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8181818181818182">9/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6363636363636364">7/11</td>
@@ -7085,7 +7085,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="class"><span><a class="anchor" href="#class">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
+<tr class="supertest" significance="1"><td id="class"><span><a class="anchor" href="#class">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5333333333333333">8/15</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8">12/15</td>
 <td data-browser="es6tr" class="tally" data-tally="0.6">9/15</td>
@@ -8157,7 +8157,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="super"><span><a class="anchor" href="#super">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword">super</a></span></td>
+<tr class="supertest" significance="0.5"><td id="super"><span><a class="anchor" href="#super">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-super-keyword">super</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">4/4</td>
 <td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="1">4/4</td>
@@ -8499,7 +8499,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
+<tr class="supertest" significance="1"><td id="generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">14/14</td>
 <td data-browser="_6to5" class="tally" data-tally="0.9285714285714286">13/14</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/14</td>
@@ -9580,7 +9580,7 @@ return passed;
 </tr>
 <tr class="category"><td colspan="60">Built-ins</td>
 </tr>
-<tr class="supertest"><td id="typed_arrays"><span><a class="anchor" href="#typed_arrays">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects">typed arrays</a></span></td>
+<tr class="supertest" significance="1"><td id="typed_arrays"><span><a class="anchor" href="#typed_arrays">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-typedarray-objects">typed arrays</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/40</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/40</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/40</td>
@@ -12386,7 +12386,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="_6to5" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
@@ -13161,7 +13161,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
 <td data-browser="_6to5" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
@@ -13938,7 +13938,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
+<tr class="supertest" significance="0.5"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
@@ -14328,7 +14328,7 @@ return m.get(f) === 42;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
+<tr class="supertest" significance="0.5"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
@@ -14651,7 +14651,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Proxy"><span><a class="anchor" href="#Proxy">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
+<tr class="supertest" significance="1"><td id="Proxy"><span><a class="anchor" href="#Proxy">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/20</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/20</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/20</td>
@@ -16130,7 +16130,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/15</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8666666666666667">13/15</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/15</td>
@@ -17168,7 +17168,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span></td>
+<tr class="supertest" significance="1"><td id="Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/3</td>
@@ -17466,7 +17466,7 @@ function check() {
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.3333333333333333">3/9</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5555555555555556" data-flagged-tally="0.6666666666666666">5/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
@@ -18143,7 +18143,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
+<tr class="supertest" significance="0.5"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.14285714285714285">1/7</td>
 <td data-browser="_6to5" class="tally" data-tally="0.2857142857142857">2/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
@@ -18686,7 +18686,7 @@ with (a) {
 </tr>
 <tr class="category"><td colspan="60">Built-in extensions</td>
 </tr>
-<tr class="supertest"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
@@ -19004,7 +19004,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
+<tr class="supertest" significance="0.25"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/16</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5625">9/16</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/16</td>
@@ -20113,7 +20113,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="String_static_methods"><span><a class="anchor" href="#String_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-constructor">String static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="String_static_methods"><span><a class="anchor" href="#String_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-constructor">String static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="_6to5" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
@@ -20299,7 +20299,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8333333333333334">5/6</td>
 <td data-browser="_6to5" class="tally" data-tally="0.8333333333333334">5/6</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/6</td>
@@ -20743,7 +20743,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
+<tr class="supertest" significance="0.25"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" class="tally" data-tally="0.2">1/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
@@ -21118,7 +21118,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">4/4</td>
 <td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
@@ -21433,7 +21433,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
 <td data-browser="_6to5" class="tally" data-tally="1">8/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/8</td>
@@ -22005,7 +22005,7 @@ return true;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Number_properties"><span><a class="anchor" href="#Number_properties">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isfinite-number">Number properties</a></span></td>
+<tr class="supertest" significance="0.25"><td id="Number_properties"><span><a class="anchor" href="#Number_properties">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isfinite-number">Number properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">7/7</td>
 <td data-browser="_6to5" class="tally" data-tally="1">7/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
@@ -22506,7 +22506,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Math_methods"><span><a class="anchor" href="#Math_methods">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-math">Math methods</a></span></td>
+<tr class="supertest" significance="0.25"><td id="Math_methods"><span><a class="anchor" href="#Math_methods">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-math">Math methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">17/17</td>
 <td data-browser="_6to5" class="tally" data-tally="1">17/17</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/17</td>
@@ -23642,7 +23642,7 @@ return Math.hypot() === 0 &amp;&amp;
 </tr>
 <tr class="category"><td colspan="60">Subclassing</td>
 </tr>
-<tr class="supertest"><td id="Array_is_subclassable"><span><a class="anchor" href="#Array_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-constructor">Array is subclassable</a></span></td>
+<tr class="supertest" significance="0.5"><td id="Array_is_subclassable"><span><a class="anchor" href="#Array_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-constructor">Array is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
@@ -23965,7 +23965,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp-constructor">RegExp is subclassable</a></span></td>
+<tr class="supertest" significance="0.25"><td id="RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp-constructor">RegExp is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/3</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/3</td>
@@ -24220,7 +24220,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Function is subclassable</a></span></td>
+<tr class="supertest" significance="0.25"><td id="Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Function is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
@@ -24606,7 +24606,7 @@ return c() === 3;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="Promise_is_subclassable"><span><a class="anchor" href="#Promise_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Promise is subclassable</a></span></td>
+<tr class="supertest" significance="0.25"><td id="Promise_is_subclassable"><span><a class="anchor" href="#Promise_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Promise is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="_6to5" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/3</td>
@@ -24907,7 +24907,7 @@ function check() {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
+<tr class="supertest" significance="0.25"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/3</td>
 <td data-browser="_6to5" class="tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/3</td>
@@ -25169,7 +25169,7 @@ return c instanceof String
 </tr>
 <tr class="category"><td colspan="60">Misc</td>
 </tr>
-<tr class="supertest"><td id="Object_static_methods_accept_primitives"><span><a class="anchor" href="#Object_static_methods_accept_primitives">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods accept primitives</a></span></td>
+<tr class="supertest" significance="0.25"><td id="Object_static_methods_accept_primitives"><span><a class="anchor" href="#Object_static_methods_accept_primitives">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods accept primitives</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/10</td>
 <td data-browser="_6to5" class="tally" data-tally="1">10/10</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/10</td>
@@ -25862,7 +25862,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
+<tr class="supertest" significance="0.25"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="_6to5" class="tally" data-tally="0.5714285714285714">4/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
@@ -26390,7 +26390,7 @@ return Array.prototype.length === undefined;
 </tr>
 <tr class="category"><td colspan="60">Annex b</td>
 </tr>
-<tr class="annex_b"><td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span><script data-source="
+<tr significance="0.25" class="annex_b"><td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span><script data-source="
 // Note: only available outside of strict mode.
 { function f() { return 1; } }
   function g() { return 1; }
@@ -26460,7 +26460,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest annex_b"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[27]</sup></a></span></td>
+<tr class="supertest annex_b" significance="0.25"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[27]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="_6to5" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
@@ -26852,7 +26852,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest annex_b"><td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
+<tr class="supertest annex_b" significance="0.25"><td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="_6to5" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
@@ -27111,7 +27111,7 @@ return (desc
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="annex_b"><td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor">String.prototype HTML methods</a></span><script data-source="
+<tr significance="0.25" class="annex_b"><td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.anchor">String.prototype HTML methods</a></span><script data-source="
 var i, names = [&quot;anchor&quot;, &quot;big&quot;, &quot;bold&quot;, &quot;fixed&quot;, &quot;fontcolor&quot;, &quot;fontsize&quot;,
   &quot;italics&quot;, &quot;link&quot;, &quot;small&quot;, &quot;strike&quot;, &quot;sub&quot;, &quot;sup&quot;];
 for (i = 0; i &lt; names.length; i++) {
@@ -27181,7 +27181,7 @@ return true;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="annex_b"><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
+<tr significance="0.25" class="annex_b"><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("409");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>

--- a/es7/index.html
+++ b/es7/index.html
@@ -107,7 +107,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr><td id="Exponentiation_operator"><span><a class="anchor" href="#Exponentiation_operator">&#xA7;</a><a href="https://gist.github.com/rwaldron/ebe0f4d2d267370be882">Exponentiation operator</a></span><script data-source="
+      <tr significance="1"><td id="Exponentiation_operator"><span><a class="anchor" href="#Exponentiation_operator">&#xA7;</a><a href="https://gist.github.com/rwaldron/ebe0f4d2d267370be882">Exponentiation operator</a></span><script data-source="
 return 2 ** 3 === 8;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("0");return Function("asyncTestPassed","\nreturn 2 ** 3 === 8;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -136,7 +136,7 @@ return 2 ** 3 === 8;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span><script data-source="
+<tr significance="1"><td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span><script data-source="
 return [for (a of [1, 2, 3]) a * a][0] === 1
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a][0] === 1\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -165,7 +165,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Generator_comprehensions"><span><a class="anchor" href="#Generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions</a></span><script data-source="
+<tr significance="1"><td id="Generator_comprehensions"><span><a class="anchor" href="#Generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions</a></span><script data-source="
 (for (a of [1, 2, 3]) a * a)
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");return Function("asyncTestPassed","\n(for (a of [1, 2, 3]) a * a)\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -194,7 +194,7 @@ return [for (a of [1, 2, 3]) a * a][0] === 1
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Async_functions"><span><a class="anchor" href="#Async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Async functions</a></span><script data-source="
+<tr significance="1"><td id="Async_functions"><span><a class="anchor" href="#Async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Async functions</a></span><script data-source="
 return (async function(){
   return 42 + await Promise.resolve(42)
 })() instanceof Promise
@@ -225,7 +225,7 @@ return (async function(){
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Arrow_async_functions"><span><a class="anchor" href="#Arrow_async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Arrow async functions</a></span><script data-source="
+<tr significance="1"><td id="Arrow_async_functions"><span><a class="anchor" href="#Arrow_async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Arrow async functions</a></span><script data-source="
 return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");return Function("asyncTestPassed","\nreturn (async () => 42 + await Promise.resolve(42))() instanceof Promise\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -254,7 +254,7 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Typed_objects"><span><a class="anchor" href="#Typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed objects</a></span><script data-source="
+<tr significance="1"><td id="Typed_objects"><span><a class="anchor" href="#Typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed objects</a></span><script data-source="
 return typeof StructType !== &apos;undefined&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");return Function("asyncTestPassed","\nreturn typeof StructType !== 'undefined';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -283,7 +283,7 @@ return typeof StructType !== &apos;undefined&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:observe">Object.observe</a></span><script data-source="
+<tr significance="1"><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:observe">Object.observe</a></span><script data-source="
 return typeof Object.observe === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");return Function("asyncTestPassed","\nreturn typeof Object.observe === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -312,7 +312,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
+<tr significance="1"><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
 return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");return Function("asyncTestPassed","\nreturn typeof Object.getOwnPropertyDescriptors === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -341,7 +341,7 @@ return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes/blob/master/spec.md">Array.prototype.includes</a></span><script data-source="
+<tr significance="1"><td id="Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes/blob/master/spec.md">Array.prototype.includes</a></span><script data-source="
 return typeof Array.prototype.includes === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");return Function("asyncTestPassed","\nreturn typeof Array.prototype.includes === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -370,7 +370,7 @@ return typeof Array.prototype.includes === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr><td id="Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="
+<tr significance="1"><td id="Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="
 var i, names =
   [&quot;eval&quot;, &quot;global&quot;, &quot;intrinsics&quot;, &quot;stdlib&quot;, &quot;directEval&quot;,
   &quot;indirectEval&quot;, &quot;initGlobal&quot;, &quot;nonEval&quot;];

--- a/master.css
+++ b/master.css
@@ -24,8 +24,24 @@ th:nth-child(3) {
     min-width: 10px;
 }
 td {
-    background: #eee; position:relative; padding-left: 10px; margin-left: -10px; font-size: 14px;
+    background: #eee; position:relative; margin-left: -10px; font-size: 14px;
 }
+[significance] td:first-child:before {
+    content: "⬤";
+    opacity:0.2;
+    width:1.5rem;
+    text-align:center;
+    display:inline-block;
+}
+[significance="0.25"] td:first-child:before {
+    content: "⬤";
+    font-size:5px;
+}
+[significance="0.5"] td:first-child:before {
+    content: "⬤";
+    font-size:9px;
+}
+
 td:hover .anchor,
 td .anchor:focus {
     color: #00c;
@@ -39,7 +55,6 @@ td:first-child {
 a[href^='#'] {
     text-decoration: none;
 }
-
 code {
     font-family: "Courier New", Courier, monospace;
 }

--- a/master.js
+++ b/master.js
@@ -253,7 +253,7 @@ $(function() {
     var flaggedResults = yesResults;
     
     table.find('tr.supertest td[data-tally]:not(.not-applicable)' + name).each(function() {
-      var weight = $(this).parent().is('.annex_b') ? 0.2 : 1;
+      var weight = +$(this).parent().attr('significance') || 1;
       var yes = (+$(this).attr('data-tally') || 0) * weight;
       yesResults += yes;
       flaggedResults += yes + (+$(this).attr('data-flagged-tally') || 0) * weight;

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -115,7 +115,7 @@
         </thead>
         <tbody>
           <!-- TABLE BODY -->
-        <tr><td id="uneval"><span><a class="anchor" href="#uneval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval</a></span><script data-source="function () {
+        <tr significance="1"><td id="uneval"><span><a class="anchor" href="#uneval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval</a></span><script data-source="function () {
 return typeof uneval == &apos;function&apos;;
   }">test(
 function () {
@@ -150,7 +150,7 @@ return typeof uneval == 'function';
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="toSource_method"><span><a class="anchor" href="#toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
+<tr significance="1"><td id="toSource_method"><span><a class="anchor" href="#toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
 return &apos;toSource&apos; in Object.prototype
     &amp;&amp; Number   .prototype.hasOwnProperty(&apos;toSource&apos;)
     &amp;&amp; Boolean  .prototype.hasOwnProperty(&apos;toSource&apos;)
@@ -203,7 +203,7 @@ return 'toSource' in Object.prototype
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="function_caller_property"><span><a class="anchor" href="#function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="function_caller_property"><span><a class="anchor" href="#function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
 return &apos;caller&apos; in (function(){});
   }">test(
 function () {
@@ -238,7 +238,7 @@ return 'caller' in (function(){});
 <td class="no" data-browser="rhino">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="function_arity_property"><span><a class="anchor" href="#function_arity_property">&#xA7;</a>function &quot;arity&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="function_arity_property"><span><a class="anchor" href="#function_arity_property">&#xA7;</a>function &quot;arity&quot; property</span><script data-source="function () {
 return (function (){}).arity === 0 &amp;&amp;
   (function (x){}).arity === 1 &amp;&amp;
   (function (x, y){}).arity === 2;
@@ -277,7 +277,7 @@ return (function (){}).arity === 0 &&
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="function_arguments_property"><span><a class="anchor" href="#function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="function_arguments_property"><span><a class="anchor" href="#function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property</span><script data-source="function () {
 function f(a, b) {
   return f.arguments &amp;&amp; f.arguments[0] === 1 &amp;&amp; f.arguments[1] === &apos;boo&apos;;
 }
@@ -318,7 +318,7 @@ return f(1, 'boo');
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="Function.prototype.isGenerator"><span><a class="anchor" href="#Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></span><script data-source="function () {
+<tr significance="1"><td id="Function.prototype.isGenerator"><span><a class="anchor" href="#Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></span><script data-source="function () {
 return typeof Function.prototype.isGenerator == &apos;function&apos;;
   }">test(
 function () {
@@ -355,7 +355,7 @@ return typeof Function.prototype.isGenerator == 'function';
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="__count__"><span><a class="anchor" href="#__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span><script data-source="function () {
+<tr significance="1"><td id="__count__"><span><a class="anchor" href="#__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span><script data-source="function () {
 return typeof ({}).__count__ === &apos;number&apos; &amp;&amp;
   ({ x: 1, y: 2 }).__count__ === 2;
 }">test(
@@ -392,7 +392,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="__parent__"><span><a class="anchor" href="#__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></span><script data-source="function () {
+<tr significance="1"><td id="__parent__"><span><a class="anchor" href="#__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></span><script data-source="function () {
 return typeof ({}).__parent__ !== &apos;undefined&apos;;
   }">test(
 function () {
@@ -427,7 +427,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="__noSuchMethod__"><span><a class="anchor" href="#__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></span><script data-source="function () {
+<tr significance="1"><td id="__noSuchMethod__"><span><a class="anchor" href="#__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></span><script data-source="function () {
 var o = { }, executed = false;
 o.__noSuchMethod__ = function () { executed = true; }
 try {
@@ -472,7 +472,7 @@ return executed;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="__defineGetter__"><span><a class="anchor" href="#__defineGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></span><script data-source="function () {
+<tr significance="1"><td id="__defineGetter__"><span><a class="anchor" href="#__defineGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></span><script data-source="function () {
 return &apos;__defineGetter__&apos; in {};
   }">test(
 function () {
@@ -507,7 +507,7 @@ return '__defineGetter__' in {};
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="__defineSetter__"><span><a class="anchor" href="#__defineSetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></span><script data-source="function () {
+<tr significance="1"><td id="__defineSetter__"><span><a class="anchor" href="#__defineSetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></span><script data-source="function () {
 return &apos;__defineSetter__&apos; in {};
   }">test(
 function () {
@@ -542,7 +542,7 @@ return '__defineSetter__' in {};
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="__lookupGetter__"><span><a class="anchor" href="#__lookupGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span><script data-source="
+<tr significance="1"><td id="__lookupGetter__"><span><a class="anchor" href="#__lookupGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span><script data-source="
 try {
   var obj = eval(&apos;{ get foo() { return &quot;bar&quot;; } }&apos;);
 }
@@ -584,7 +584,7 @@ return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="Array_generics"><span><a class="anchor" href="#Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
+<tr significance="1"><td id="Array_generics"><span><a class="anchor" href="#Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
 return typeof Array.slice === &apos;function&apos; &amp;&amp; Array.slice(&apos;abc&apos;).length === 3;
   }">test(
 function () {
@@ -619,7 +619,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="String_generics"><span><a class="anchor" href="#String_generics">&#xA7;</a>String generics</span><script data-source="function () {
+<tr significance="1"><td id="String_generics"><span><a class="anchor" href="#String_generics">&#xA7;</a>String generics</span><script data-source="function () {
 return typeof String.slice === &apos;function&apos; &amp;&amp; String.slice(123, 1) === &quot;23&quot;;
   }">test(
 function () {
@@ -656,7 +656,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="Array_comprehensions_(right-to-left)"><span><a class="anchor" href="#Array_comprehensions_(right-to-left)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (right-to-left)</a></span><script data-source="
+<tr significance="1"><td id="Array_comprehensions_(right-to-left)"><span><a class="anchor" href="#Array_comprehensions_(right-to-left)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (right-to-left)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var a = [i * 2 for (i in obj) if (i !== &quot;foo&quot;)];
 return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
@@ -691,7 +691,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Expression_closures"><span><a class="anchor" href="#Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
+<tr significance="1"><td id="Expression_closures"><span><a class="anchor" href="#Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
 return (function(x)x)(1) === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");return Function("asyncTestPassed","\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -724,7 +724,7 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
+<tr significance="1"><td id="ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");return Function("asyncTestPassed","\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -757,7 +757,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="for_each..in_loops"><span><a class="anchor" href="#for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a></span><script data-source="
+<tr significance="1"><td id="for_each..in_loops"><span><a class="anchor" href="#for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a></span><script data-source="
 var str = &apos;&apos;;
 for each (var item in {a: &quot;foo&quot;, b: &quot;bar&quot;, c: &quot;baz&quot;}) {
   str += item;
@@ -794,7 +794,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
+<tr significance="1"><td id="Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
 var arr = #1=[1, #1#, 3];
 return arr[1] === arr;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");return Function("asyncTestPassed","\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed);}catch(e){return false;}}());
@@ -830,7 +830,7 @@ return arr[1] === arr;
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="Iterator"><span><a class="anchor" href="#Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
+<tr significance="1"><td id="Iterator"><span><a class="anchor" href="#Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
 try {
   var it = Iterator({ foo: 1, bar: 2 });
   var keys = &quot;&quot;;
@@ -889,7 +889,7 @@ catch(e) {
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="__iterator__"><span><a class="anchor" href="#__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
+<tr significance="1"><td id="__iterator__"><span><a class="anchor" href="#__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
 try {
   var x = 5;
   var iter = {
@@ -956,7 +956,7 @@ catch(e) {
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Generators_(JS_1.8)"><span><a class="anchor" href="#Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="test(function () {
+<tr significance="1"><td id="Generators_(JS_1.8)"><span><a class="anchor" href="#Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="test(function () {
 try {
   var g = eval(&apos;(function() { var a = yield &quot;foo&quot;; yield a + &quot;baz&quot;;})&apos;)();
   var passed = g.next() === &quot;foo&quot;;
@@ -1028,7 +1028,7 @@ test(function () {
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Generator_comprehensions_(JS_1.8)"><span><a class="anchor" href="#Generator_comprehensions_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8)</a></span><script data-source="
+<tr significance="1"><td id="Generator_comprehensions_(JS_1.8)"><span><a class="anchor" href="#Generator_comprehensions_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var g = (i * 2 for (i in obj) if (i !== &quot;foo&quot;));
 return g.next() === 4 &amp;&amp; g.next() === 8;
@@ -1065,7 +1065,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
+<tr significance="1"><td id="RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
   var re = RegExp(&apos;^ ( \\d+ ) \
                      ( \\w+ ) \
@@ -1114,7 +1114,7 @@ try {
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="RegExp_lastMatch"><span><a class="anchor" href="#RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot;</span><script data-source="function () {
+<tr significance="1"><td id="RegExp_lastMatch"><span><a class="anchor" href="#RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot;</span><script data-source="function () {
 var re = /\w/;
 re.exec(&apos;x&apos;);
 return RegExp.lastMatch === &apos;x&apos;;
@@ -1153,7 +1153,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="RegExp.$1-$9"><span><a class="anchor" href="#RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9</span><script data-source="function () {
+<tr significance="1"><td id="RegExp.$1-$9"><span><a class="anchor" href="#RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9</span><script data-source="function () {
 for (var i = 1; i &lt; 10; i++) {
   if (!((&apos;$&apos; + i) in RegExp)) return false;
 }
@@ -1194,7 +1194,7 @@ return true;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
+<tr significance="1"><td id="Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");return Function("asyncTestPassed","\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -1227,7 +1227,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
+<tr significance="1"><td id="RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
@@ -1262,7 +1262,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="String.prototype.trimLeft"><span><a class="anchor" href="#String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
+<tr significance="1"><td id="String.prototype.trimLeft"><span><a class="anchor" href="#String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimLeft === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1293,7 +1293,7 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="no" data-browser="rhino">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="String.prototype.trimRight"><span><a class="anchor" href="#String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a></span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
+<tr significance="1"><td id="String.prototype.trimRight"><span><a class="anchor" href="#String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a></span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimRight === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1324,7 +1324,7 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="no" data-browser="rhino">No</td>
 <td class="yes" data-browser="phantom">Yes</td>
 </tr>
-<tr><td id="String.prototype.quote"><span><a class="anchor" href="#String.prototype.quote">&#xA7;</a>String.prototype.quote</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
+<tr significance="1"><td id="String.prototype.quote"><span><a class="anchor" href="#String.prototype.quote">&#xA7;</a>String.prototype.quote</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1355,7 +1355,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="String.prototype.replace_flags"><span><a class="anchor" href="#String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a></span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
+<tr significance="1"><td id="String.prototype.replace_flags"><span><a class="anchor" href="#String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a></span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1388,7 +1388,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="Date.prototype.toLocaleFormat"><span><a class="anchor" href="#Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
+<tr significance="1"><td id="Date.prototype.toLocaleFormat"><span><a class="anchor" href="#Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1421,7 +1421,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="Object.prototype.watch"><span><a class="anchor" href="#Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
+<tr significance="1"><td id="Object.prototype.watch"><span><a class="anchor" href="#Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1452,7 +1452,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Object.prototype.unwatch"><span><a class="anchor" href="#Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a></span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
+<tr significance="1"><td id="Object.prototype.unwatch"><span><a class="anchor" href="#Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a></span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1483,7 +1483,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="Object.prototype.eval"><span><a class="anchor" href="#Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a></span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
+<tr significance="1"><td id="Object.prototype.eval"><span><a class="anchor" href="#Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a></span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1516,7 +1516,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 </tr>
 <tr><th colspan="31" class="separator"></th>
 </tr>
-<tr><td id="error_stack"><span><a class="anchor" href="#error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="error_stack"><span><a class="anchor" href="#error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
 try {
   throw new Error;
 } catch (err) {
@@ -1559,7 +1559,7 @@ try {
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="error_lineNumber"><span><a class="anchor" href="#error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="error_lineNumber"><span><a class="anchor" href="#error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a></span><script data-source="function () {
 return &apos;lineNumber&apos; in new Error;
   }">test(
 function () {
@@ -1594,7 +1594,7 @@ return 'lineNumber' in new Error;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="error_columnNumber"><span><a class="anchor" href="#error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="error_columnNumber"><span><a class="anchor" href="#error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a></span><script data-source="function () {
 return &apos;columnNumber&apos; in new Error;
   }">test(
 function () {
@@ -1629,7 +1629,7 @@ return 'columnNumber' in new Error;
 <td class="no" data-browser="rhino">No</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="error_fileName"><span><a class="anchor" href="#error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="error_fileName"><span><a class="anchor" href="#error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a></span><script data-source="function () {
 return &apos;fileName&apos; in new Error;
   }">test(
 function () {
@@ -1664,7 +1664,7 @@ return 'fileName' in new Error;
 <td class="yes" data-browser="rhino">Yes</td>
 <td class="no" data-browser="phantom">No</td>
 </tr>
-<tr><td id="error_description"><span><a class="anchor" href="#error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="error_description"><span><a class="anchor" href="#error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
 return &apos;description&apos; in new Error;
   }">test(
 function () {


### PR DESCRIPTION
These weightings are used to calculate the percentages more accurately - a supertest rated "large" (representing a major, transformative language feature) is worth 1, one rated "medium" (representing a significant feature that's less universally useful, or is primarily connected to another feature) is worth 0.5, and one rated "small" (representing a useful but subtle improvement from ES5) is worth 0.25. They are based solely on my informed judgment, and could easily be disputed.

This replaces the previous weighting system installed recently, which made every supertest equal to 1, but every annex B supertest equal to 0.2.

Also: some faint circles have been added to the supertests' `<td>` names, denoting their weighting (large, medium or small) to the reader.
