### PR TITLE
Bring back sticky table header on safari

### DIFF
--- a/master.css
+++ b/master.css
@@ -15,9 +15,14 @@ table {
     margin-bottom: 2em; width: 100%;
 }
 thead > tr:nth-child(2) {
+    background: white;
     position: -webkit-sticky;
+    position: sticky;
     top: 0px;
     z-index: 1;
+}
+thead > tr:nth-child(2) > th {
+    outline: 2px solid white;
 }
 th {
     font-weight: normal; text-align: center; padding: 1em 0.45em; position: relative; min-width: 40px; font-size: 13px; background: #eee; vertical-align: middle;

--- a/master.css
+++ b/master.css
@@ -14,6 +14,11 @@ body {
 table {
     margin-bottom: 2em; width: 100%;
 }
+thead > tr:nth-child(2) {
+    position: -webkit-sticky;
+    top: 0px;
+    z-index: 1;
+}
 th {
     font-weight: normal; text-align: center; padding: 1em 0.45em; position: relative; min-width: 40px; font-size: 13px; background: #eee; vertical-align: middle;
 }

--- a/master.css
+++ b/master.css
@@ -17,12 +17,14 @@ table {
 thead > tr:nth-child(2) {
     background: white;
     position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
     position: sticky;
     top: 0px;
     z-index: 1;
 }
 thead > tr:nth-child(2) > th {
-    outline: 2px solid white;
+    box-shadow: 0 0 0 2px white;
 }
 th {
     font-weight: normal; text-align: center; padding: 1em 0.45em; position: relative; min-width: 40px; font-size: 13px; background: #eee; vertical-align: middle;


### PR DESCRIPTION
Firefox still don't do sticky table headers very well, but Safari do.

It makes it so much easier to read the table as the headers are always visible.

What it looks like on Safari 8.0.5 on Yosemite:

![animation](https://cloud.githubusercontent.com/assets/81981/7451544/2b565634-f252-11e4-8194-0f72971cf22a.gif)
