### PR TITLE
update core-js results

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,16 +80,16 @@ process.nextTick(function () {
       target_file: 'es6/compilers/6to5.html',
       polyfills: [],
       compiler: function(code) {
-        return to5.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
+        return to5.transform(code, { experimental: true }).code;
       },
     },
     {
-      name: '6to5 + polyfill',
+      name: '6to5 + core-js',
       url: 'https://6to5.github.io/',
-      target_file: 'es6/compilers/6to5-polyfill.html',
+      target_file: 'es6/compilers/6to5-core-js.html',
       polyfills: ['node_modules/6to5/browser-polyfill.js'],
       compiler: function(code) {
-        return to5.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
+        return to5.transform(code, { experimental: true }).code;
       },
     },
     {

--- a/data-es6.js
+++ b/data-es6.js
@@ -2281,6 +2281,7 @@ exports.tests = [
         return Number('0o1') === 1;
       */},
       res: {
+        _6to5:       true,
         ejs:         true,
         firefox36:   true,
         chrome30:    flag,
@@ -2294,6 +2295,7 @@ exports.tests = [
         return Number('0b1') === 1;
       */},
       res: {
+        _6to5:       true,
         ejs:         true,
         firefox36:   true,
         chrome30:    flag,
@@ -4410,6 +4412,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        _6to5:       true,
         ejs:         true,
         ie11tp:      true,
         firefox36:   true,
@@ -5252,6 +5255,7 @@ exports.tests = [
           && !(Symbol.species in Object);
       */},
       res: {
+        _6to5:       true,
         ejs:         true,
       },
     },

--- a/es6/index.html
+++ b/es6/index.html
@@ -2506,7 +2506,7 @@ return result === &quot;123&quot;;
 </tr>
 <tr class="supertest"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="_6to5" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="closure" class="tally" data-tally="0.5">2/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -2695,7 +2695,7 @@ return Number(&apos;0o1&apos;) === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");return Function("asyncTestPassed","\nreturn Number('0o1') === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -2758,7 +2758,7 @@ return Number(&apos;0b1&apos;) === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");return Function("asyncTestPassed","\nreturn Number('0b1') === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18142,7 +18142,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 </tr>
 <tr class="supertest"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="_6to5" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="_6to5" class="tally" data-tally="0.42857142857142855">3/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -18419,7 +18419,7 @@ return RegExp[Symbol.species] === RegExp
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nreturn RegExp[Symbol.species] === RegExp\n  && Array[Symbol.species] === Array\n  && !(Symbol.species in Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18685,7 +18685,7 @@ with (a) {
 </tr>
 <tr class="supertest"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="_6to5" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="_6to5" class="tally" data-tally="0.75">3/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -18880,7 +18880,7 @@ return Object.getOwnPropertySymbols(o)[0] === sym;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol();\no[sym] = \"foo\";\nreturn Object.getOwnPropertySymbols(o)[0] === sym;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="no" data-browser="_6to5">No</td>
+<td class="yes" data-browser="_6to5">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>


### PR DESCRIPTION
- [octal supported by `Number()`](http://goo.gl/TbdwsM)
- [binary supported by `Number()`](http://goo.gl/shrq0j)
- [well-known symbols -> `Symbol.species`](http://goo.gl/hRfYwW)
- [`Object.getOwnPropertySymbols`](http://goo.gl/uo4uFV)

Also, removed `typeofSymbol` optional transformer from 6to5 build step (deprecated, now available as `spec.typeofSymbol` and not required for tests).
