### PR TITLE
Update `es6-shim` with `Reflect` and `Object.gOPN` primitives

### DIFF
--- a/build.js
+++ b/build.js
@@ -51,7 +51,7 @@ process.nextTick(function () {
     fs.mkdirSync('es7/compilers');
   }
   var closure    = require('closurecompiler');
-  var to5        = require('6to5');
+  var babel      = require('babel');
   var traceur    = require('traceur');
   var reacttools = require('react-tools');
   var tss        = require('typescript-simple');
@@ -80,7 +80,7 @@ process.nextTick(function () {
       target_file: 'es6/compilers/babel.html',
       polyfills: [],
       compiler: function(code) {
-        return to5.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
+        return babel.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
       },
     },
     {
@@ -89,7 +89,7 @@ process.nextTick(function () {
       target_file: 'es6/compilers/babel-polyfill.html',
       polyfills: ['node_modules/babel/browser-polyfill.js'],
       compiler: function(code) {
-        return to5.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
+        return babel.transform(code, { experimental: true, optional: ['typeofSymbol'] }).code;
       },
     },
     {

--- a/data-es6.js
+++ b/data-es6.js
@@ -4505,6 +4505,7 @@ exports.tests = [
         firefox33:   true,
         chrome40:    true,
         iojs:        true,
+        es6shim:     true,
       },
     },
     'Object.seal': {

--- a/data-es6.js
+++ b/data-es6.js
@@ -3819,16 +3819,16 @@ exports.tests = [
         var obj = { foo: 1, bar: 2 };
         var iterator = Reflect.enumerate(obj);
         var passed = 1;
-        if (typeof Symbol != undefined && 'iterator' in Symbol) {
+        if (typeof Symbol === 'function' && 'iterator' in Symbol) {
           passed &= Symbol.iterator in iterator;
         }
         var item = iterator.next();
-        passed    &= item.value === "foo" && item.done === false;
+        passed &= item.value === "foo" && item.done === false;
         item = iterator.next();
-        passed    &= item.value === "bar" && item.done === false;
+        passed &= item.value === "bar" && item.done === false;
         item = iterator.next();
-        passed    &= item.value === undefined && item.done === true;
-        return passed;
+        passed &= item.value === undefined && item.done === true;
+        return passed === 1;
       */},
       res: {
         babel:       true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -3708,6 +3708,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.set': {
@@ -3720,6 +3721,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.has': {
@@ -3730,6 +3732,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.deleteProperty': {
@@ -3742,6 +3745,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.getOwnPropertyDescriptor': {
@@ -3755,6 +3759,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.defineProperty': {
@@ -3767,6 +3772,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.getPrototypeOf': {
@@ -3777,6 +3783,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.setPrototypeOf': {
@@ -3789,6 +3796,7 @@ exports.tests = [
         babel:       { val: false, note_id: 'compiler-proto' },
         ejs:         true,
         ie11tp:      true,
+        es6shim:     { val: false, note_id: 'compiler-proto' },
       },
     },
     'Reflect.isExtensible': {
@@ -3800,6 +3808,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.preventExtensions': {
@@ -3812,6 +3821,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.enumerate': {
@@ -3833,6 +3843,7 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        es6shim:     true,
       },
     },
     'Reflect.ownKeys': {
@@ -3843,6 +3854,7 @@ exports.tests = [
       res: {
         babel:       true,
         ejs:         true,
+        es6shim:     true,
       },
     },
     'Reflect.apply': {
@@ -3853,6 +3865,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.construct': {
@@ -3865,6 +3878,7 @@ exports.tests = [
         babel:       true,
         ejs:         true,
         ie11tp:      true,
+        es6shim:     true,
       },
     },
     'Reflect.construct, new.target': {

--- a/es6/index.html
+++ b/es6/index.html
@@ -16143,7 +16143,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td data-browser="closure" class="tally" data-tally="0">0/15</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/15</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/15</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/15</td>
+<td data-browser="es6shim" class="tally" data-tally="0.8666666666666667">13/15</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/15</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/15</td>
 <td data-browser="ie11tp" class="tally" data-tally="0.8">12/15</td>
@@ -16206,7 +16206,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16271,7 +16271,7 @@ return obj.quux === 654;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16334,7 +16334,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16399,7 +16399,7 @@ return !(&quot;bar&quot; in obj);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16465,7 +16465,7 @@ return desc.value === 789 &amp;&amp;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16530,7 +16530,7 @@ return obj.foo === 123;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16593,7 +16593,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16658,7 +16658,7 @@ return obj instanceof Array;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16722,7 +16722,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16787,7 +16787,7 @@ return !Object.isExtensible(obj);
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -16844,17 +16844,17 @@ return !Object.isExtensible(obj);
 var obj = { foo: 1, bar: 2 };
 var iterator = Reflect.enumerate(obj);
 var passed = 1;
-if (typeof Symbol != undefined &amp;&amp; &apos;iterator&apos; in Symbol) {
+if (typeof Symbol === &apos;function&apos; &amp;&amp; &apos;iterator&apos; in Symbol) {
   passed &amp;= Symbol.iterator in iterator;
 }
 var item = iterator.next();
-passed    &amp;= item.value === &quot;foo&quot; &amp;&amp; item.done === false;
+passed &amp;= item.value === &quot;foo&quot; &amp;&amp; item.done === false;
 item = iterator.next();
-passed    &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
+passed &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
-passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
-return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1;\nif (typeof Symbol != undefined && 'iterator' in Symbol) {\n  passed &= Symbol.iterator in iterator;\n}\nvar item = iterator.next();\npassed    &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+passed &amp;= item.value === undefined &amp;&amp; item.done === true;
+return passed === 1;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1;\nif (typeof Symbol === 'function' && 'iterator' in Symbol) {\n  passed &= Symbol.iterator in iterator;\n}\nvar item = iterator.next();\npassed &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === undefined && item.done === true;\nreturn passed === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -16862,7 +16862,7 @@ return passed;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="ie11tp">No</td>
@@ -16926,7 +16926,7 @@ return Reflect.ownKeys(obj) + &quot;&quot; === &quot;foo,bar&quot;;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="ie11tp">No</td>
@@ -16989,7 +16989,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>
@@ -17054,7 +17054,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="ie11tp">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -25182,7 +25182,7 @@ return c instanceof String
 <td data-browser="closure" class="tally" data-tally="0">0/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/10</td>
-<td data-browser="es6shim" class="tally" data-tally="0.1">1/10</td>
+<td data-browser="es6shim" class="tally" data-tally="0.2">2/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11tp" class="tally" data-tally="0">0/10</td>
@@ -25373,7 +25373,7 @@ return s.length === 2 &amp;&amp;
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="ie11tp">No</td>

--- a/es7/compilers/es7-shim.html
+++ b/es7/compilers/es7-shim.html
@@ -682,54 +682,54 @@ module.exports = require('./es7-shim').shim();
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr><td id="Exponentiation_operator"><span><a class="anchor" href="#Exponentiation_operator">&#xA7;</a><a href="https://gist.github.com/rwaldron/ebe0f4d2d267370be882">Exponentiation operator</a></span><script data-source="(function(){
+      <tr significance="1"><td id="Exponentiation_operator"><span><a class="anchor" href="#Exponentiation_operator">&#xA7;</a><a href="https://gist.github.com/rwaldron/ebe0f4d2d267370be882">Exponentiation operator</a></span><script data-source="(function(){
 return 2 ** 3 === 8;
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("0");return global.__asyncPassedFn && __asyncPassedFn("0") && eval("(function(){\nreturn 2 ** 3 === 8;\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span><script data-source="(function(){
+<tr significance="1"><td id="Array_comprehensions"><span><a class="anchor" href="#Array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions</a></span><script data-source="(function(){
 return [for (a of [1, 2, 3]) a * a][0] === 1
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");return global.__asyncPassedFn && __asyncPassedFn("1") && eval("(function(){\nreturn [for (a of [1, 2, 3]) a * a][0] === 1\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Generator_comprehensions"><span><a class="anchor" href="#Generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions</a></span><script data-source="(function(){
+<tr significance="1"><td id="Generator_comprehensions"><span><a class="anchor" href="#Generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions</a></span><script data-source="(function(){
 (for (a of [1, 2, 3]) a * a)
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");return global.__asyncPassedFn && __asyncPassedFn("2") && eval("(function(){\n(for (a of [1, 2, 3]) a * a)\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Async_functions"><span><a class="anchor" href="#Async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Async functions</a></span><script data-source="(function(){
+<tr significance="1"><td id="Async_functions"><span><a class="anchor" href="#Async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Async functions</a></span><script data-source="(function(){
 return (async function(){
   return 42 + await Promise.resolve(42)
 })() instanceof Promise
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");return global.__asyncPassedFn && __asyncPassedFn("3") && eval("(function(){\nreturn (async function(){\n  return 42 + await Promise.resolve(42)\n})() instanceof Promise\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Arrow_async_functions"><span><a class="anchor" href="#Arrow_async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Arrow async functions</a></span><script data-source="(function(){
+<tr significance="1"><td id="Arrow_async_functions"><span><a class="anchor" href="#Arrow_async_functions">&#xA7;</a><a href="https://github.com/lukehoban/ecmascript-asyncawait">Arrow async functions</a></span><script data-source="(function(){
 return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");return global.__asyncPassedFn && __asyncPassedFn("4") && eval("(function(){\nreturn (async () => 42 + await Promise.resolve(42))() instanceof Promise\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Typed_objects"><span><a class="anchor" href="#Typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed objects</a></span><script data-source="(function(){
+<tr significance="1"><td id="Typed_objects"><span><a class="anchor" href="#Typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">Typed objects</a></span><script data-source="(function(){
 return typeof StructType !== &apos;undefined&apos;;
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");return global.__asyncPassedFn && __asyncPassedFn("5") && eval("(function(){\nreturn typeof StructType !== 'undefined';\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:observe">Object.observe</a></span><script data-source="(function(){
+<tr significance="1"><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:observe">Object.observe</a></span><script data-source="(function(){
 return typeof Object.observe === &apos;function&apos;;
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");return global.__asyncPassedFn && __asyncPassedFn("6") && eval("(function(){\nreturn typeof Object.observe === 'function';\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="(function(){
+<tr significance="1"><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="(function(){
 return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");return global.__asyncPassedFn && __asyncPassedFn("7") && eval("(function(){\nreturn typeof Object.getOwnPropertyDescriptors === 'function';\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes/blob/master/spec.md">Array.prototype.includes</a></span><script data-source="(function(){
+<tr significance="1"><td id="Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes/blob/master/spec.md">Array.prototype.includes</a></span><script data-source="(function(){
 return typeof Array.prototype.includes === &apos;function&apos;;
   })">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");return global.__asyncPassedFn && __asyncPassedFn("8") && eval("(function(){\nreturn typeof Array.prototype.includes === 'function';\n  })")()}catch(e){return false;}}());
 </script></td>
 </tr>
-<tr><td id="Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="(function(){
+<tr significance="1"><td id="Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="(function(){
 var i, names =
   [&quot;eval&quot;, &quot;global&quot;, &quot;intrinsics&quot;, &quot;stdlib&quot;, &quot;directEval&quot;,
   &quot;indirectEval&quot;, &quot;initGlobal&quot;, &quot;nonEval&quot;];


### PR DESCRIPTION
`es6-shim` now has the `Reflect` API, as well as wrapping `Object.getOwnPropertyNames` to accept primitives.

Also, the `Reflect.enumerate` test was broken, so I fixed it - you may want to check on all the other columns' values for that.

Also fixes an issue from #439 with an incomplete 6to5 → babel rename.
