### PR TITLE
Update es7-shim SIMD results; fix a bunch of es7 tests

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -320,7 +320,7 @@ exports.tests = [
   link: 'https://gist.github.com/WebReflection/9353781',
   category: 'strawman',
   exec: function () {/*
-    var B = Symbol('b');
+    var B = typeof Symbol === 'function' ? Symbol('b') : 'b';
     var O = Object.defineProperty({a: 1, [B]: 2}, 'c', {value: 3});
     var D = Object.getOwnPropertyDescriptors(O);
 

--- a/data-es7.js
+++ b/data-es7.js
@@ -738,7 +738,10 @@ exports.tests = [
   category: 'strawman',
   link : 'https://github.com/DavidBruant/Map-Set.prototype.toJSON',
   exec: function(){/*
-    return JSON.stringify(new Map([['a', 'b'], ['c', 'd']])) === '[["a","b"],["c","d"]]';
+    var map = new Map();
+    map.set('a', 'b');
+    map.set('c', 'd');
+    return JSON.stringify(map) === '[["a","b"],["c","d"]]';
   */},
   res: {
     babel:       true,
@@ -773,7 +776,9 @@ exports.tests = [
   category: 'strawman',
   link: 'https://github.com/DavidBruant/Map-Set.prototype.toJSON',
   exec: function(){/*
-    return JSON.stringify(new Set([1, 2, 3, 2, 1])) === '[1,2,3]';
+    var set = new Set();
+    [1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });
+    return JSON.stringify(set) === '[1,2,3]';
   */},
   res: {
     babel:       true,

--- a/data-es7.js
+++ b/data-es7.js
@@ -320,8 +320,10 @@ exports.tests = [
   link: 'https://gist.github.com/WebReflection/9353781',
   category: 'strawman',
   exec: function () {/*
+    var object = {a: 1};
     var B = typeof Symbol === 'function' ? Symbol('b') : 'b';
-    var O = Object.defineProperty({a: 1, [B]: 2}, 'c', {value: 3});
+    object[B] = 2;
+    var O = Object.defineProperty(object, 'c', {value: 3});
     var D = Object.getOwnPropertyDescriptors(O);
 
     return D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true

--- a/data-es7.js
+++ b/data-es7.js
@@ -419,6 +419,7 @@ exports.tests = [
       */},
       res: {
         firefox39:   true,
+        es7shim: true,
       }
     },
     'float32x4' : {
@@ -427,6 +428,7 @@ exports.tests = [
       */},
       res: {
         firefox39:   true,
+        es7shim: true,
       }
     },
     'float64x2' : {
@@ -435,6 +437,7 @@ exports.tests = [
       */},
       res: {
         firefox39:   true,
+        es7shim: true,
       }
     },
     'int32x4' : {
@@ -443,6 +446,7 @@ exports.tests = [
       */},
       res: {
         firefox39:   true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.abs' : {
@@ -451,6 +455,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.add' : {
@@ -459,6 +464,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.and' : {
@@ -467,6 +473,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.bitselect' : {
@@ -491,6 +498,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.equal' : {
@@ -499,6 +507,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.equivalent' : {
@@ -515,6 +524,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.greaterThanOrEqual' : {
@@ -523,6 +533,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.lessThan' : {
@@ -531,6 +542,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.lessThanOrEqual' : {
@@ -539,6 +551,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.mul' : {
@@ -547,6 +560,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.neg' : {
@@ -555,6 +569,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.not' : {
@@ -563,6 +578,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.notEqual' : {
@@ -571,6 +587,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.or' : {
@@ -579,6 +596,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.select' : {
@@ -587,6 +605,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.shuffle' : {
@@ -595,6 +614,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.sub' : {
@@ -603,6 +623,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.swizzle' : {
@@ -611,6 +632,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     },
     'SIMD.%type%.xor' : {
@@ -619,6 +641,7 @@ exports.tests = [
       */},
       res: {
         firefox39: true,
+        es7shim: true,
       }
     }
   }

--- a/es7/index.html
+++ b/es7/index.html
@@ -683,7 +683,7 @@ return typeof Array.prototype.scatterPar === &apos;function&apos;;
 <td data-browser="tr" class="tally" data-tally="0">0/26</td>
 <td data-browser="babel" class="tally" data-tally="0">0/26</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/26</td>
-<td data-browser="es7shim" class="tally" data-tally="0">0/26</td>
+<td data-browser="es7shim" class="tally" data-tally="0.8846153846153846" style="background-color:hsl(106,47%,50%)">23/26</td>
 <td data-browser="firefox31" class="obsolete tally" data-tally="0">0/26</td>
 <td data-browser="firefox32" class="obsolete tally" data-tally="0">0/26</td>
 <td data-browser="firefox34" class="obsolete tally" data-tally="0">0/26</td>
@@ -711,7 +711,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -739,7 +739,7 @@ return typeof SIMD.float32x4 === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -767,7 +767,7 @@ return typeof SIMD.float64x2 === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -795,7 +795,7 @@ return typeof SIMD.int32x4 === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -823,7 +823,7 @@ return typeof SIMD.float32x4.abs === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -851,7 +851,7 @@ return typeof SIMD.float32x4.add === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -879,7 +879,7 @@ return typeof SIMD.float32x4.and === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -963,7 +963,7 @@ return typeof SIMD.float32x4.check === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -991,7 +991,7 @@ return typeof SIMD.float32x4.equal === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1047,7 +1047,7 @@ return typeof SIMD.float32x4.greaterThan === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1075,7 +1075,7 @@ return typeof SIMD.float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1103,7 +1103,7 @@ return typeof SIMD.float32x4.lessThan === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1131,7 +1131,7 @@ return typeof SIMD.float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1159,7 +1159,7 @@ return typeof SIMD.float32x4.mul === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1187,7 +1187,7 @@ return typeof SIMD.float32x4.neg === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1215,7 +1215,7 @@ return typeof SIMD.float32x4.not === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1243,7 +1243,7 @@ return typeof SIMD.float32x4.notEqual === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1271,7 +1271,7 @@ return typeof SIMD.float32x4.or === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1299,7 +1299,7 @@ return typeof SIMD.float32x4.select === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1327,7 +1327,7 @@ return typeof SIMD.float32x4.shuffle === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1355,7 +1355,7 @@ return typeof SIMD.float32x4.sub === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1383,7 +1383,7 @@ return typeof SIMD.float32x4.swizzle === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1411,7 +1411,7 @@ return typeof SIMD.float32x4.xor === &apos;function&apos;;
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
 <td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
+<td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox32">No</td>
 <td class="no obsolete" data-browser="firefox34">No</td>
@@ -1661,14 +1661,14 @@ return e instanceof Array
 <td class="no" data-browser="iojs">No</td>
 </tr>
 <tr significance="1"><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
-var B = Symbol(&apos;b&apos;);
+var B = typeof Symbol === &apos;function&apos; ? Symbol(&apos;b&apos;) : &apos;b&apos;;
 var O = Object.defineProperty({a: 1, [B]: 2}, &apos;c&apos;, {value: 3});
 var D = Object.getOwnPropertyDescriptors(O);
 
 return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configurable === true &amp;&amp; D.a.writable === true
   &amp;&amp; D[B].value === 2 &amp;&amp; D[B].enumerable === true &amp;&amp; D[B].configurable === true &amp;&amp; D[B].writable === true
   &amp;&amp; D.c.value === 3 &amp;&amp; D.c.enumerable === false &amp;&amp; D.c.configurable === false &amp;&amp; D.c.writable === false;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");return Function("asyncTestPassed","\nvar B = Symbol('b');\nvar O = Object.defineProperty({a: 1, [B]: 2}, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");return Function("asyncTestPassed","\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nvar O = Object.defineProperty({a: 1, [B]: 2}, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -1818,8 +1818,11 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no" data-browser="iojs">No</td>
 </tr>
 <tr significance="1"><td id="Map.prototype.toJSON"><span><a class="anchor" href="#Map.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Map.prototype.toJSON</a></span><script data-source="
-return JSON.stringify(new Map([[&apos;a&apos;, &apos;b&apos;], [&apos;c&apos;, &apos;d&apos;]])) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quot;,&quot;d&quot;]]&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");return Function("asyncTestPassed","\nreturn JSON.stringify(new Map([['a', 'b'], ['c', 'd']])) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+var map = new Map();
+map.set(&apos;a&apos;, &apos;b&apos;);
+map.set(&apos;c&apos;, &apos;d&apos;);
+return JSON.stringify(map) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quot;,&quot;d&quot;]]&apos;;
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set('a', 'b');\nmap.set('c', 'd');\nreturn JSON.stringify(map) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -1887,8 +1890,10 @@ return true;
 <td class="no" data-browser="iojs">No</td>
 </tr>
 <tr significance="1"><td id="Set.prototype.toJSON"><span><a class="anchor" href="#Set.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Set.prototype.toJSON</a></span><script data-source="
-return JSON.stringify(new Set([1, 2, 3, 2, 1])) === &apos;[1,2,3]&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");return Function("asyncTestPassed","\nreturn JSON.stringify(new Set([1, 2, 3, 2, 1])) === '[1,2,3]';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+var set = new Set();
+[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });
+return JSON.stringify(set) === &apos;[1,2,3]&apos;;
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");return Function("asyncTestPassed","\nvar set = new Set();\n[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });\nreturn JSON.stringify(set) === '[1,2,3]';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>

--- a/es7/index.html
+++ b/es7/index.html
@@ -1661,14 +1661,16 @@ return e instanceof Array
 <td class="no" data-browser="iojs">No</td>
 </tr>
 <tr significance="1"><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
+var object = {a: 1};
 var B = typeof Symbol === &apos;function&apos; ? Symbol(&apos;b&apos;) : &apos;b&apos;;
-var O = Object.defineProperty({a: 1, [B]: 2}, &apos;c&apos;, {value: 3});
+object[B] = 2;
+var O = Object.defineProperty(object, &apos;c&apos;, {value: 3});
 var D = Object.getOwnPropertyDescriptors(O);
 
 return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configurable === true &amp;&amp; D.a.writable === true
   &amp;&amp; D[B].value === 2 &amp;&amp; D[B].enumerable === true &amp;&amp; D[B].configurable === true &amp;&amp; D[B].writable === true
   &amp;&amp; D.c.value === 3 &amp;&amp; D.c.enumerable === false &amp;&amp; D.c.configurable === false &amp;&amp; D.c.writable === false;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");return Function("asyncTestPassed","\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nvar O = Object.defineProperty({a: 1, [B]: 2}, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jshint": "2.6.x"
   },
   "scripts": {
-    "lint": "jshint data-es5.js data-es6.js data-es7.js"
+    "lint": "jshint data-es5.js data-es6.js data-es7.js",
+    "build:compilers": "node build.js compilers"
   }
 }


### PR DESCRIPTION
The `es7-shim` now supports `SIMD` using the official polyfill for the spec. I'm not sure where the three extra methods in `compat-table` came from though - just because Firefox has them doesn't mean they belong there :-)

The `getOwnPropertyDescriptors` test had an unnecessary dependency on `Symbol`, and the `Map#toJSON`/`Set#toJSON` tests don't account for the fact that some engines don't accept an initial argument in their `Map`/`Set` constructors - both fixed :-)
