### PR TITLE
Updating `es7-shim` `Object.getOwnPropertyDescriptors` results

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -348,7 +348,7 @@ exports.tests = [
   res: {
     tr: false,
     babel: false,
-    es7shim: false,
+    es7shim: true,
     ejs: false,
     ie11: false,
     firefox31: false,

--- a/es7/index.html
+++ b/es7/index.html
@@ -318,7 +318,7 @@ return typeof Object.getOwnPropertyDescriptors === &apos;function&apos;;
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox31">No</td>
 <td class="no" data-browser="firefox32">No</td>


### PR DESCRIPTION
`es7-shim` now supports `Object.getOwnPropertyDescriptors`
