### PR TITLE
Supertest cells are now coloured by percentage.

### DIFF
--- a/build.js
+++ b/build.js
@@ -392,11 +392,15 @@ function dataToHtml(skeleton, browsers, tests, compiler) {
             flaggedTally += testValue(result) === 'flagged';
             outOf += 1;
           });
-
+          var grade = (tally / outOf);
           var cell = resultCell(browserId, null)
             .text((tally|0) + "/" + outOf)
             .addClass('tally')
-            .attr('data-tally', tally / outOf);
+            .attr('data-tally', grade);
+          if (grade > 0 && grade < 1 && !cell.hasClass('not-applicable')) {
+            cell.attr('style','background-color:hsl(' + (120*grade|0) + ','
+              +((86 - (grade*44))|0)  +'%,50%)');
+          }
 
           if (flaggedTally) {
             cell.attr('data-flagged-tally',  (tally + flaggedTally) / outOf);

--- a/es6/index.html
+++ b/es6/index.html
@@ -185,7 +185,7 @@
 </tr>
 <tr class="supertest" significance="0.5"><td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0" data-flagged-tally="1">0/2</td>
-<td data-browser="babel" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="closure" class="tally" data-tally="0">0/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -391,35 +391,35 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <tr class="category"><td colspan="60">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="babel" class="tally" data-tally="1">5/5</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="closure" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="closure" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
-<td data-browser="typescript" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="typescript" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11tp" class="tally" data-tally="0">0/5</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.4">2/5</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.4">2/5</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox35" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox36" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox37" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox35" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox36" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox37" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/5</td>
@@ -446,7 +446,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/5</td>
-<td data-browser="ejs" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="ejs" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/5</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/5</td>
 </tr>
@@ -783,33 +783,33 @@ return (function(a=function(){
 <tr class="supertest" significance="0.5"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="babel" class="tally" data-tally="1">3/3</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="closure" class="tally" data-tally="0.3333333333333333">1/3</td>
-<td data-browser="jsx" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="typescript" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="closure" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td data-browser="jsx" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="typescript" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/3</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/3</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/3</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/3</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox35" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox36" class="tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox37" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox35" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox36" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox37" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/3</td>
@@ -836,7 +836,7 @@ return (function(a=function(){
 <td data-browser="phantom" class="tally" data-tally="0">0/3</td>
 <td data-browser="node" class="tally" data-tally="0">0/3</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/3</td>
-<td data-browser="ejs" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="ejs" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/3</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/3</td>
 </tr>
@@ -1042,31 +1042,31 @@ return (function (foo, ...args) {
 <tr class="supertest" significance="1"><td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">10/10</td>
 <td data-browser="babel" class="tally" data-tally="1">10/10</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6">6/10</td>
-<td data-browser="closure" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
+<td data-browser="closure" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/10</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/10</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.4">4/10</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/10</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.1">1/10</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2">2/10</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2">2/10</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.2">2/10</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.2">2/10</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.2">2/10</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox31" class="tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.8">8/10</td>
-<td data-browser="firefox35" class="tally" data-tally="0.8">8/10</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox31" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="firefox36" class="tally" data-tally="1">10/10</td>
 <td data-browser="firefox37" class="tally" data-tally="1">10/10</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/10</td>
@@ -1087,17 +1087,17 @@ return (function (foo, ...args) {
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/10</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.2">2/10</td>
-<td data-browser="webkit" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="webkit" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="opera" class="tally" data-tally="0">0/10</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/10</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/10</td>
 <td data-browser="node" class="tally" data-tally="0">0/10</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/10</td>
-<td data-browser="ejs" class="tally" data-tally="0.8">8/10</td>
+<td data-browser="ejs" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/10</td>
-<td data-browser="ios8" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="ios8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 </tr>
 <tr class="subtest" data-parent="spread_(...)_operator"><td><span>with arrays, in function calls</span><script data-source="
 return Math.max(...[1, 2, 3]) === 3
@@ -1737,9 +1737,9 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="tr" class="tally" data-tally="1">5/5</td>
 <td data-browser="babel" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="tally" data-tally="1">5/5</td>
-<td data-browser="closure" class="tally" data-tally="0.8">4/5</td>
-<td data-browser="jsx" class="tally" data-tally="0.4">2/5</td>
-<td data-browser="typescript" class="tally" data-tally="0.4">2/5</td>
+<td data-browser="closure" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="jsx" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="typescript" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/5</td>
@@ -1758,7 +1758,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="firefox30" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="firefox31" class="tally" data-tally="0">0/5</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.2">1/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="1">5/5</td>
 <td data-browser="firefox35" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox36" class="tally" data-tally="1">5/5</td>
@@ -1781,17 +1781,17 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="webkit" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="webkit" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="0">0/5</td>
 <td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.4">0/5</td>
-<td data-browser="ejs" class="tally" data-tally="0.6">3/5</td>
+<td data-browser="ejs" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/5</td>
-<td data-browser="ios8" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="ios8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 </tr>
 <tr class="subtest" data-parent="object_literal_extensions"><td><span>computed properties</span><script data-source="
 var x = &apos;y&apos;;
@@ -2121,8 +2121,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <tr class="supertest" significance="1"><td id="for..of_loops"><span><a class="anchor" href="#for..of_loops">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">5/5</td>
 <td data-browser="babel" class="tally" data-tally="1">5/5</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="closure" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="closure" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/5</td>
@@ -2130,22 +2130,22 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td data-browser="ie11" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/5</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox31" class="tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox35" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox31" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="firefox36" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox37" class="tally" data-tally="1">5/5</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/5</td>
@@ -2166,17 +2166,17 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="webkit" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="webkit" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/5</td>
 <td data-browser="node" class="tally" data-tally="1">5/5</td>
 <td data-browser="iojs" class="tally" data-tally="1">5/5</td>
-<td data-browser="ejs" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="ejs" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/5</td>
-<td data-browser="ios8" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="ios8" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 </tr>
 <tr class="subtest" data-parent="for..of_loops"><td><span>with arrays</span><script data-source="
 var arr = [5];
@@ -2512,16 +2512,16 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals">octal and binary literals</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="babel" class="tally" data-tally="1">4/4</td>
-<td data-browser="es6tr" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="closure" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="es6tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="closure" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
-<td data-browser="typescript" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/4</td>
@@ -2529,16 +2529,16 @@ return result === &quot;123&quot;;
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox23" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox24" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox35" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox35" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="firefox36" class="tally" data-tally="1">4/4</td>
 <td data-browser="firefox37" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
@@ -2829,11 +2829,11 @@ return Number(&apos;0b1&apos;) === 1;
 <td data-browser="es6tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="closure" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="1">2/2</td>
-<td data-browser="typescript" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="typescript" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/2</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/2</td>
@@ -3023,8 +3023,8 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky">RegExp &quot;y&quot; and &quot;u&quot; flags</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="babel" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="closure" class="tally" data-tally="0">0/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -3032,26 +3032,26 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td data-browser="es6shim" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/2</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox35" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox36" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox37" class="tally" data-tally="0.5">1/2</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox35" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox36" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox37" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/2</td>
@@ -3213,35 +3213,35 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9166666666666666">22/24</td>
-<td data-browser="babel" class="tally" data-tally="0.9583333333333334" data-flagged-tally="1">23/24</td>
-<td data-browser="es6tr" class="tally" data-tally="0.7083333333333334">17/24</td>
-<td data-browser="closure" class="tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="jsx" class="tally" data-tally="0.375">9/24</td>
+<td data-browser="tr" class="tally" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">22/24</td>
+<td data-browser="babel" class="tally" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)" data-flagged-tally="1">23/24</td>
+<td data-browser="es6tr" class="tally" data-tally="0.7083333333333334" style="background-color:hsl(85,54%,50%)">17/24</td>
+<td data-browser="closure" class="tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="jsx" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">9/24</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/24</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/24</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/24</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/24</td>
 <td data-browser="ie11tp" class="tally" data-tally="0">0/24</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.4583333333333333">11/24</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.5">12/24</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5833333333333334">14/24</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.7083333333333334">17/24</td>
-<td data-browser="firefox35" class="tally" data-tally="0.75">18/24</td>
-<td data-browser="firefox36" class="tally" data-tally="0.7916666666666666">19/24</td>
-<td data-browser="firefox37" class="tally" data-tally="0.7916666666666666">19/24</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.4583333333333333" style="background-color:hsl(55,65%,50%)">11/24</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">12/24</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.7083333333333334" style="background-color:hsl(85,54%,50%)">17/24</td>
+<td data-browser="firefox35" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">18/24</td>
+<td data-browser="firefox36" class="tally" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
+<td data-browser="firefox37" class="tally" data-tally="0.7916666666666666" style="background-color:hsl(95,51%,50%)">19/24</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/24</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/24</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/24</td>
@@ -3260,17 +3260,17 @@ return &quot;&#x20BB7;&quot;.match(/./u)[0].length === 2;
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/24</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/24</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/24</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.5416666666666666">13/24</td>
-<td data-browser="webkit" class="tally" data-tally="0.5833333333333334">14/24</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.5416666666666666" style="background-color:hsl(65,62%,50%)">13/24</td>
+<td data-browser="webkit" class="tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
 <td data-browser="opera" class="tally" data-tally="0">0/24</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/24</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/24</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/24</td>
 <td data-browser="node" class="tally" data-tally="0">0/24</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/24</td>
-<td data-browser="ejs" class="tally" data-tally="0.375">9/24</td>
+<td data-browser="ejs" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">9/24</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/24</td>
-<td data-browser="ios8" class="tally" data-tally="0.5416666666666666">13/24</td>
+<td data-browser="ios8" class="tally" data-tally="0.5416666666666666" style="background-color:hsl(65,62%,50%)">13/24</td>
 </tr>
 <tr class="subtest" data-parent="destructuring"><td><span>with arrays</span><script data-source="
 var [a, , [b], c] = [5, null, [6]];
@@ -4922,64 +4922,64 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <tr class="category"><td colspan="60">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="const"><span><a class="anchor" href="#const">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">const</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="babel" class="tally" data-tally="0.75" data-flagged-tally="1">6/8</td>
-<td data-browser="es6tr" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="closure" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="jsx" class="tally" data-tally="0.125">1/8</td>
+<td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)" data-flagged-tally="1">6/8</td>
+<td data-browser="es6tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="closure" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="jsx" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/8</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie11" class="tally" data-tally="1">8/8</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">8/8</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox31" class="tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.375">3/8</td>
-<td data-browser="firefox35" class="tally" data-tally="0.375">3/8</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox31" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="firefox35" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
 <td data-browser="firefox36" class="tally" data-tally="1">8/8</td>
 <td data-browser="firefox37" class="tally" data-tally="1">8/8</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.25">1/8</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.5">1/8</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome40" class="tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="chrome41" class="tally" data-tally="0.625">5/8</td>
-<td data-browser="chrome42" class="tally" data-tally="0.625">5/8</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.125">1/8</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.125">1/8</td>
-<td data-browser="safari7" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="webkit" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="opera" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="konq49" class="tally" data-tally="0.25">2/8</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.25">1/8</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.5">1/8</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome40" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="chrome41" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td data-browser="chrome42" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="safari7" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="webkit" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="opera" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="konq49" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
-<td data-browser="phantom" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="node" class="tally" data-tally="0.125" data-flagged-tally="0.625">1/8</td>
-<td data-browser="iojs" class="tally" data-tally="0.625">5/8</td>
-<td data-browser="ejs" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="ios7" class="tally" data-tally="0.125">1/8</td>
-<td data-browser="ios8" class="tally" data-tally="0.125">1/8</td>
+<td data-browser="phantom" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="node" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.625">1/8</td>
+<td data-browser="iojs" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td data-browser="ejs" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="ios7" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td data-browser="ios8" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 </tr>
 <tr class="subtest" data-parent="const"><td><span>basic support</span><script data-source="
 const foo = 123;
@@ -5510,16 +5510,16 @@ return passed;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="let"><span><a class="anchor" href="#let">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-let-and-const-declarations">let</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8">8/10</td>
-<td data-browser="babel" class="tally" data-tally="0.8" data-flagged-tally="1">8/10</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6">6/10</td>
-<td data-browser="closure" class="tally" data-tally="0.8">8/10</td>
+<td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="1">8/10</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
+<td data-browser="closure" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/10</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
-<td data-browser="ie11" class="tally" data-tally="0.8">8/10</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.8">8/10</td>
+<td data-browser="ie11" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/10</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/10</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/10</td>
@@ -5552,8 +5552,8 @@ return passed;
 <td data-browser="chrome38" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/10</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/10</td>
 <td data-browser="chrome40" class="tally" data-tally="0" data-flagged-tally="0.5">0/10</td>
-<td data-browser="chrome41" class="tally" data-tally="0.5">5/10</td>
-<td data-browser="chrome42" class="tally" data-tally="0.5">5/10</td>
+<td data-browser="chrome41" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome42" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/10</td>
@@ -5564,7 +5564,7 @@ return passed;
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/10</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.5">0/10</td>
-<td data-browser="iojs" class="tally" data-tally="0.5">5/10</td>
+<td data-browser="iojs" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td data-browser="ejs" class="tally" data-tally="1">10/10</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/10</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/10</td>
@@ -6311,35 +6311,35 @@ return f() === 1;
 <tr class="category"><td colspan="60">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions">arrow functions</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="babel" class="tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="closure" class="tally" data-tally="0.7272727272727273">8/11</td>
-<td data-browser="jsx" class="tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="typescript" class="tally" data-tally="0.5454545454545454" data-flagged-tally="0.6363636363636364">6/11</td>
+<td data-browser="tr" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="babel" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="closure" class="tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
+<td data-browser="jsx" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="typescript" class="tally" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)" data-flagged-tally="0.6363636363636364">6/11</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/11</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/11</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/11</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.7272727272727273">8/11</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox35" class="tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox36" class="tally" data-tally="0.6363636363636364">7/11</td>
-<td data-browser="firefox37" class="tally" data-tally="0.6363636363636364">7/11</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox35" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox36" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
+<td data-browser="firefox37" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/11</td>
@@ -6366,7 +6366,7 @@ return f() === 1;
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/11</td>
-<td data-browser="ejs" class="tally" data-tally="0.6363636363636364">7/11</td>
+<td data-browser="ejs" class="tally" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/11</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/11</td>
 </tr>
@@ -7090,16 +7090,16 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="class"><span><a class="anchor" href="#class">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions">class</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.5333333333333333">8/15</td>
-<td data-browser="babel" class="tally" data-tally="0.8">12/15</td>
-<td data-browser="es6tr" class="tally" data-tally="0.6">9/15</td>
-<td data-browser="closure" class="tally" data-tally="0.3333333333333333">5/15</td>
-<td data-browser="jsx" class="tally" data-tally="0.5333333333333333">8/15</td>
+<td data-browser="tr" class="tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
+<td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
+<td data-browser="es6tr" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td data-browser="closure" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">5/15</td>
+<td data-browser="jsx" class="tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td data-browser="typescript" class="tally" data-tally="0" data-flagged-tally="0.4">0/15</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/15</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/15</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/15</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.8">12/15</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/15</td>
@@ -7145,7 +7145,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td data-browser="phantom" class="tally" data-tally="0">0/15</td>
 <td data-browser="node" class="tally" data-tally="0">0/15</td>
 <td data-browser="iojs" class="tally" data-tally="0" data-flagged-tally="0.8">0/15</td>
-<td data-browser="ejs" class="tally" data-tally="0.6666666666666666">10/15</td>
+<td data-browser="ejs" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/15</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/15</td>
 </tr>
@@ -8167,7 +8167,7 @@ return passed;
 <td data-browser="tr" class="tally" data-tally="1">4/4</td>
 <td data-browser="babel" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="tally" data-tally="1">4/4</td>
-<td data-browser="closure" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="closure" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
 <td data-browser="typescript" class="tally" data-tally="0" data-flagged-tally="1">0/4</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
@@ -8507,9 +8507,9 @@ return obj.qux() === &quot;barley&quot;;
 </tr>
 <tr class="supertest" significance="1"><td id="generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">14/14</td>
-<td data-browser="babel" class="tally" data-tally="0.9285714285714286">13/14</td>
+<td data-browser="babel" class="tally" data-tally="0.9285714285714286" style="background-color:hsl(111,45%,50%)">13/14</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/14</td>
-<td data-browser="closure" class="tally" data-tally="0.7142857142857143">10/14</td>
+<td data-browser="closure" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/14</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/14</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/14</td>
@@ -8524,17 +8524,17 @@ return obj.qux() === &quot;barley&quot;;
 <td data-browser="firefox23" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="firefox24" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="firefox25" class="obsolete tally" data-tally="0">0/14</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox31" class="tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.7142857142857143">10/14</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.8571428571428571">12/14</td>
-<td data-browser="firefox35" class="tally" data-tally="0.8571428571428571">12/14</td>
-<td data-browser="firefox36" class="tally" data-tally="0.9285714285714286">13/14</td>
-<td data-browser="firefox37" class="tally" data-tally="0.9285714285714286">13/14</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox31" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
+<td data-browser="firefox36" class="tally" data-tally="0.9285714285714286" style="background-color:hsl(111,45%,50%)">13/14</td>
+<td data-browser="firefox37" class="tally" data-tally="0.9285714285714286" style="background-color:hsl(111,45%,50%)">13/14</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/14</td>
@@ -8546,10 +8546,10 @@ return obj.qux() === &quot;barley&quot;;
 <td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.5714285714285714">0/14</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.5714285714285714">0/14</td>
 <td data-browser="chrome38" class="obsolete tally" data-tally="0" data-flagged-tally="0.7857142857142857">0/14</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.7857142857142857" data-flagged-tally="0.8571428571428571">11/14</td>
-<td data-browser="chrome40" class="tally" data-tally="0.7857142857142857" data-flagged-tally="0.8571428571428571">11/14</td>
-<td data-browser="chrome41" class="tally" data-tally="0.7857142857142857" data-flagged-tally="0.8571428571428571">11/14</td>
-<td data-browser="chrome42" class="tally" data-tally="0.7857142857142857" data-flagged-tally="0.8571428571428571">11/14</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)" data-flagged-tally="0.8571428571428571">11/14</td>
+<td data-browser="chrome40" class="tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)" data-flagged-tally="0.8571428571428571">11/14</td>
+<td data-browser="chrome41" class="tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)" data-flagged-tally="0.8571428571428571">11/14</td>
+<td data-browser="chrome42" class="tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)" data-flagged-tally="0.8571428571428571">11/14</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/14</td>
@@ -8560,7 +8560,7 @@ return obj.qux() === &quot;barley&quot;;
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/14</td>
 <td data-browser="node" class="tally" data-tally="0" data-flagged-tally="0.7857142857142857">0/14</td>
-<td data-browser="iojs" class="tally" data-tally="0.6428571428571429" data-flagged-tally="0.7142857142857143">9/14</td>
+<td data-browser="iojs" class="tally" data-tally="0.6428571428571429" style="background-color:hsl(77,57%,50%)" data-flagged-tally="0.7142857142857143">9/14</td>
 <td data-browser="ejs" class="tally" data-tally="0">0/14</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/14</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/14</td>
@@ -9594,57 +9594,57 @@ return passed;
 <td data-browser="jsx" class="tally" data-tally="0">0/40</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/40</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/40</td>
-<td data-browser="ie10" class="tally" data-tally="0.4">16/40</td>
-<td data-browser="ie11" class="tally" data-tally="0.4">16/40</td>
+<td data-browser="ie10" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">16/40</td>
+<td data-browser="ie11" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">16/40</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">40/40</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.225">9/40</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.225">9/40</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox31" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.475">19/40</td>
-<td data-browser="firefox35" class="tally" data-tally="0.475">19/40</td>
-<td data-browser="firefox36" class="tally" data-tally="0.475">19/40</td>
-<td data-browser="firefox37" class="tally" data-tally="0.825">33/40</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.525">21/40</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.525">21/40</td>
-<td data-browser="chrome40" class="tally" data-tally="0.525">21/40</td>
-<td data-browser="chrome41" class="tally" data-tally="0.525">21/40</td>
-<td data-browser="chrome42" class="tally" data-tally="0.525">21/40</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.4">16/40</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.45">18/40</td>
-<td data-browser="safari7" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="webkit" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="opera" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="konq49" class="tally" data-tally="0.2">8/40</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.225" style="background-color:hsl(27,76%,50%)">9/40</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.225" style="background-color:hsl(27,76%,50%)">9/40</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox31" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.475" style="background-color:hsl(57,65%,50%)">19/40</td>
+<td data-browser="firefox35" class="tally" data-tally="0.475" style="background-color:hsl(57,65%,50%)">19/40</td>
+<td data-browser="firefox36" class="tally" data-tally="0.475" style="background-color:hsl(57,65%,50%)">19/40</td>
+<td data-browser="firefox37" class="tally" data-tally="0.825" style="background-color:hsl(99,49%,50%)">33/40</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="chrome40" class="tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="chrome41" class="tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="chrome42" class="tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">16/40</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="safari7" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="webkit" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="opera" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="konq49" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">8/40</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/40</td>
-<td data-browser="phantom" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="node" class="tally" data-tally="0.525">21/40</td>
-<td data-browser="iojs" class="tally" data-tally="0.525">21/40</td>
-<td data-browser="ejs" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="ios7" class="tally" data-tally="0.45">18/40</td>
-<td data-browser="ios8" class="tally" data-tally="0.45">18/40</td>
+<td data-browser="phantom" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="node" class="tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="iojs" class="tally" data-tally="0.525" style="background-color:hsl(63,62%,50%)">21/40</td>
+<td data-browser="ejs" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="ios7" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
+<td data-browser="ios8" class="tally" data-tally="0.45" style="background-color:hsl(54,66%,50%)">18/40</td>
 </tr>
 <tr class="subtest" data-parent="typed_arrays"><td><span>Int8Array</span><script data-source="
 var buffer = new ArrayBuffer(64);
@@ -12393,7 +12393,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="tr" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="babel" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="closure" class="tally" data-tally="0">0/11</td>
@@ -12401,22 +12401,22 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td data-browser="typescript" class="tally" data-tally="0">0/11</td>
 <td data-browser="es6shim" class="tally" data-tally="1">11/11</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/11</td>
-<td data-browser="ie11" class="tally" data-tally="0.45454545454545453">5/11</td>
+<td data-browser="ie11" class="tally" data-tally="0.45454545454545453" style="background-color:hsl(54,66%,50%)">5/11</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">11/11</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.7272727272727273">8/11</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.7272727272727273">8/11</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox31" class="tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox31" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="firefox35" class="tally" data-tally="1">11/11</td>
@@ -12432,7 +12432,7 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.36363636363636365">0/11</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.6363636363636364">0/11</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.7272727272727273">0/11</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="chrome40" class="tally" data-tally="1">11/11</td>
 <td data-browser="chrome41" class="tally" data-tally="1">11/11</td>
@@ -12440,17 +12440,17 @@ return typeof Int8Array.prototype.entries === &quot;function&quot; &amp;&amp;
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="webkit" class="tally" data-tally="0.8181818181818182">9/11</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="webkit" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td data-browser="opera" class="tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
-<td data-browser="node" class="tally" data-tally="0.9090909090909091" data-flagged-tally="1">10/11</td>
+<td data-browser="node" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)" data-flagged-tally="1">10/11</td>
 <td data-browser="iojs" class="tally" data-tally="1">11/11</td>
-<td data-browser="ejs" class="tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="ejs" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/11</td>
-<td data-browser="ios8" class="tally" data-tally="0.8181818181818182">9/11</td>
+<td data-browser="ios8" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 </tr>
 <tr class="subtest" data-parent="Map"><td><span>basic functionality</span><script data-source="
 var key = {};
@@ -13168,7 +13168,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="tr" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="babel" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="closure" class="tally" data-tally="0">0/11</td>
@@ -13176,22 +13176,22 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td data-browser="typescript" class="tally" data-tally="0">0/11</td>
 <td data-browser="es6shim" class="tally" data-tally="1">11/11</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/11</td>
-<td data-browser="ie11" class="tally" data-tally="0.45454545454545453">5/11</td>
+<td data-browser="ie11" class="tally" data-tally="0.45454545454545453" style="background-color:hsl(54,66%,50%)">5/11</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">11/11</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/11</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2727272727272727">3/11</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.45454545454545453">5/11</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.7272727272727273">8/11</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox31" class="tally" data-tally="0.9090909090909091">10/11</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.45454545454545453" style="background-color:hsl(54,66%,50%)">5/11</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox31" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="firefox35" class="tally" data-tally="1">11/11</td>
@@ -13207,7 +13207,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.36363636363636365">0/11</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.45454545454545453">0/11</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.6363636363636364">0/11</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="1">11/11</td>
 <td data-browser="chrome40" class="tally" data-tally="1">11/11</td>
 <td data-browser="chrome41" class="tally" data-tally="1">11/11</td>
@@ -13215,17 +13215,17 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182">9/11</td>
-<td data-browser="webkit" class="tally" data-tally="0.8181818181818182">9/11</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td data-browser="webkit" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td data-browser="opera" class="tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/11</td>
-<td data-browser="node" class="tally" data-tally="0.9090909090909091" data-flagged-tally="1">10/11</td>
+<td data-browser="node" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)" data-flagged-tally="1">10/11</td>
 <td data-browser="iojs" class="tally" data-tally="1">11/11</td>
-<td data-browser="ejs" class="tally" data-tally="0.9090909090909091">10/11</td>
+<td data-browser="ejs" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/11</td>
-<td data-browser="ios8" class="tally" data-tally="0.8181818181818182">9/11</td>
+<td data-browser="ios8" class="tally" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 </tr>
 <tr class="subtest" data-parent="Set"><td><span>basic functionality</span><script data-source="
 var obj = {};
@@ -13953,25 +13953,25 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td data-browser="typescript" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6shim" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
-<td data-browser="ie11" class="tally" data-tally="0.4">2/5</td>
+<td data-browser="ie11" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">5/5</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.8">4/5</td>
-<td data-browser="firefox35" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="firefox36" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox37" class="tally" data-tally="1">5/5</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/5</td>
@@ -13982,8 +13982,8 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
 <td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/5</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.6">3/5</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.6">3/5</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td data-browser="chrome38" class="obsolete tally" data-tally="1">5/5</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="1">5/5</td>
 <td data-browser="chrome40" class="tally" data-tally="1">5/5</td>
@@ -13992,8 +13992,8 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/5</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.8">4/5</td>
-<td data-browser="webkit" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="webkit" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="opera" class="tally" data-tally="0">0/5</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/5</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/5</td>
@@ -14002,7 +14002,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td data-browser="iojs" class="tally" data-tally="1">5/5</td>
 <td data-browser="ejs" class="tally" data-tally="1">5/5</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/5</td>
-<td data-browser="ios8" class="tally" data-tally="0.8">4/5</td>
+<td data-browser="ios8" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 </tr>
 <tr class="subtest" data-parent="WeakMap"><td><span>basic functionality</span><script data-source="
 var key = {};
@@ -14372,8 +14372,8 @@ return m.get(f) === 42;
 <td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
 <td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.5">2/4</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="chrome38" class="obsolete tally" data-tally="1">4/4</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="1">4/4</td>
 <td data-browser="chrome40" class="tally" data-tally="1">4/4</td>
@@ -14667,26 +14667,26 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td data-browser="es6shim" class="tally" data-tally="0">0/20</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/20</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/20</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.85">17/20</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.85" style="background-color:hsl(102,48%,50%)">17/20</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="0">0/20</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">10/20</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.55">11/20</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6">12/20</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6">12/20</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.65">13/20</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.7">14/20</td>
-<td data-browser="firefox35" class="tally" data-tally="0.7">14/20</td>
-<td data-browser="firefox36" class="tally" data-tally="0.7">14/20</td>
-<td data-browser="firefox37" class="tally" data-tally="0.8">16/20</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">10/20</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.55" style="background-color:hsl(66,61%,50%)">11/20</td>
+<td data-browser="firefox31" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">12/20</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">12/20</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
+<td data-browser="firefox35" class="tally" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
+<td data-browser="firefox36" class="tally" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
+<td data-browser="firefox37" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">16/20</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/20</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/20</td>
@@ -14713,7 +14713,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td data-browser="phantom" class="tally" data-tally="0">0/20</td>
 <td data-browser="node" class="tally" data-tally="0">0/20</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/20</td>
-<td data-browser="ejs" class="tally" data-tally="0.55">11/20</td>
+<td data-browser="ejs" class="tally" data-tally="0.55" style="background-color:hsl(66,61%,50%)">11/20</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/20</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/20</td>
 </tr>
@@ -16138,15 +16138,15 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="supertest" significance="0.5"><td id="Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/15</td>
-<td data-browser="babel" class="tally" data-tally="0.8666666666666667">13/15</td>
+<td data-browser="babel" class="tally" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/15</td>
 <td data-browser="closure" class="tally" data-tally="0">0/15</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/15</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/15</td>
-<td data-browser="es6shim" class="tally" data-tally="0.8666666666666667">13/15</td>
+<td data-browser="es6shim" class="tally" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/15</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/15</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.8">12/15</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/15</td>
@@ -16192,7 +16192,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td data-browser="phantom" class="tally" data-tally="0">0/15</td>
 <td data-browser="node" class="tally" data-tally="0">0/15</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/15</td>
-<td data-browser="ejs" class="tally" data-tally="0.9333333333333333">14/15</td>
+<td data-browser="ejs" class="tally" data-tally="0.9333333333333333" style="background-color:hsl(112,44%,50%)">14/15</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/15</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/15</td>
 </tr>
@@ -17473,8 +17473,8 @@ function check() {
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.3333333333333333">3/9</td>
-<td data-browser="babel" class="tally" data-tally="0.5555555555555556" data-flagged-tally="0.6666666666666666">5/9</td>
+<td data-browser="tr" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="babel" class="tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.6666666666666666">5/9</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
@@ -17482,7 +17482,7 @@ function check() {
 <td data-browser="es6shim" class="tally" data-tally="0">0/9</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/9</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/9</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.8888888888888888">8/9</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/9</td>
@@ -17512,23 +17512,23 @@ function check() {
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.6666666666666666">0/9</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.6666666666666666">0/9</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.6666666666666666">0/9</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.7777777777777778">7/9</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.8888888888888888">8/9</td>
-<td data-browser="chrome40" class="tally" data-tally="0.8888888888888888">8/9</td>
-<td data-browser="chrome41" class="tally" data-tally="0.8888888888888888">8/9</td>
-<td data-browser="chrome42" class="tally" data-tally="0.8888888888888888">8/9</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="chrome40" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="chrome41" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="chrome42" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/9</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/9</td>
-<td data-browser="webkit" class="tally" data-tally="0.8888888888888888">8/9</td>
+<td data-browser="webkit" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td data-browser="opera" class="tally" data-tally="0">0/9</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/9</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/9</td>
-<td data-browser="node" class="tally" data-tally="0.7777777777777778">7/9</td>
-<td data-browser="iojs" class="tally" data-tally="0.8888888888888888">8/9</td>
-<td data-browser="ejs" class="tally" data-tally="0.8888888888888888">8/9</td>
+<td data-browser="node" class="tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="iojs" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="ejs" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/9</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/9</td>
 </tr>
@@ -18151,8 +18151,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="babel" class="tally" data-tally="0.42857142857142855">3/7</td>
+<td data-browser="tr" class="tally" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td data-browser="babel" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -18160,7 +18160,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="es6shim" class="tally" data-tally="0">0/7</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/7</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/7</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/7</td>
@@ -18178,8 +18178,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="firefox33" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="firefox35" class="tally" data-tally="0">0/7</td>
-<td data-browser="firefox36" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="firefox37" class="tally" data-tally="0.14285714285714285">1/7</td>
+<td data-browser="firefox36" class="tally" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td data-browser="firefox37" class="tally" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/7</td>
@@ -18190,11 +18190,11 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="chrome35" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome40" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
-<td data-browser="chrome41" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
-<td data-browser="chrome42" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome40" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)" data-flagged-tally="0.42857142857142855">2/7</td>
+<td data-browser="chrome41" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)" data-flagged-tally="0.42857142857142855">2/7</td>
+<td data-browser="chrome42" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)" data-flagged-tally="0.42857142857142855">2/7</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/7</td>
@@ -18204,9 +18204,9 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="konq49" class="tally" data-tally="0">0/7</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/7</td>
-<td data-browser="node" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="iojs" class="tally" data-tally="0.2857142857142857" data-flagged-tally="0.42857142857142855">2/7</td>
-<td data-browser="ejs" class="tally" data-tally="0.8571428571428571">6/7</td>
+<td data-browser="node" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="iojs" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)" data-flagged-tally="0.42857142857142855">2/7</td>
+<td data-browser="ejs" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/7</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/7</td>
 </tr>
@@ -18694,61 +18694,61 @@ with (a) {
 <tr class="category"><td colspan="60">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="babel" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/4</td>
-<td data-browser="es6shim" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="es6shim" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie11" class="tally" data-tally="0.25">1/4</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="ie11" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5">2/4</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox35" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="firefox35" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="firefox36" class="tally" data-tally="1">4/4</td>
 <td data-browser="firefox37" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.5" data-flagged-tally="0.75">2/4</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.5" data-flagged-tally="0.75">2/4</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.5" data-flagged-tally="0.75">2/4</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.5" data-flagged-tally="0.75">2/4</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="chrome40" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="chrome41" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="chrome42" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="0.75">2/4</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="0.75">2/4</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="0.75">2/4</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="0.75">2/4</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="chrome40" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="chrome41" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="chrome42" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="webkit" class="tally" data-tally="0">0/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
-<td data-browser="konq49" class="tally" data-tally="0.25">1/4</td>
+<td data-browser="konq49" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
-<td data-browser="node" class="tally" data-tally="0.75">3/4</td>
-<td data-browser="iojs" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="node" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="iojs" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="ejs" class="tally" data-tally="1">4/4</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/4</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/4</td>
@@ -19013,7 +19013,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 </tr>
 <tr class="supertest" significance="0.25"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/16</td>
-<td data-browser="babel" class="tally" data-tally="0.625">10/16</td>
+<td data-browser="babel" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/16</td>
 <td data-browser="closure" class="tally" data-tally="0">0/16</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/16</td>
@@ -19021,55 +19021,55 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td data-browser="es6shim" class="tally" data-tally="0">0/16</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/16</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/16</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.625">10/16</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox31" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.25">4/16</td>
-<td data-browser="firefox35" class="tally" data-tally="0.25">4/16</td>
-<td data-browser="firefox36" class="tally" data-tally="0.25">4/16</td>
-<td data-browser="firefox37" class="tally" data-tally="0.25">4/16</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.125">2/16</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.125" data-flagged-tally="0.1875">2/16</td>
-<td data-browser="chrome40" class="tally" data-tally="0.125" data-flagged-tally="0.1875">2/16</td>
-<td data-browser="chrome41" class="tally" data-tally="0.125" data-flagged-tally="0.1875">2/16</td>
-<td data-browser="chrome42" class="tally" data-tally="0.125" data-flagged-tally="0.1875">2/16</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="safari7" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="webkit" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="opera" class="tally" data-tally="0.125">2/16</td>
-<td data-browser="konq49" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0.1875">3/16</td>
-<td data-browser="phantom" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="node" class="tally" data-tally="0.125">2/16</td>
-<td data-browser="iojs" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="ejs" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="ios7" class="tally" data-tally="0.1875">3/16</td>
-<td data-browser="ios8" class="tally" data-tally="0.1875">3/16</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox31" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td data-browser="firefox35" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td data-browser="firefox36" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td data-browser="firefox37" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.1875">2/16</td>
+<td data-browser="chrome40" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.1875">2/16</td>
+<td data-browser="chrome41" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.1875">2/16</td>
+<td data-browser="chrome42" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.1875">2/16</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="safari7" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="webkit" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="opera" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="konq49" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="phantom" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="node" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">2/16</td>
+<td data-browser="iojs" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="ejs" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="ios7" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
+<td data-browser="ios8" class="tally" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
 </tr>
 <tr class="subtest" data-parent="function_name_property"><td><span>function statements</span><script data-source="
 function foo(){};
@@ -20141,11 +20141,11 @@ return descriptor.enumerable   === false &amp;&amp;
 <td data-browser="firefox25" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="firefox27" class="obsolete tally" data-tally="0">0/2</td>
 <td data-browser="firefox28" class="obsolete tally" data-tally="0">0/2</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox31" class="tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.5">1/2</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5">1/2</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="1">2/2</td>
 <td data-browser="firefox35" class="tally" data-tally="1">2/2</td>
 <td data-browser="firefox36" class="tally" data-tally="1">2/2</td>
@@ -20307,62 +20307,62 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="babel" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="tr" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="babel" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/6</td>
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/6</td>
-<td data-browser="es6shim" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="es6shim" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/6</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.3333333333333333">2/6</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.3333333333333333">2/6</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.3333333333333333">2/6</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5">3/6</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5">3/6</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5">3/6</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">3/6</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666">4/6</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666">4/6</td>
-<td data-browser="firefox31" class="tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox35" class="tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox36" class="tally" data-tally="0.8333333333333334">5/6</td>
-<td data-browser="firefox37" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td data-browser="firefox31" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox35" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox36" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox37" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/6</td>
 <td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/6</td>
 <td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.5">0/6</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.6666666666666666">1/6</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.6666666666666666">1/6</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.6666666666666666">1/6</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.6666666666666666">1/6</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.8333333333333334">1/6</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.16666666666666666" data-flagged-tally="0.8333333333333334">1/6</td>
-<td data-browser="chrome40" class="tally" data-tally="0.16666666666666666" data-flagged-tally="0.8333333333333334">1/6</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.6666666666666666">1/6</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.6666666666666666">1/6</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.6666666666666666">1/6</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.6666666666666666">1/6</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.8333333333333334">1/6</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.8333333333333334">1/6</td>
+<td data-browser="chrome40" class="tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.8333333333333334">1/6</td>
 <td data-browser="chrome41" class="tally" data-tally="1">6/6</td>
 <td data-browser="chrome42" class="tally" data-tally="1">6/6</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/6</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/6</td>
-<td data-browser="webkit" class="tally" data-tally="0.6666666666666666">4/6</td>
+<td data-browser="webkit" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td data-browser="opera" class="tally" data-tally="0">0/6</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/6</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/6</td>
-<td data-browser="node" class="tally" data-tally="0.16666666666666666" data-flagged-tally="1">1/6</td>
+<td data-browser="node" class="tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
 <td data-browser="iojs" class="tally" data-tally="1">6/6</td>
-<td data-browser="ejs" class="tally" data-tally="0.8333333333333334">5/6</td>
+<td data-browser="ejs" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/6</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/6</td>
 </tr>
@@ -20752,12 +20752,12 @@ return typeof String.prototype.includes === &apos;function&apos;
 </tr>
 <tr class="supertest" significance="0.25"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
-<td data-browser="babel" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="babel" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/5</td>
-<td data-browser="es6shim" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="es6shim" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11tp" class="tally" data-tally="0">0/5</td>
@@ -20779,7 +20779,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td data-browser="firefox34" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="firefox35" class="tally" data-tally="0">0/5</td>
 <td data-browser="firefox36" class="tally" data-tally="0">0/5</td>
-<td data-browser="firefox37" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="firefox37" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/5</td>
@@ -21132,7 +21132,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/4</td>
-<td data-browser="es6shim" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="es6shim" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">4/4</td>
@@ -21143,16 +21143,16 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox23" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox24" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox31" class="tally" data-tally="0.25">1/4</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.75">3/4</td>
-<td data-browser="firefox35" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox31" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="firefox35" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="firefox36" class="tally" data-tally="1">4/4</td>
 <td data-browser="firefox37" class="tally" data-tally="1">4/4</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
@@ -21174,14 +21174,14 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
-<td data-browser="webkit" class="tally" data-tally="0.25">1/4</td>
+<td data-browser="webkit" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td data-browser="opera" class="tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/4</td>
 <td data-browser="node" class="tally" data-tally="0">0/4</td>
 <td data-browser="iojs" class="tally" data-tally="0">0/4</td>
-<td data-browser="ejs" class="tally" data-tally="0.75">3/4</td>
+<td data-browser="ejs" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/4</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/4</td>
 </tr>
@@ -21441,13 +21441,13 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75">6/8</td>
+<td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="babel" class="tally" data-tally="1">8/8</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/8</td>
 <td data-browser="closure" class="tally" data-tally="0">0/8</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/8</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/8</td>
-<td data-browser="es6shim" class="tally" data-tally="0.875">7/8</td>
+<td data-browser="es6shim" class="tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/8</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">8/8</td>
@@ -21458,18 +21458,18 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="firefox23" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="firefox24" class="obsolete tally" data-tally="0">0/8</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.25">2/8</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.25">2/8</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5">4/8</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5">4/8</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5">4/8</td>
-<td data-browser="firefox31" class="tally" data-tally="0.625">5/8</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.75">6/8</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.75">6/8</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.75">6/8</td>
-<td data-browser="firefox35" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="firefox36" class="tally" data-tally="0.75">6/8</td>
-<td data-browser="firefox37" class="tally" data-tally="0.75">6/8</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td data-browser="firefox31" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="firefox35" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="firefox36" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
+<td data-browser="firefox37" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/8</td>
@@ -21480,25 +21480,25 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.625">0/8</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.75">0/8</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
-<td data-browser="chrome40" class="tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
-<td data-browser="chrome41" class="tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
-<td data-browser="chrome42" class="tally" data-tally="0.375" data-flagged-tally="0.75">3/8</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.75">3/8</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.75">3/8</td>
+<td data-browser="chrome40" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.75">3/8</td>
+<td data-browser="chrome41" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.75">3/8</td>
+<td data-browser="chrome42" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.75">3/8</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/8</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.625">5/8</td>
-<td data-browser="webkit" class="tally" data-tally="0.625">5/8</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td data-browser="webkit" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 <td data-browser="opera" class="tally" data-tally="0">0/8</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/8</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/8</td>
-<td data-browser="node" class="tally" data-tally="0.5" data-flagged-tally="0.875">4/8</td>
-<td data-browser="iojs" class="tally" data-tally="0.375">3/8</td>
-<td data-browser="ejs" class="tally" data-tally="0.875">7/8</td>
+<td data-browser="node" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="0.875">4/8</td>
+<td data-browser="iojs" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
+<td data-browser="ejs" class="tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/8</td>
-<td data-browser="ios8" class="tally" data-tally="0.625">5/8</td>
+<td data-browser="ios8" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods"><td><span>Array.prototype.copyWithin</span><script data-source="
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
@@ -22025,17 +22025,17 @@ return true;
 <td data-browser="ie11tp" class="tally" data-tally="1">7/7</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.5714285714285714">4/7</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.5714285714285714">4/7</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.5714285714285714">4/7</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.5714285714285714">4/7</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.5714285714285714">4/7</td>
-<td data-browser="firefox31" class="tally" data-tally="0.8571428571428571">6/7</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="firefox31" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="1">7/7</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="1">7/7</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="1">7/7</td>
@@ -22043,11 +22043,11 @@ return true;
 <td data-browser="firefox36" class="tally" data-tally="1">7/7</td>
 <td data-browser="firefox37" class="tally" data-tally="1">7/7</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td data-browser="chrome34" class="obsolete tally" data-tally="1">7/7</td>
 <td data-browser="chrome35" class="obsolete tally" data-tally="1">7/7</td>
 <td data-browser="chrome36" class="obsolete tally" data-tally="1">7/7</td>
@@ -22063,7 +22063,7 @@ return true;
 <td data-browser="safari71_8" class="tally" data-tally="0">0/7</td>
 <td data-browser="webkit" class="tally" data-tally="1">7/7</td>
 <td data-browser="opera" class="tally" data-tally="0">0/7</td>
-<td data-browser="konq49" class="tally" data-tally="0.8571428571428571">6/7</td>
+<td data-browser="konq49" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/7</td>
 <td data-browser="node" class="tally" data-tally="1">7/7</td>
@@ -22529,13 +22529,13 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="firefox18" class="obsolete tally" data-tally="0">0/17</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.8235294117647058">14/17</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.9411764705882353">16/17</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.9411764705882353">16/17</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.9411764705882353">16/17</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.9411764705882353">16/17</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
 <td data-browser="firefox31" class="tally" data-tally="1">17/17</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="1">17/17</td>
 <td data-browser="firefox33" class="obsolete tally" data-tally="1">17/17</td>
@@ -22545,14 +22545,14 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td data-browser="firefox37" class="tally" data-tally="1">17/17</td>
 <td data-browser="chrome" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/17</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.058823529411764705" data-flagged-tally="0.17647058823529413">1/17</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.058823529411764705" data-flagged-tally="0.7647058823529411">1/17</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.058823529411764705" data-flagged-tally="1">1/17</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.058823529411764705" data-flagged-tally="1">1/17</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.058823529411764705" data-flagged-tally="1">1/17</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="0.17647058823529413">1/17</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="0.7647058823529411">1/17</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="1">1/17</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="1">1/17</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)" data-flagged-tally="1">1/17</td>
 <td data-browser="chrome38" class="obsolete tally" data-tally="1">17/17</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="1">17/17</td>
 <td data-browser="chrome40" class="tally" data-tally="1">17/17</td>
@@ -22560,18 +22560,18 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td data-browser="chrome42" class="tally" data-tally="1">17/17</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/17</td>
-<td data-browser="safari7" class="tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.8823529411764706">15/17</td>
-<td data-browser="webkit" class="tally" data-tally="0.9411764705882353">16/17</td>
+<td data-browser="safari7" class="tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">15/17</td>
+<td data-browser="webkit" class="tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
 <td data-browser="opera" class="tally" data-tally="0">0/17</td>
-<td data-browser="konq49" class="tally" data-tally="0.8235294117647058">14/17</td>
+<td data-browser="konq49" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/17</td>
-<td data-browser="phantom" class="tally" data-tally="0.058823529411764705">1/17</td>
+<td data-browser="phantom" class="tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
 <td data-browser="node" class="tally" data-tally="1">17/17</td>
 <td data-browser="iojs" class="tally" data-tally="1">17/17</td>
 <td data-browser="ejs" class="tally" data-tally="1">17/17</td>
-<td data-browser="ios7" class="tally" data-tally="0.058823529411764705">1/17</td>
-<td data-browser="ios8" class="tally" data-tally="0.8823529411764706">15/17</td>
+<td data-browser="ios7" class="tally" data-tally="0.058823529411764705" style="background-color:hsl(7,83%,50%)">1/17</td>
+<td data-browser="ios8" class="tally" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">15/17</td>
 </tr>
 <tr class="subtest" data-parent="Math_methods"><td><span>Math.clz32</span><script data-source="
 return typeof Math.clz32 === &quot;function&quot;;
@@ -23659,7 +23659,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td data-browser="es6shim" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/4</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.5">2/4</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="firefox11" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox13" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="firefox16" class="obsolete tally" data-tally="0">0/4</td>
@@ -24915,8 +24915,8 @@ function check() {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/5</td>
-<td data-browser="babel" class="tally" data-tally="0">0/5</td>
+<td data-browser="tr" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="babel" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -25184,8 +25184,8 @@ map.set(key, 123);
 return map.has(key) &amp;&amp; map.get(key) === 123;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("378");return Function("asyncTestPassed","\nvar key = {};\nclass M extends Map {}\nvar map = new M();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25254,8 +25254,8 @@ set.add(123);
 return set.has(123);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("379");return Function("asyncTestPassed","\nvar obj = {};\nclass S extends Set {}\nvar set = new S();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="tr">Yes</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25322,7 +25322,7 @@ return set.has(123);
 <td data-browser="closure" class="tally" data-tally="0">0/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/10</td>
-<td data-browser="es6shim" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="es6shim" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11tp" class="tally" data-tally="0">0/10</td>
@@ -25340,8 +25340,8 @@ return set.has(123);
 <td data-browser="firefox30" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="firefox31" class="tally" data-tally="0">0/10</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="0">0/10</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.1">1/10</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.1">1/10</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td data-browser="firefox35" class="tally" data-tally="1">10/10</td>
 <td data-browser="firefox36" class="tally" data-tally="1">10/10</td>
 <td data-browser="firefox37" class="tally" data-tally="1">10/10</td>
@@ -25357,9 +25357,9 @@ return set.has(123);
 <td data-browser="chrome37" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="chrome38" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="chrome39" class="obsolete tally" data-tally="0">0/10</td>
-<td data-browser="chrome40" class="tally" data-tally="0.2">2/10</td>
-<td data-browser="chrome41" class="tally" data-tally="0.2">2/10</td>
-<td data-browser="chrome42" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="chrome40" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="chrome41" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="chrome42" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/10</td>
@@ -25370,7 +25370,7 @@ return set.has(123);
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
 <td data-browser="phantom" class="tally" data-tally="0">0/10</td>
 <td data-browser="node" class="tally" data-tally="0">0/10</td>
-<td data-browser="iojs" class="tally" data-tally="0.2">2/10</td>
+<td data-browser="iojs" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="ejs" class="tally" data-tally="0">0/10</td>
 <td data-browser="ios7" class="tally" data-tally="0">0/10</td>
 <td data-browser="ios8" class="tally" data-tally="0">0/10</td>
@@ -26010,63 +26010,63 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 </tr>
 <tr class="supertest" significance="0.25"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/7</td>
-<td data-browser="babel" class="tally" data-tally="0.42857142857142855">3/7</td>
+<td data-browser="babel" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td data-browser="es6tr" class="tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/7</td>
-<td data-browser="es6shim" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="ie10" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="ie11" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox31" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox35" class="tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox36" class="tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="firefox37" class="tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome40" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome41" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="chrome42" class="tally" data-tally="0.42857142857142855">3/7</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="safari7" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="webkit" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="opera" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="konq49" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="phantom" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="node" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="iojs" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="ejs" class="tally" data-tally="0.14285714285714285">1/7</td>
-<td data-browser="ios7" class="tally" data-tally="0.2857142857142857">2/7</td>
-<td data-browser="ios8" class="tally" data-tally="0.2857142857142857">2/7</td>
+<td data-browser="es6shim" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="ie10" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="ie11" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox31" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox35" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox36" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="firefox37" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome40" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome41" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="chrome42" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="safari7" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="webkit" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="opera" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="konq49" class="tally" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="phantom" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="node" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="iojs" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="ejs" class="tally" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td data-browser="ios7" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
+<td data-browser="ios8" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 </tr>
 <tr class="subtest" data-parent="miscellaneous"><td><span>duplicate property names in strict mode</span><script data-source="
 &apos;use strict&apos;;
@@ -26615,56 +26615,56 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td data-browser="typescript" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6shim" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
-<td data-browser="ie11" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="ie11tp" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox31" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.4">2/5</td>
+<td data-browser="ie11" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="ie11tp" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox31" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="firefox35" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox36" class="tally" data-tally="1">5/5</td>
 <td data-browser="firefox37" class="tally" data-tally="1">5/5</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome40" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome41" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="chrome42" class="tally" data-tally="0.4">2/5</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.2">1/5</td>
-<td data-browser="safari7" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.4">2/5</td>
-<td data-browser="webkit" class="tally" data-tally="0.4">2/5</td>
-<td data-browser="opera" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="konq49" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome40" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome41" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="chrome42" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="safari7" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="webkit" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="opera" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="konq49" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="0.2">1/5</td>
-<td data-browser="phantom" class="tally" data-tally="0.2">1/5</td>
+<td data-browser="phantom" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
 <td data-browser="iojs" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0.2">1/5</td>
 <td data-browser="ejs" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/5</td>
-<td data-browser="ios7" class="tally" data-tally="0.2">1/5</td>
-<td data-browser="ios8" class="tally" data-tally="0.4">2/5</td>
+<td data-browser="ios7" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td data-browser="ios8" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 </tr>
 <tr class="subtest" data-parent="__proto___in_object_literals"><td><span>basic support</span><script data-source="
 return { __proto__ : [] } instanceof Array
@@ -27009,9 +27009,9 @@ return !({ __proto__(){} } instanceof Function);
 <td data-browser="ie10" class="tally" data-tally="0">0/3</td>
 <td data-browser="ie11" class="tally" data-tally="1">3/3</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">3/3</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="firefox18" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="firefox23" class="obsolete tally" data-tally="1">3/3</td>
@@ -27028,9 +27028,9 @@ return !({ __proto__(){} } instanceof Function);
 <td data-browser="firefox35" class="tally" data-tally="1">3/3</td>
 <td data-browser="firefox36" class="tally" data-tally="1">3/3</td>
 <td data-browser="firefox37" class="tally" data-tally="1">3/3</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="chrome30" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="chrome31" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="chrome33" class="obsolete tally" data-tally="1">3/3</td>
@@ -27043,13 +27043,13 @@ return !({ __proto__(){} } instanceof Function);
 <td data-browser="chrome40" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome41" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome42" class="tally" data-tally="1">3/3</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="safari7" class="tally" data-tally="1">3/3</td>
 <td data-browser="safari71_8" class="tally" data-tally="1">3/3</td>
 <td data-browser="webkit" class="tally" data-tally="1">3/3</td>
 <td data-browser="opera" class="tally" data-tally="1">3/3</td>
-<td data-browser="konq49" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="konq49" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="1">3/3</td>
 <td data-browser="phantom" class="tally" data-tally="1">3/3</td>
 <td data-browser="node" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
@@ -27265,12 +27265,12 @@ return (desc
 <td data-browser="jsx" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="typescript" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="es6shim" title="This feature is optional on non-browser platforms." class="not-applicable tally" data-tally="1">3/3</td>
-<td data-browser="ie10" class="tally" data-tally="0.3333333333333333">1/3</td>
-<td data-browser="ie11" class="tally" data-tally="0.3333333333333333">1/3</td>
+<td data-browser="ie10" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td data-browser="ie11" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td data-browser="ie11tp" class="tally" data-tally="1">3/3</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="firefox17" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="firefox18" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="firefox23" class="obsolete tally" data-tally="1">3/3</td>
@@ -27302,12 +27302,12 @@ return (desc
 <td data-browser="chrome40" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome41" class="tally" data-tally="1">3/3</td>
 <td data-browser="chrome42" class="tally" data-tally="1">3/3</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.3333333333333333">1/3</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="1">3/3</td>
 <td data-browser="safari7" class="tally" data-tally="1">3/3</td>
 <td data-browser="safari71_8" class="tally" data-tally="1">3/3</td>
 <td data-browser="webkit" class="tally" data-tally="1">3/3</td>
-<td data-browser="opera" class="tally" data-tally="0.6666666666666666">2/3</td>
+<td data-browser="opera" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td data-browser="konq49" class="tally" data-tally="1">3/3</td>
 <td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="1">3/3</td>
 <td data-browser="phantom" class="tally" data-tally="1">3/3</td>

--- a/master.css
+++ b/master.css
@@ -148,38 +148,28 @@ table.one-selected td.selected {
 [data-tally] {
     background: #acc20a;
 }
-tr:hover td[data-tally],
-td.hover[data-tally] {
-    background: #8da000;
+tr:hover td,
+td.hover {
+    filter:saturate(0.8) brightness(0.8);
+    -webkit-filter:saturate(0.8) brightness(0.8);
 }
-[data-tally].obsolete {
-    background: #cedd5c;
+.obsolete {
+    filter:opacity(0.75) brightness(1.2);
+    -webkit-filter:opacity(0.75) brightness(1.2);
 }
-tr:hover td[data-tally].obsolete,
-td.hover[data-tally].obsolete {
-    background: #b0c037;
+tr:hover td.obsolete,
+td.hover.obsolete {
+    filter:opacity(0.75) saturate(0.8);
+    -webkit-filter:opacity(0.75) saturate(0.8);
+}
+td:first-child, td:not([class]) {
+    filter:none !important;
 }
 
 /* yes */
 .yes,
 [data-tally="1"] {
     background: #44ab44;
-}
-tr:hover td.yes,
-td.hover.yes,
-tr:hover td[data-tally="1"],
-td.hover[data-tally="1"] {
-    background: #269326;
-}
-.yes.obsolete,
-[data-tally="1"].obsolete {
-    background: #9fe09f;
-}
-tr:hover td.yes.obsolete,
-td.hover.yes.obsolete,
-tr:hover td[data-tally="1"].obsolete,
-td.hover[data-tally="1"].obsolete {
-    background: #73cc73;
 }
 
 /* yes, but flagged */
@@ -197,80 +187,21 @@ td.hover[data-tally="1"].obsolete {
 [data-flagged-tally]:not([data-flagged-tally="1"])::after {
 	border-top-color: #acc20a;
 }
-tr:hover [data-flagged-tally]::after,
-td.hover[data-flagged-tally]::after {
-	border-top-color: #8da000;
-}
-[data-flagged-tally].obsolete::after {
-	border-top-color: #cedd5c;
-}
-tr:hover [data-flagged-tally].obsolete::after,
-td.hover[data-flagged-tally].obsolete::after {
-	border-top-color: #b0c037;
-}
-tr:hover .flagged::after,
-td.hover.flagged::after,
-tr:hover [data-flagged-tally="1"]::after,
-td.hover[data-flagged-tally="1"]::after {
-	border-top-color: #269326;
-}
-.flagged.obsolete::after,
-[data-flagged-tally="1"].obsolete::after {
-	border-top-color: #9fe09f;
-}
-tr:hover .flagged.obsolete::after,
-td.hover.flagged.obsolete::after,
-tr:hover [data-flagged-tally="1"].obsolete::after,
-td.hover[data-flagged-tally="1"].obsolete::after {
-	border-top-color: #73cc73;
-}
 
 /* no */
 .no,
 [data-tally="0"] {
     background: #e11;
 }
-tr:hover td.no,
-td.hover.no,
-tr:hover td[data-tally="0"],
-td.hover[data-tally="0"] {
-    background: #bb0606;
-}
-.no.obsolete,
-[data-tally="0"].obsolete {
-    background: #ff6e6e;
-}
-tr:hover td.no.obsolete,
-td.hover.no.obsolete,
-tr:hover td[data-tally="0"].obsolete,
-td.hover[data-tally="0"].obsolete {
-    background: #e24545;
-}
 
 /* not applicable */
 .not-applicable {
     background: hsl(120,  14%,  67%); background: #9fb79f; cursor: help;
 }
-tr:hover td.not-applicable,
-td.hover.not-applicable {
-    background: hsl(120,  14%,  47%); background: #678967;
-}
 
 /* non-standard no */
 .non-standard .no {
     background: #4444ac;
-}
-.non-standard tr:hover td.no,
-.non-standard td.hover.no {
-    background: #111178;
-}
-
-.non-standard .no.obsolete {
-    background: #8080b8;
-}
-.non-standard tr:hover td.no.obsolete,
-.non-standard td.hover.no.obsolete {
-    background: #474775;
 }
 
 /* tooltip button/box */

--- a/master.js
+++ b/master.js
@@ -62,11 +62,14 @@ $(function() {
       return;
     }
     var tally = subtests.find(".yes" + currentBrowserSelector).length;
+    var grade = tally/subtests.length;
     tr
       .find('.tally.current, .tally.current + td:empty').remove().end()
       .find('td:first-child')
       .after(
-      '<td class="tally current" data-tally="' + tally/subtests.length + '">' +
+      '<td class="tally current" data-tally="' + tally/subtests.length
+      + '" style="background-color:hsl(' + (120*grade|0) + ',' +((86 - (grade*44))|0)  +'%,50%)'
+      + '">' +
       tally + '/' + subtests.length + '</td><td></td>'
     );
   }


### PR DESCRIPTION
Preview: https://raw.githack.com/webbedspace/compat-table/gh-pages/es6/index.html

Also, in order to enable these cells to be correctly shaded when the mouse hovers over them, I replaced the multiple cell colour declarations with CSS filters. Support for these is in the latest Firefox, Chrome/Opera and Safari. As it's purely a visual garnish, a lack of IE support is not really that important.
