### PR TITLE
Update some compilers / polyfills

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -7171,6 +7171,7 @@ exports.tests = [
         return len1 === 0 && len2 === 3 && c.length === 1 && !(2 in c);
       */},
       res: {
+        babel:       true,
         iojs:        { val: flag, note_id: 'strict-required' },
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7227,6 +7228,7 @@ exports.tests = [
         return r.global && r.source === "baz";
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7239,6 +7241,7 @@ exports.tests = [
         return r.exec("foobarbaz")[0] === "baz" && r.lastIndex === 9;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7251,6 +7254,7 @@ exports.tests = [
         return r.test("foobarbaz");
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7271,6 +7275,7 @@ exports.tests = [
         return c() === 'foo';
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
@@ -7283,6 +7288,7 @@ exports.tests = [
         return new c().bar === 2 && new c().baz === 3;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
@@ -7294,6 +7300,7 @@ exports.tests = [
         return c.call({bar:1}, 2) === 3;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
@@ -7305,6 +7312,7 @@ exports.tests = [
         return c.apply({bar:1}, [2]) === 3;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome43:    { val: flag, note_id: 'strict-required' },
       },
@@ -7355,7 +7363,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
-        babel:       true,
+        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -7380,7 +7388,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
-        babel:       true,
+        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -7405,7 +7413,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
-        babel:       true,
+        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -7425,6 +7433,7 @@ exports.tests = [
           && c == true;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -7437,6 +7446,7 @@ exports.tests = [
           && +c === 6;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -7451,6 +7461,7 @@ exports.tests = [
           && c.length === 5;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },

--- a/data-es6.js
+++ b/data-es6.js
@@ -7362,7 +7362,6 @@ exports.tests = [
         }
       */},
       res: {
-        tr:          true,
         babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
@@ -7387,7 +7386,6 @@ exports.tests = [
         }
       */},
       res: {
-        tr:          true,
         babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
@@ -7412,7 +7410,6 @@ exports.tests = [
         }
       */},
       res: {
-        tr:          true,
         babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
@@ -7477,7 +7474,6 @@ exports.tests = [
         return map.has(key) && map.get(key) === 123;
       */},
       res: {
-        tr:          true,
         babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
@@ -7495,7 +7491,6 @@ exports.tests = [
         return set.has(123);
       */},
       res: {
-        tr:          true,
         babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -1145,6 +1145,7 @@ exports.tests = [
         }());
       */},
       res: {
+        babel:       true,
         tr:          true,
         closure:     true,
         jsx:         true,
@@ -2397,6 +2398,7 @@ exports.tests = [
       */},
       res: {
         tr:          true,
+        babel:       true,
         firefox27:   true,
         chrome21dev: flag,
         chrome39:    true,
@@ -2637,6 +2639,7 @@ exports.tests = [
         return closed;
       */},
       res: {
+        babel:       true,
       },
     },
     'shorthand generator methods': {
@@ -4694,6 +4697,7 @@ exports.tests = [
         return closed;
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -4741,7 +4745,7 @@ exports.tests = [
         webkit:       false,
         safari71_8:   false,
         ios8:         false,
-        babel:        false,
+        babel:        true,
         tr:           false,
         closure:      false,
       }),

--- a/data-es6.js
+++ b/data-es6.js
@@ -6039,6 +6039,7 @@ exports.tests = [
         return typeof Symbol() === "symbol";
       */},
       res: {
+        tr:          flag,
         babel:       flag,
         typescript:  temp.typescriptFallthrough,
         ejs:         true,

--- a/data-es7.js
+++ b/data-es7.js
@@ -691,6 +691,7 @@ exports.tests = [
     return typeof Set.prototype.toJSON === 'function';
   */},
   res: {
+    babel:       true,
   }
 },
 {

--- a/data-es7.js
+++ b/data-es7.js
@@ -191,13 +191,17 @@ exports.tests = [
       exec: function(){/*
         return typeof function f( a, b, ){} === 'function';
       */},
-      res: {},
+      res: {
+        babel:       true,
+      }
     },
     'in argument lists': {
       exec: function(){/*
         return Math.min(1,2,3,) === 1;
       */},
-      res: {},
+      res: {
+        babel:       true,
+      }
     },
   },
 },

--- a/es6/index.html
+++ b/es6/index.html
@@ -884,7 +884,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 </tr>
 <tr class="supertest" significance="0.5"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-definitions">rest parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td data-browser="babel" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="closure" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td data-browser="jsx" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
@@ -1164,7 +1164,7 @@ return (function (...args) {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");return Function("asyncTestPassed","\nreturn (function (...args) {\n  try {\n    eval(\"({set e(...args){}})\");\n  } catch(e) {\n    return true;\n  }\n}());\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -3778,7 +3778,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 </tr>
 <tr class="supertest" significance="1"><td id="destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-destructuring-assignment">destructuring</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">24/30</td>
-<td data-browser="babel" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)" data-flagged-tally="0.8666666666666667">25/30</td>
+<td data-browser="babel" class="tally" data-tally="0.9" style="background-color:hsl(108,46%,50%)" data-flagged-tally="0.9333333333333333">27/30</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">20/30</td>
 <td data-browser="closure" class="tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">16/30</td>
 <td data-browser="jsx" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">15/30</td>
@@ -4196,7 +4196,7 @@ return closed;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = __createIterableObject(1, 2, 3);\niter['return'] = function(){ closed = true; return {}; }\nvar [a, b] = iter;\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -4398,7 +4398,7 @@ return a === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");return Function("asyncTestPassed","\nvar [a,] = [1];\nreturn a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
 <td class="yes" data-browser="jsx">Yes</td>
@@ -10422,7 +10422,7 @@ return obj.qux() === &quot;barley&quot;;
 </tr>
 <tr class="supertest" significance="1"><td id="generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions">generators</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9047619047619048" style="background-color:hsl(108,46%,50%)">19/21</td>
-<td data-browser="babel" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">18/21</td>
+<td data-browser="babel" class="tally" data-tally="0.9523809523809523" style="background-color:hsl(114,44%,50%)">20/21</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/21</td>
 <td data-browser="closure" class="tally" data-tally="0.6190476190476191" style="background-color:hsl(74,58%,50%)">13/21</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/21</td>
@@ -10873,7 +10873,7 @@ return passed;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");return Function("asyncTestPassed","\nfunction * generatorFn(){}\nvar ownProto = Object.getPrototypeOf(generatorFn());\nvar passed = ownProto === generatorFn.prototype;\n\nvar sharedProto = Object.getPrototypeOf(ownProto);\npassed &= sharedProto !== Object.prototype &&\n  sharedProto === Object.getPrototypeOf(function*(){}.prototype) &&\n  sharedProto.hasOwnProperty('next');\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -11639,7 +11639,7 @@ return closed;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = __createIterableObject(1, 2, 3);\niter['throw'] = undefined;\niter['return'] = function(){\n  closed = true;\n  return {done: true};\n}\nvar gen = (function*(){\n  try {\n    yield *iter;\n  } catch(e){}\n})();\ngen.next();\ngen['throw']();\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20623,7 +20623,7 @@ function check() {
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-symbol-constructor">Symbol</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="tr" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)" data-flagged-tally="0.4444444444444444">3/9</td>
 <td data-browser="babel" class="tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.6666666666666666">5/9</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/9</td>
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
@@ -20759,7 +20759,7 @@ return object[symbol] === value;
 return typeof Symbol() === &quot;symbol&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="no" data-browser="tr">No</td>
+<td class="no flagged" data-browser="tr">Flag</td>
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
@@ -27434,7 +27434,7 @@ return Math.hypot() === 0 &amp;&amp;
 </tr>
 <tr class="supertest" significance="0.5"><td id="Array_is_subclassable"><span><a class="anchor" href="#Array_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array-constructor">Array is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
-<td data-browser="babel" class="tally" data-tally="0">0/4</td>
+<td data-browser="babel" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -27506,7 +27506,7 @@ return len1 === 0 &amp;&amp; len2 === 3 &amp;&amp; c.length === 1 &amp;&amp; !(2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("394");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nvar len1 = c.length;\nc[2] = 'foo';\nvar len2 = c.length;\nc.length = 1;\nreturn len1 === 0 && len2 === 3 && c.length === 1 && !(2 in c);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27772,7 +27772,7 @@ return C.of(0) instanceof C;
 </tr>
 <tr class="supertest" significance="0.25"><td id="RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp-constructor">RegExp is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/3</td>
-<td data-browser="babel" class="tally" data-tally="0">0/3</td>
+<td data-browser="babel" class="tally" data-tally="1">3/3</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="closure" class="tally" data-tally="0">0/3</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/3</td>
@@ -27840,7 +27840,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("399");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.global && r.source === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27908,7 +27908,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("400");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.exec(\"foobarbaz\")[0] === \"baz\" && r.lastIndex === 9;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27976,7 +27976,7 @@ return r.test(&quot;foobarbaz&quot;);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("401");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\");\nreturn r.test(\"foobarbaz\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28039,7 +28039,7 @@ return r.test(&quot;foobarbaz&quot;);
 </tr>
 <tr class="supertest" significance="0.25"><td id="Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Function is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
-<td data-browser="babel" class="tally" data-tally="0">0/5</td>
+<td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -28107,7 +28107,7 @@ return c() === &apos;foo&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("403");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c() === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28176,7 +28176,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("404");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"this.bar = 2;\");\nc.prototype.baz = 3;\nreturn new c().bar === 2 && new c().baz === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28244,7 +28244,7 @@ return c.call({bar:1}, 2) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("405");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.call({bar:1}, 2) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28312,7 +28312,7 @@ return c.apply({bar:1}, [2]) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("406");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.apply({bar:1}, [2]) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28442,8 +28442,8 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="Promise_is_subclassable"><span><a class="anchor" href="#Promise_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Promise is subclassable</a></span></td>
-<td data-browser="tr" class="tally" data-tally="1">3/3</td>
-<td data-browser="babel" class="tally" data-tally="1">3/3</td>
+<td data-browser="tr" class="tally" data-tally="0">0/3</td>
+<td data-browser="babel" class="tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/3</td>
 <td data-browser="closure" class="tally" data-tally="0">0/3</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/3</td>
@@ -28530,8 +28530,8 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("409");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar p1 = new P(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new P(function(resolve, reject) { reject(\"quux\"); });\nvar score = +(p1 instanceof P);\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // P.prototype.then() should return a new P\n  score += p1.then() instanceof P && p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28611,8 +28611,8 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("410");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = P.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28692,8 +28692,8 @@ function check() {
 }
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("411");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = P.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28755,8 +28755,8 @@ function check() {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
-<td data-browser="babel" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td data-browser="tr" class="tally" data-tally="0">0/5</td>
+<td data-browser="babel" class="tally" data-tally="1">5/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -28825,7 +28825,7 @@ return c instanceof Boolean
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("413");return Function("asyncTestPassed","\nclass C extends Boolean {}\nvar c = new C(true);\nreturn c instanceof Boolean\n  && c == true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28894,7 +28894,7 @@ return c instanceof Number
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("414");return Function("asyncTestPassed","\nclass C extends Number {}\nvar c = new C(6);\nreturn c instanceof Number\n  && +c === 6;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -28965,7 +28965,7 @@ return c instanceof String
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("415");return Function("asyncTestPassed","\nclass C extends String {}\nvar c = new C(\"golly\");\nreturn c instanceof String\n  && c + '' === \"golly\"\n  && c[0] === \"g\"\n  && c.length === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -29036,7 +29036,7 @@ map.set(key, 123);
 return map.has(key) &amp;&amp; map.get(key) === 123;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("416");return Function("asyncTestPassed","\nvar key = {};\nclass M extends Map {}\nvar map = new M();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
@@ -29109,7 +29109,7 @@ set.add(123);
 return set.has(123);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("417");return Function("asyncTestPassed","\nvar obj = {};\nclass S extends Set {}\nvar set = new S();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
-<td class="yes" data-browser="tr">Yes</td>
+<td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>

--- a/es7/index.html
+++ b/es7/index.html
@@ -197,7 +197,7 @@ return typeof Array.prototype.includes === &apos;function&apos;;
 </tr>
 <tr class="supertest" significance="1"><td id="trailing_commas_in_function_syntax"><span><a class="anchor" href="#trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/tc39-notes/raw/master/es6/2014-09/trailing_comma_proposal.pdf">trailing commas in function syntax</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
-<td data-browser="babel" class="tally" data-tally="0">0/2</td>
+<td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
 <td data-browser="es7shim" class="tally" data-tally="0">0/2</td>
 <td data-browser="firefox31" class="obsolete tally" data-tally="0">0/2</td>
@@ -224,7 +224,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");return Function("asyncTestPassed","\nreturn typeof function f( a, b, ){} === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
@@ -251,7 +251,7 @@ return Math.min(1,2,3,) === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");return Function("asyncTestPassed","\nreturn Math.min(1,2,3,) === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
@@ -1663,11 +1663,11 @@ return true;
 <td class="no" data-browser="iojs">No</td>
 </tr>
 <tr significance="1"><td id="Set.prototype.toJSON"><span><a class="anchor" href="#Set.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Set.prototype.toJSON</a></span><script data-source="
-return typeof Map.prototype.toJSON === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");return Function("asyncTestPassed","\nreturn typeof Map.prototype.toJSON === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+return typeof Set.prototype.toJSON === &apos;function&apos;;
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");return Function("asyncTestPassed","\nreturn typeof Set.prototype.toJSON === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>


### PR DESCRIPTION
- Added support subclassing native constructors to `babel`, https://github.com/babel/babel/issues/1172 . [Result in modern browsers](http://habrastorage.org/files/2f7/43a/1c3/2f743a1c38684417807e9dfea7ba4e55.png), **but it requires `__proto__`**, [result in IE9](http://habrastorage.org/files/92f/7cc/d18/92f7ccd180384b1483f059675ebdc5f0.png). Btw, maybe add flag for show features, available with `__proto__`, as `yes`?
- Removed subclassing native constructors false positive in `traceur` - it works only without native `Map`, `Set`, `Promise` - [result in modern browsers](http://habrastorage.org/files/872/6e4/687/8726e468775b41ffb03416c7693a46b5.png).
- Added `Set#toJSON` to `core-js`, https://github.com/zloirock/core-js/issues/50
- Added trailing commas in function syntax to `babel`, https://github.com/babel/babel/pull/1215
- Added `typeof Symbol()` support to `traceur` as flagged feature, part of https://github.com/kangax/compat-table/issues/495
- Updated `babel` results to 5.1.9 - for example, generators use actual vanilla `regenerator`, https://github.com/babel/babel/issues/1123 .

Result: [ES6](https://raw.githack.com/zloirock/compat-table/951a51387f72a017db6906d7676d4b624efb6703/es6/index.html), [ES7](https://raw.githack.com/zloirock/compat-table/951a51387f72a017db6906d7676d4b624efb6703/es7/index.html)
