### PR TITLE
Fix some core-js results and remove babel native constructors subclassing

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -5996,6 +5996,7 @@ exports.tests = [
           (function(){}).name === '';
       */},
       res: (temp.legacyFunctionNameResults = {
+        babel:       true,
         ejs:         true,
         firefox11:   true,
         edge:        true,
@@ -6021,7 +6022,6 @@ exports.tests = [
         return (new Function).name === "anonymous";
       */},
       res: {
-        babel:       true,
         firefox11:   true,
         edge:        true,
         safari51:    true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -7949,7 +7949,6 @@ exports.tests = [
         return r.global && r.source === "baz";
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7976,7 +7975,6 @@ exports.tests = [
         return r.exec("foobarbaz")[0] === "baz" && r.lastIndex === 9;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -7989,7 +7987,6 @@ exports.tests = [
         return r.test("foobarbaz");
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
         webkit:      true,
@@ -8010,7 +8007,6 @@ exports.tests = [
         return c() === 'foo';
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
       },
@@ -8035,7 +8031,6 @@ exports.tests = [
         return new c().bar === 2 && new c().baz === 3;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
       },
@@ -8047,7 +8042,6 @@ exports.tests = [
         return c.call({bar:1}, 2) === 3;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
       },
@@ -8059,7 +8053,6 @@ exports.tests = [
         return c.apply({bar:1}, [2]) === 3;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome44:    { val: flag, note_id: 'strict-required' },
       },
@@ -8109,7 +8102,6 @@ exports.tests = [
         }
       */},
       res: {
-        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -8120,7 +8112,6 @@ exports.tests = [
         return c instanceof C && c instanceof Promise && Object.getPrototypeOf(C) === Promise;
       */},
       res: {
-        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough
       },
     },
@@ -8144,7 +8135,6 @@ exports.tests = [
         }
       */},
       res: {
-        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -8168,7 +8158,6 @@ exports.tests = [
         }
       */},
       res: {
-        babel:       { val: false, note_id: 'compiler-proto' },
         typescript:  temp.typescriptFallthrough,
       },
     },
@@ -8188,7 +8177,6 @@ exports.tests = [
           && c == true;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -8201,7 +8189,6 @@ exports.tests = [
           && +c === 6;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -8216,7 +8203,6 @@ exports.tests = [
           && c.length === 5;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -8232,7 +8218,6 @@ exports.tests = [
         return map.has(key) && map.get(key) === 123;
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },
@@ -8249,7 +8234,6 @@ exports.tests = [
         return set.has(123);
       */},
       res: {
-        babel:       true,
         typescript:  temp.typescriptFallthrough,
         webkit:      true,
       },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3831,6 +3831,7 @@ exports.tests = [
         return 'get' in prop && Map[Symbol.species] === Map;
       */},
       res: {
+        babel:       true,
       },
     },
   },
@@ -4120,6 +4121,7 @@ exports.tests = [
         return 'get' in prop && Set[Symbol.species] === Set;
       */},
       res: {
+        babel:       true,
       },
     },
   },
@@ -4255,6 +4257,7 @@ exports.tests = [
         return 'get' in prop && WeakMap[Symbol.species] === WeakMap;
       */},
       res: {
+        babel:       true,
       },
     },
   },
@@ -4365,6 +4368,7 @@ exports.tests = [
         return 'get' in prop && WeakSet[Symbol.species] === WeakSet;
       */},
       res: {
+        babel:       true,
       },
     },
   },
@@ -5656,6 +5660,7 @@ exports.tests = [
         return 'get' in prop && Promise[Symbol.species] === Promise;
       */},
       res: {
+        babel:       true,
       },
     },
   },
@@ -6943,6 +6948,7 @@ exports.tests = [
           && JSON[s] === "JSON";
       */},
       res: {
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         chrome40:    flag,
         chrome44:    true,
@@ -7034,6 +7040,7 @@ exports.tests = [
         return 'get' in prop && RegExp[Symbol.species] === RegExp;
       */},
       res: {
+        babel:       true,
       },
     },
   }
@@ -7229,6 +7236,7 @@ exports.tests = [
         return 'get' in prop && Array[Symbol.species] === Array;
       */},
       res: {
+        babel:       true,
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -4983,7 +4983,7 @@ exports.tests = [
         return result[l-3] === sym1 && result[l-2] === sym2 && result[l-1] === sym3;
       */},
       res: {
-        babel:       { val: false, note_id: "forin-order", note_html: "This uses native for-in enumeration order, rather than the correct order." },
+        babel:       true,
         typescript:  temp.typescriptFallthrough,
         ejs:         true,
         es6shim:     { val: false, note_id: "forin-order" },
@@ -5996,7 +5996,6 @@ exports.tests = [
           (function(){}).name === '';
       */},
       res: (temp.legacyFunctionNameResults = {
-        babel:       true,
         ejs:         true,
         firefox11:   true,
         edge:        true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -16784,7 +16784,7 @@ return typeof Int8Array[Symbol.species] === &quot;function&quot; &amp;&amp;
 </tr>
 <tr class="supertest" significance="0.25"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects">Map</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)">11/14</td>
-<td data-browser="babel" class="tally" data-tally="0.9285714285714286" style="background-color:hsl(111,45%,50%)">13/14</td>
+<td data-browser="babel" class="tally" data-tally="1">14/14</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="closure" class="tally" data-tally="0">0/14</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/14</td>
@@ -17780,7 +17780,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Map, Symbol.species);\nreturn 'get' in prop && Map[Symbol.species] === Map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -17846,7 +17846,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 </tr>
 <tr class="supertest" significance="0.25"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.7857142857142857" style="background-color:hsl(94,51%,50%)">11/14</td>
-<td data-browser="babel" class="tally" data-tally="0.9285714285714286" style="background-color:hsl(111,45%,50%)">13/14</td>
+<td data-browser="babel" class="tally" data-tally="1">14/14</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/14</td>
 <td data-browser="closure" class="tally" data-tally="0">0/14</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/14</td>
@@ -18847,7 +18847,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Set, Symbol.species);\nreturn 'get' in prop && Set[Symbol.species] === Set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -18913,7 +18913,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 </tr>
 <tr class="supertest" significance="0.25"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/7</td>
-<td data-browser="babel" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td data-browser="babel" class="tally" data-tally="1">7/7</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="closure" class="tally" data-tally="0">0/7</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/7</td>
@@ -19419,7 +19419,7 @@ return &apos;get&apos; in prop &amp;&amp; WeakMap[Symbol.species] === WeakMap;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(WeakMap, Symbol.species);\nreturn 'get' in prop && WeakMap[Symbol.species] === WeakMap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19485,7 +19485,7 @@ return &apos;get&apos; in prop &amp;&amp; WeakMap[Symbol.species] === WeakMap;
 </tr>
 <tr class="supertest" significance="0.25"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakset-objects">WeakSet</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
-<td data-browser="babel" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="babel" class="tally" data-tally="1">6/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
@@ -19918,7 +19918,7 @@ return &apos;get&apos; in prop &amp;&amp; WeakSet[Symbol.species] === WeakSet;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(WeakSet, Symbol.species);\nreturn 'get' in prop && WeakSet[Symbol.species] === WeakSet;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -21589,7 +21589,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="supertest" significance="0.5"><td id="Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reflection">Reflect</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/16</td>
-<td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td data-browser="babel" class="tally" data-tally="0.8125" style="background-color:hsl(97,50%,50%)">13/16</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/16</td>
 <td data-browser="closure" class="tally" data-tally="0">0/16</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/16</td>
@@ -22544,7 +22544,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nvar sym1 = Symbol(), sym2 = Symbol(), sym3 = Symbol();\nvar obj = {\n  1:    true,\n  A:    true,\n};\nobj.B = true;\nobj[sym1] = true;\nobj[2] = true;\nobj[sym2] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, sym3,{ value: true, enumerable: true });\nObject.defineProperty(obj, 'D', { value: true, enumerable: true });\n\nvar result = Reflect.ownKeys(obj);\nvar l = result.length;\nreturn result[l-3] === sym1 && result[l-2] === sym2 && result[l-1] === sym3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#forin-order-note"><sup>[23]</sup></a></td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -22823,7 +22823,7 @@ return Reflect.construct(function(a, b, c) {
 </tr>
 <tr class="supertest" significance="1"><td id="Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="babel" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -23149,7 +23149,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Promise, Symbol.species);\nreturn 'get' in prop && Promise[Symbol.species] === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -23953,7 +23953,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 </tr>
 <tr class="supertest" significance="0.5"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-well-known-symbols">well-known symbols</a><a href="#symbol-iterator-functionality-note"><sup>[24]</sup></a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.06666666666666667" style="background-color:hsl(8,83%,50%)">1/15</td>
-<td data-browser="babel" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
+<td data-browser="babel" class="tally" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/15</td>
 <td data-browser="closure" class="tally" data-tally="0.06666666666666667" style="background-color:hsl(8,83%,50%)">1/15</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/15</td>
@@ -24973,7 +24973,7 @@ return Math[s] === &quot;Math&quot;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nvar s = Symbol.toStringTag;\nreturn Math[s] === \"Math\"\n  && JSON[s] === \"JSON\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25467,7 +25467,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 </tr>
 <tr class="supertest" significance="0.25"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/17</td>
-<td data-browser="babel" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="babel" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
@@ -25538,7 +25538,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25608,7 +25608,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27507,7 +27507,7 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 </tr>
 <tr class="supertest" significance="0.25"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
-<td data-browser="babel" class="tally" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td data-browser="babel" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
@@ -27922,7 +27922,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("381");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);\nreturn 'get' in prop && RegExp[Symbol.species] === RegExp;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -27988,7 +27988,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 </tr>
 <tr class="supertest" significance="0.5"><td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
-<td data-browser="babel" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td data-browser="babel" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="closure" class="tally" data-tally="0">0/11</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/11</td>
@@ -28770,7 +28770,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("393");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Array, Symbol.species);\nreturn 'get' in prop && Array[Symbol.species] === Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -31890,7 +31890,7 @@ return C.of(0) instanceof C;
 </tr>
 <tr class="supertest" significance="0.25"><td id="RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp-constructor">RegExp is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
-<td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="babel" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="closure" class="tally" data-tally="0">0/4</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/4</td>
@@ -31961,7 +31961,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("439");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.global && r.source === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32103,7 +32103,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("441");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.exec(\"foobarbaz\")[0] === \"baz\" && r.lastIndex === 9;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32174,7 +32174,7 @@ return r.test(&quot;foobarbaz&quot;);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("442");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\");\nreturn r.test(\"foobarbaz\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32240,7 +32240,7 @@ return r.test(&quot;foobarbaz&quot;);
 </tr>
 <tr class="supertest" significance="0.25"><td id="Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-function-constructor">Function is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
-<td data-browser="babel" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td data-browser="babel" class="tally" data-tally="0">0/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
@@ -32311,7 +32311,7 @@ return c() === &apos;foo&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("444");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c() === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32454,7 +32454,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("446");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"this.bar = 2;\");\nc.prototype.baz = 3;\nreturn new c().bar === 2 && new c().baz === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32525,7 +32525,7 @@ return c.call({bar:1}, 2) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("447");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.call({bar:1}, 2) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32596,7 +32596,7 @@ return c.apply({bar:1}, [2]) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("448");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.apply({bar:1}, [2]) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32824,7 +32824,7 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("451");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar p1 = new P(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new P(function(resolve, reject) { reject(\"quux\"); });\nvar score = +(p1 instanceof P);\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // P.prototype.then() should return a new P\n  score += p1.then() instanceof P && p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32895,7 +32895,7 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("452");return Function("asyncTestPassed","\nclass C extends Promise {}\nvar c = new C(function(resolve, reject) { resolve(\"foo\"); });\nreturn c instanceof C && c instanceof Promise && Object.getPrototypeOf(C) === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -32979,7 +32979,7 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("453");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = P.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33063,7 +33063,7 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("454");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = P.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[16]</sup></a></td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33129,7 +33129,7 @@ function check() {
 </tr>
 <tr class="supertest" significance="0.25"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
-<td data-browser="babel" class="tally" data-tally="1">5/5</td>
+<td data-browser="babel" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/5</td>
 <td data-browser="closure" class="tally" data-tally="0">0/5</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/5</td>
@@ -33201,7 +33201,7 @@ return c instanceof Boolean
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("456");return Function("asyncTestPassed","\nclass C extends Boolean {}\nvar c = new C(true);\nreturn c instanceof Boolean\n  && c == true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33273,7 +33273,7 @@ return c instanceof Number
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("457");return Function("asyncTestPassed","\nclass C extends Number {}\nvar c = new C(6);\nreturn c instanceof Number\n  && +c === 6;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33347,7 +33347,7 @@ return c instanceof String
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("458");return Function("asyncTestPassed","\nclass C extends String {}\nvar c = new C(\"golly\");\nreturn c instanceof String\n  && c + '' === \"golly\"\n  && c[0] === \"g\"\n  && c.length === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33422,7 +33422,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("459");return Function("asyncTestPassed","\nvar key = {};\nclass M extends Map {}\nvar map = new M();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -33498,7 +33498,7 @@ return set.has(123);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("460");return Function("asyncTestPassed","\nvar obj = {};\nclass S extends Set {}\nvar set = new S();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -25467,7 +25467,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 </tr>
 <tr class="supertest" significance="0.25"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/17</td>
-<td data-browser="babel" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="babel" class="tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
@@ -25538,7 +25538,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25608,7 +25608,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
+<td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -25677,7 +25677,7 @@ return (new Function).name === &quot;anonymous&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>


### PR DESCRIPTION
- Added `core-js` results, lost after separation well-known symbols tests:
  - `Symbol.species` getters in all required constructors
  - `Symbol.toStringTag` in `Math` and `JSON`.
- Fixed some other `core-js` results:
  - `core-js` should pass current `Reflect.ownKeys, symbol order` test in all engines.
  - `(new Function).name === "anonymous"` will work in environments w/o native `Function#name` or, for example, in FF, but not in actual V8
- Also, special case for subclassing native constructors was removed from `babel`
