### PR TITLE
adding a test for prototype of bound functions

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2915,12 +2915,16 @@ exports.tests = [
 },
 {
   name: 'prototype of bound functions',
-  category: 'functions',
+  category: 'misc',
   significance: 'small',
   link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boundfunctioncreate',
   exec: function () {/*
     function getProtoBound(proto) {
-      var f = Object.setPrototypeOf(function() { }, proto)
+      var f = function () { }
+      if (Object.setPrototypeOf)
+        Object.setPrototypeOf(f, proto)
+      else
+        f.__proto__ = proto
       var boundF = Function.prototype.bind.call(f, null)
       return Object.getPrototypeOf(boundF)
     }

--- a/data-es6.js
+++ b/data-es6.js
@@ -2914,6 +2914,30 @@ exports.tests = [
   },
 },
 {
+  name: 'prototype of bound functions',
+  category: 'functions',
+  significance: 'small',
+  link: 'https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boundfunctioncreate',
+  exec: function () {/*
+    function getProtoBound(proto) {
+      var f = Object.setPrototypeOf(function() { }, proto)
+      var boundF = Function.prototype.bind.call(f, null)
+      return Object.getPrototypeOf(boundF)
+    }
+
+    return [ Function.prototype, function(){}, [], null ].every(function(proto) {
+      return getProtoBound(proto) === proto
+    })
+  */},
+  res: {
+    ie10:        false,
+    firefox11:   false,
+    chrome:      false,
+    safari51:    false,
+    webkit:      false,
+  }
+},
+{
   name: 'octal and binary literals',
   category: 'syntax',
   significance: 'small',


### PR DESCRIPTION
Adding a test for the new initial value of the [[Prototype]] of bound functions, as discussed in Issue #553.

Also, add negative results for tested browsers (didn't test Edge).
