### PR TITLE
Object.prototype.__proto__ is now seen by Object.getOwnPropertyNames …

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -5663,6 +5663,7 @@ exports.tests = [
       */},
       res: Object.assign({}, temp.advancedProtoResults, {
         firefox11: false,
+        firefox39: true,
         rhino17:   false,
       }),
     },


### PR DESCRIPTION
…in FF39
