### PR TITLE
Update WebKit to r184902

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -311,7 +311,7 @@ exports.browsers = {
     obsolete: false
   },
   webkit: {
-    full: 'WebKit r184364',
+    full: 'WebKit r184902',
     short: 'WK',
     unstable: true,
   },
@@ -2194,6 +2194,7 @@ exports.tests = [
       res: {
         edge:         true,
         firefox35:    true,
+        webkit:       true,
         chrome42:     true,
         iojs:         true,
       },
@@ -5428,6 +5429,7 @@ exports.tests = [
         ie11:        true,
         firefox31:   true,
         chrome34:    true,
+        webkit:      true,
         node:        true,
         iojs:        true,
       },
@@ -6786,6 +6788,7 @@ exports.tests = [
         es6shim:     true,
         edge:        true,
         firefox32:   true,
+        webkit:      true,
       },
     },
     'Array.prototype.find': {

--- a/es6/index.html
+++ b/es6/index.html
@@ -176,7 +176,7 @@
 <th class="platform safari6 desktop obsolete" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
 <th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
 <th class="platform safari71_8 desktop" data-browser="safari71_8"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r184364">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r184902">WK</abbr></a></th>
 <th class="platform opera desktop obsolete" data-browser="opera"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr><a href="#khtml-note"><sup>[5]</sup></a></a></th>
 <th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
@@ -23434,7 +23434,7 @@ with (a) {
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">4/4</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
@@ -23721,7 +23721,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -26804,7 +26804,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/8</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">8/8</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/8</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/8</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/8</td>
@@ -26873,7 +26873,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -33396,7 +33396,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <td data-browser="safari6" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="safari7" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">5/5</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="konq49" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td data-browser="rhino17" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms." data-tally="0.2">1/5</td>
@@ -33540,7 +33540,7 @@ catch(e) {
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms.">No</td>


### PR DESCRIPTION
- Multiple `__proto__` in object literals becomes an error.
- `Object.setPrototypeOf` is implemented.
- `Array.prototype.copyWithin` is implemented.
