### PR TITLE
Add better tests for Typed Objects

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -236,10 +236,112 @@ exports.tests = [
   name: 'typed objects',
   category: 'proposal',
   link: 'https://github.com/dslomov-chromium/typed-objects-es7',
-  exec: function () {/*
-    return typeof StructType === "function";
-  */},
-  res: {
+  subtests : {
+    "StructType" : {
+      exec: function () {/*
+        return typeof TypedObject.StructType === "function";
+      */},
+      res: {
+      }
+    },
+    "ArrayType" : {
+      exec: function () {/*
+        return typeof TypedObject.ArrayType === "function";
+      */},
+      res: {
+      }
+    },
+    "TypedObject.storage" : {
+      exec: function () {/*
+        return typeof TypedObject.storage === "function";
+      */},
+      res: {
+      }
+    },
+    "Any type" : {
+      exec: function () {/*
+        return typeof TypedObject.Any === "function";
+      */},
+      res: {
+      }
+    },
+    "Object type" : {
+      exec: function () {/*
+        return typeof TypedObject.Object === "function";
+      */},
+      res: {
+      }
+    },
+    "float32 type" : {
+      exec: function () {/*
+        return typeof TypedObject.float32 === "function";
+      */},
+      res: {
+      }
+    },
+    "float64 type" : {
+      exec: function () {/*
+        return typeof TypedObject.float64 === "function";
+      */},
+      res: {
+      }
+    },
+    "int8 type" : {
+      exec: function () {/*
+        return typeof TypedObject.int8 === "function";
+      */},
+      res: {
+      }
+    },
+    "int16 type" : {
+      exec: function () {/*
+        return typeof TypedObject.int16 === "function";
+      */},
+      res: {
+      }
+    },
+    "int32 type" : {
+      exec: function () {/*
+        return typeof TypedObject.int32 === "function";
+      */},
+      res: {
+      }
+    },
+    "uint8 type" : {
+      exec: function () {/*
+        return typeof TypedObject.uint8 === "function";
+      */},
+      res: {
+      }
+    },
+    "uint8Clamped type" : {
+      exec: function () {/*
+        return typeof TypedObject.uint8Clamped === "function";
+      */},
+      res: {
+      }
+    },
+    "uint16 type" : {
+      exec: function () {/*
+        return typeof TypedObject.uint16 === "function";
+      */},
+      res: {
+      }
+    },
+    "uint32 type" : {
+      exec: function () {/*
+        return typeof TypedObject.uint32 === "function";
+      */},
+      res: {
+      }
+    },
+    "string type" : {
+      exec: function () {/*
+        return typeof TypedObject.string === "function";
+      */},
+      res: {
+      }
+    },
   }
 },
 {
@@ -400,7 +502,7 @@ exports.tests = [
     },
     'SIMD.%type%.bool' : {
       exec: function(){/*
-        return typeof SIMD.float32x4.bool === 'function';
+        return typeof SIMD.int32x4.bool === 'function';
       */},
       res: {
         firefox39: true,


### PR DESCRIPTION
The current test for Typed Objects tests for the existence of a global `StructType` object. In reality, `StructType` isn't a global object - it's actually a property of the global `TypedObject` object. 

This pull request fixes the current test for `StructType` and adds tests for a number of other Typed Objects features.
