### PR TITLE
Update WebKit to r185990

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -311,7 +311,7 @@ exports.browsers = {
     obsolete: false
   },
   webkit: {
-    full: 'WebKit r185853',
+    full: 'WebKit r185990',
     short: 'WK',
     unstable: true,
   },
@@ -450,6 +450,7 @@ exports.tests = [
         firefox23:   true,
         chrome38:    flag,
         chrome40:    false,
+        webkit:      true,
         node:        flag,
       },
     },
@@ -470,6 +471,7 @@ exports.tests = [
         firefox23:   true,
         chrome38:    flag,
         chrome40:    false,
+        webkit:      true,
         node:        flag,
       },
     },
@@ -490,6 +492,7 @@ exports.tests = [
         firefox23:   true,
         chrome38:    flag,
         chrome40:    false,
+        webkit:      true,
         node:        flag,
       },
     },
@@ -5495,6 +5498,7 @@ exports.tests = [
         jsx:         true,
         closure:     true,
         firefox34:   true,
+        webkit:      true,
       },
     },
     'nested rest': {

--- a/es6/index.html
+++ b/es6/index.html
@@ -178,7 +178,7 @@
 <th class="platform safari6 desktop obsolete" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
 <th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
 <th class="platform safari71_8 desktop" data-browser="safari71_8"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r185853">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r185990">WK</abbr></a></th>
 <th class="platform opera desktop obsolete" data-browser="opera"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr><a href="#khtml-note"><sup>[5]</sup></a></a></th>
 <th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
@@ -4285,7 +4285,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/32</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/32</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">16/32</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.78125" style="background-color:hsl(93,51%,50%)">25/32</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.8125" style="background-color:hsl(97,50%,50%)">26/32</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/32</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/32</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/32</td>
@@ -6160,7 +6160,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -8607,7 +8607,7 @@ return f() === 1;
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/11</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/11</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0">0/11</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/11</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/11</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/11</td>
@@ -8676,7 +8676,7 @@ return (() =&gt; 5)() === 5;
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -8746,7 +8746,7 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -8816,7 +8816,7 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>


### PR DESCRIPTION
- destructuring rest element accepts iterables
- arrow function parsing functionality is supported
