### PR TITLE
fix babel example flag syntax

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -15,7 +15,7 @@ exports.browsers = {
     short: 'Babel +<br><nobr>core-js</nobr>',
     platformtype: 'compiler',
     note_id: 'experimental-flag',
-    note_html: 'Have to be enabled via --experimental flag'
+    note_html: 'Have to be enabled via --stage 0 flag'
   },
   jsx: {
     full: 'JSX',


### PR DESCRIPTION
the babel flag changed from `--experimental` to `--stage 0` to add es7 feature support.  The table reflects this now.
