### PR TITLE
subtest "prototype of bound functions / subclasses": corrections

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -3067,11 +3067,10 @@ exports.tests = [
               }
             }
             var boundF = Function.prototype.bind.call(C, null);
-            return Object.getPrototypeOf(boundF) === proto;
+            return Object.getPrototypeOf(boundF) === superclass;
           }
           return correctProtoBound(function(){})
-            && correctProtoBound(Array)
-            && correctProtoBound(null);
+            && correctProtoBound(Array);
       */},
       res: {
       },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3067,10 +3067,11 @@ exports.tests = [
               }
             }
             var boundF = Function.prototype.bind.call(C, null);
-            return Object.getPrototypeOf(boundF) === superclass;
+            return Object.getPrototypeOf(boundF) === Object.getPrototypeOf(C);
           }
           return correctProtoBound(function(){})
-            && correctProtoBound(Array);
+            && correctProtoBound(Array)
+            && correctProtoBound(null);
       */},
       res: {
       },


### PR DESCRIPTION
Two mistakes corrected in subtest "prototype of bound functions / subclasses":
- reference to `proto` instead of `superclass`;
- `class extends null {}` does not get `null` as its [[Prototype]]; therefore, remove that case.
