### PR TITLE
Added tests for collections, promises and function length

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -8735,6 +8735,28 @@ exports.tests = [
       res: {
       },
     },
+    'function "length" is configurable': {
+      exec: function(){/*
+        var fn = function(a, b) {};
+
+        var desc = Object.getOwnPropertyDescriptor(fn, "length");
+        if (desc.configurable) {
+          Object.defineProperty(fn, "length", { value: 1 });
+          return fn.length === 1;
+        }
+
+        return false;
+      */},
+      res: {
+        babel:       false,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      false,
+        iojs:        false,
+      },
+    },
   },
 },
 ];

--- a/data-es6.js
+++ b/data-es6.js
@@ -3596,6 +3596,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         firefox36:   false,
         firefox37:   true,
         firefox38:   true,
@@ -3951,6 +3952,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         firefox36:   false,
         firefox37:   true,
         firefox38:   true,
@@ -4306,6 +4308,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         firefox36:   false,
         firefox37:   true,
         firefox38:   true,
@@ -4421,7 +4424,7 @@ exports.tests = [
     },
     'WeakMap.prototype.clear is missing': {
       exec: function () {/*
-        return !("clear" in WeakMap.prototype);
+        return typeof WeakMap !== "undefined" && !("clear" in WeakMap.prototype);
       */},
       res: {
         firefox38:   false,
@@ -4506,6 +4509,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         firefox36:   false,
         firefox37:   true,
         firefox38:   true,
@@ -4598,7 +4602,7 @@ exports.tests = [
     },
     'WeakSet.prototype.clear is missing': {
       exec: function () {/*
-        return !("clear" in WeakSet.prototype);
+        return typeof WeakSet !== "undefined" && !("clear" in WeakSet.prototype);
       */},
       res: {
         firefox38:   false,
@@ -5916,6 +5920,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         typescript:  temp.typescriptFallthrough,
         firefox38:   true,
         firefox40:   true,
@@ -5978,6 +5983,7 @@ exports.tests = [
       */},
       res: {
         babel:       true,
+        es6shim:     true,
         typescript:  temp.typescriptFallthrough,
         firefox38:   true,
         firefox40:   true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -4275,13 +4275,18 @@ exports.tests = [
         iojs:        true,
       },
     },
-    'WeakMap[Symbol.species]': {
+    'WeakMap[Symbol.species] is missing': {
       exec: function () {/*
-        var prop = Object.getOwnPropertyDescriptor(WeakMap, Symbol.species);
-        return 'get' in prop && WeakMap[Symbol.species] === WeakMap;
+        return !(Symbol.species in WeakMap);
       */},
       res: {
-        babel:       true,
+        babel:       false,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
       },
     },
   },
@@ -4386,13 +4391,18 @@ exports.tests = [
         iojs:        true,
       },
     },
-    'WeakSet[Symbol.species]': {
+    'WeakSet[Symbol.species] is missing': {
       exec: function () {/*
-        var prop = Object.getOwnPropertyDescriptor(WeakSet, Symbol.species);
-        return 'get' in prop && WeakSet[Symbol.species] === WeakSet;
+        return !(Symbol.species in WeakSet);
       */},
       res: {
-        babel:       true,
+        babel:       false,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -5896,6 +5896,35 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'Promise.all supports iterables': {
+      exec: function () {/*
+        var fulfills = Promise.all(new Set([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
+        ]));
+        var rejects = Promise.all(new Set([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
+        ]));
+        var score = 0;
+        fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
+        rejects.catch(function(result) { score += (result === "qux"); check(); });
+
+        function check() {
+          if (score === 2) asyncTestPassed();
+        }
+      */},
+      res: {
+        babel:       true,
+        typescript:  temp.typescriptFallthrough,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        false,
+      },
+    },
     'Promise.race': {
       exec: function () {/*
         var fulfills = Promise.race([
@@ -5927,6 +5956,35 @@ exports.tests = [
         safari71_8:  true,
         node:        true,
         iojs:        true,
+      },
+    },
+    'Promise.race supports iterables': {
+      exec: function () {/*
+        var fulfills = Promise.race(new Set([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
+        ]));
+        var rejects = Promise.race(new Set([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
+        ]));
+        var score = 0;
+        fulfills.then(function(result) { score += (result === "foo"); check(); });
+        rejects.catch(function(result) { score += (result === "baz"); check(); });
+
+        function check() {
+          if (score === 2) asyncTestPassed();
+        }
+      */},
+      res: {
+        babel:       true,
+        typescript:  temp.typescriptFallthrough,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        false,
       },
     },
     'Promise[Symbol.species]': {
@@ -8454,36 +8512,6 @@ exports.tests = [
         typescript:  temp.typescriptFallthrough,
       },
     },
-    'Promise.all supports iterables': {
-      exec: function () {/*
-        class P extends Promise {}
-        var fulfills = P.all(new Set([
-          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
-          new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
-        ]));
-        var rejects = P.all(new Set([
-          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
-          new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
-        ]));
-        var score = +(fulfills instanceof P);
-        fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
-        rejects.catch(function(result) { score += (result === "qux"); check(); });
-
-        function check() {
-          if (score === 3) asyncTestPassed();
-        }
-      */},
-      res: {
-        babel:       true,
-        typescript:  temp.typescriptFallthrough,
-        firefox38:   true,
-        firefox40:   true,
-        chrome43:    true,
-        chrome45:    true,
-        webkit:      true,
-        iojs:        false,
-      },
-    },
     'Promise.race': {
       exec: function () {/*
         class P extends Promise {}
@@ -8505,36 +8533,6 @@ exports.tests = [
       */},
       res: {
         typescript:  temp.typescriptFallthrough,
-      },
-    },
-    'Promise.race supports iterables': {
-      exec: function () {/*
-        class P extends Promise {}
-        var fulfills = P.race(new Set([
-          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
-          new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
-        ]));
-        var rejects = P.race(new Set([
-          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
-          new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
-        ]));
-        var score = +(fulfills instanceof P);
-        fulfills.then(function(result) { score += (result === "foo"); check(); });
-        rejects.catch(function(result) { score += (result === "baz"); check(); });
-
-        function check() {
-          if (score === 3) asyncTestPassed();
-        }
-      */},
-      res: {
-        babel:       true,
-        typescript:  temp.typescriptFallthrough,
-        firefox38:   true,
-        firefox40:   true,
-        chrome43:    true,
-        chrome45:    true,
-        webkit:      true,
-        iojs:        false,
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -4275,6 +4275,19 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'WeakMap.prototype.clear is missing': {
+      exec: function () {/*
+        return !("clear" in WeakMap.prototype);
+      */},
+      res: {
+        firefox38:   false,
+        firefox40:   false,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
     'WeakMap[Symbol.species] is missing': {
       exec: function () {/*
         return !(Symbol.species in WeakMap);
@@ -4388,6 +4401,19 @@ exports.tests = [
         chrome36:    true,
         webkit:      true,
         node:        true,
+        iojs:        true,
+      },
+    },
+    'WeakSet.prototype.clear is missing': {
+      exec: function () {/*
+        return !("clear" in WeakSet.prototype);
+      */},
+      res: {
+        firefox38:   false,
+        firefox40:   false,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
         iojs:        true,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -8236,6 +8236,36 @@ exports.tests = [
         typescript:  temp.typescriptFallthrough,
       },
     },
+    'Promise.all supports iterables': {
+      exec: function () {/*
+        class P extends Promise {}
+        var fulfills = P.all(new Set([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,100,"bar"); }),
+        ]));
+        var rejects = P.all(new Set([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 100,"qux"); }),
+        ]));
+        var score = +(fulfills instanceof P);
+        fulfills.then(function(result) { score += (result + "" === "foo,bar"); check(); });
+        rejects.catch(function(result) { score += (result === "qux"); check(); });
+
+        function check() {
+          if (score === 3) asyncTestPassed();
+        }
+      */},
+      res: {
+        babel:       true,
+        typescript:  temp.typescriptFallthrough,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        false,
+      },
+    },
     'Promise.race': {
       exec: function () {/*
         class P extends Promise {}
@@ -8257,6 +8287,36 @@ exports.tests = [
       */},
       res: {
         typescript:  temp.typescriptFallthrough,
+      },
+    },
+    'Promise.race supports iterables': {
+      exec: function () {/*
+        class P extends Promise {}
+        var fulfills = P.race(new Set([
+          new Promise(function(resolve)   { setTimeout(resolve,200,"foo"); }),
+          new Promise(function(_, reject) { setTimeout(reject, 300,"bar"); }),
+        ]));
+        var rejects = P.race(new Set([
+          new Promise(function(_, reject) { setTimeout(reject, 200,"baz"); }),
+          new Promise(function(resolve)   { setTimeout(resolve,300,"qux"); }),
+        ]));
+        var score = +(fulfills instanceof P);
+        fulfills.then(function(result) { score += (result === "foo"); check(); });
+        rejects.catch(function(result) { score += (result === "baz"); check(); });
+
+        function check() {
+          if (score === 3) asyncTestPassed();
+        }
+      */},
+      res: {
+        babel:       true,
+        typescript:  temp.typescriptFallthrough,
+        firefox38:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        false,
       },
     },
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3586,6 +3586,27 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'constructor accepts null': {
+      exec: function () {/*
+        try {
+          new Map(null); return true;
+        } catch (ex) {
+          return false;
+        }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
     'iterator closing': {
       exec: function () {/*
         var closed = false;
@@ -3890,6 +3911,27 @@ exports.tests = [
         chrome38:    true,
         webkit:      true,
         node:        true,
+        iojs:        true,
+      },
+    },
+    'constructor accepts null': {
+      exec: function () {/*
+        try {
+          new Set(null); return true;
+        } catch (ex) {
+          return false;
+        }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
         iojs:        true,
       },
     },
@@ -4200,6 +4242,27 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'constructor accepts null': {
+      exec: function () {/*
+        try {
+          new WeakMap(null); return true;
+        } catch (ex) {
+          return false;
+        }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
     'frozen objects as keys': {
       exec: function () {/*
         var f = Object.freeze({});
@@ -4349,6 +4412,27 @@ exports.tests = [
         chrome38:    true,
         webkit:      true,
         node:        true,
+        iojs:        true,
+      },
+    },
+    'constructor accepts null': {
+      exec: function () {/*
+        try {
+          new WeakSet(null); return true;
+        } catch (ex) {
+          return false;
+        }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
         iojs:        true,
       },
     },

--- a/data-es6.js
+++ b/data-es6.js
@@ -3607,6 +3607,33 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'constructor invokes set': {
+      exec: function () {/*
+        var passed = false;
+        var _set = Map.prototype.set;
+
+        Map.prototype.set = function(k, v) {
+          passed = true;
+        };
+
+        new Map([ [1, 2] ]);
+        Map.prototype.set = _set;
+
+        return passed;
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
     'iterator closing': {
       exec: function () {/*
         var closed = false;
@@ -3921,6 +3948,33 @@ exports.tests = [
         } catch (ex) {
           return false;
         }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
+    'constructor invokes add': {
+      exec: function () {/*
+        var passed = false;
+        var _add = Set.prototype.add;
+
+        Set.prototype.add = function(v) {
+          passed = true;
+        };
+
+        new Set([ 1 ]);
+        Set.prototype.add = _add;
+
+        return passed;
       */},
       res: {
         babel:       true,
@@ -4263,6 +4317,33 @@ exports.tests = [
         iojs:        true,
       },
     },
+    'constructor invokes set': {
+      exec: function () {/*
+        var passed = false;
+        var _set = WeakMap.prototype.set;
+
+        WeakMap.prototype.set = function(k, v) {
+          passed = true;
+        };
+
+        new WeakMap([ [{ }, 42] ]);
+        WeakMap.prototype.set = _set;
+
+        return passed;
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
     'frozen objects as keys': {
       exec: function () {/*
         var f = Object.freeze({});
@@ -4422,6 +4503,33 @@ exports.tests = [
         } catch (ex) {
           return false;
         }
+      */},
+      res: {
+        babel:       true,
+        firefox36:   false,
+        firefox37:   true,
+        firefox38:   true,
+        firefox39:   true,
+        firefox40:   true,
+        chrome43:    true,
+        chrome45:    true,
+        webkit:      true,
+        iojs:        true,
+      },
+    },
+    'constructor invokes add': {
+      exec: function () {/*
+        var passed = false;
+        var _add = WeakSet.prototype.add;
+
+        WeakSet.prototype.add = function(v) {
+          passed = true;
+        };
+
+        new WeakSet([ { } ]);
+        WeakSet.prototype.add = _add;
+
+        return passed;
       */},
       res: {
         babel:       true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -16865,7 +16865,7 @@ return typeof Int8Array[Symbol.species] === &quot;function&quot; &amp;&amp;
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/17</td>
-<td data-browser="es6shim" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="es6shim" class="tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/17</td>
 <td data-browser="ie11" class="tally" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
 <td data-browser="edge" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
@@ -17086,7 +17086,7 @@ try {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>
@@ -18158,7 +18158,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td data-browser="closure" class="tally" data-tally="0">0/17</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/17</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/17</td>
-<td data-browser="es6shim" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="es6shim" class="tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/17</td>
 <td data-browser="ie11" class="tally" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
 <td data-browser="edge" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
@@ -18379,7 +18379,7 @@ try {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>
@@ -19456,7 +19456,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td data-browser="closure" class="tally" data-tally="0">0/10</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/10</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/10</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
+<td data-browser="es6shim" class="tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/10</td>
 <td data-browser="ie11" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td data-browser="edge" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
@@ -19677,7 +19677,7 @@ try {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>
@@ -20104,8 +20104,8 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="subtest" data-parent="WeakMap" id="WeakMap_WeakMap.prototype.clear_is_missing"><td><span><a class="anchor" href="#WeakMap_WeakMap.prototype.clear_is_missing">&#xA7;</a>WeakMap.prototype.clear is missing</span><script data-source="
-return !(&quot;clear&quot; in WeakMap.prototype);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nreturn !(\"clear\" in WeakMap.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+return typeof WeakMap !== &quot;undefined&quot; &amp;&amp; !(&quot;clear&quot; in WeakMap.prototype);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nreturn typeof WeakMap !== \"undefined\" && !(\"clear\" in WeakMap.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20248,7 +20248,7 @@ return !(Symbol.species in WeakMap);
 <td data-browser="closure" class="tally" data-tally="0">0/9</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/9</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/9</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/9</td>
+<td data-browser="es6shim" class="tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/9</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/9</td>
 <td data-browser="edge" class="unstable tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
@@ -20468,7 +20468,7 @@ try {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>
@@ -20823,8 +20823,8 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="WeakSet" id="WeakSet_WeakSet.prototype.clear_is_missing"><td><span><a class="anchor" href="#WeakSet_WeakSet.prototype.clear_is_missing">&#xA7;</a>WeakSet.prototype.clear is missing</span><script data-source="
-return !(&quot;clear&quot; in WeakSet.prototype);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn !(\"clear\" in WeakSet.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+return typeof WeakSet !== &quot;undefined&quot; &amp;&amp; !(&quot;clear&quot; in WeakSet.prototype);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn typeof WeakSet !== \"undefined\" && !(\"clear\" in WeakSet.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -23806,7 +23806,7 @@ return Reflect.construct(function(a, b, c) {
 <td data-browser="closure" class="tally" data-tally="0">0/6</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/6</td>
 <td data-browser="typescript" class="tally" data-tally="0">0/6</td>
-<td data-browser="es6shim" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="es6shim" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie11" class="tally" data-tally="0">0/6</td>
 <td data-browser="edge" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
@@ -24062,7 +24062,7 @@ function check() {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>
@@ -24228,7 +24228,7 @@ function check() {
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
-<td class="no" data-browser="es6shim">No</td>
+<td class="yes" data-browser="es6shim">Yes</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no unstable" data-browser="edge">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -16859,70 +16859,70 @@ return typeof Int8Array[Symbol.species] === &quot;function&quot; &amp;&amp;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">Map</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="babel" class="tally" data-tally="1">15/15</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="closure" class="tally" data-tally="0">0/15</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/15</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/15</td>
-<td data-browser="es6shim" class="tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/15</td>
-<td data-browser="ie11" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">5/15</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox38" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.4666666666666667">0/15</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.6">0/15</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome43" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/15</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.9333333333333333" style="background-color:hsl(112,44%,50%)">14/15</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/15</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/15</td>
-<td data-browser="node" class="tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)" data-flagged-tally="0.8">11/15</td>
-<td data-browser="iojs" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/15</td>
-<td data-browser="ios8" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td data-browser="tr" class="tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="babel" class="tally" data-tally="1">17/17</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="closure" class="tally" data-tally="0">0/17</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/17</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/17</td>
+<td data-browser="es6shim" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/17</td>
+<td data-browser="ie11" class="tally" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)">8/17</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)">8/17</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox38" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.4117647058823529">0/17</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.5294117647058824">0/17</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome43" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/17</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/17</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/17</td>
+<td data-browser="node" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)" data-flagged-tally="0.7058823529411765">11/17</td>
+<td data-browser="iojs" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/17</td>
+<td data-browser="ios8" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_basic_functionality"><td><span><a class="anchor" href="#Map_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var key = {};
@@ -17072,6 +17072,158 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="Map" id="Map_constructor_accepts_null"><td><span><a class="anchor" href="#Map_constructor_accepts_null">&#xA7;</a>constructor accepts null</span><script data-source="
+try {
+  new Map(null); return true;
+} catch (ex) {
+  return false;
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("231");return Function("asyncTestPassed","\ntry {\n  new Map(null); return true;\n} catch (ex) {\n  return false;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="Map" id="Map_constructor_invokes_set"><td><span><a class="anchor" href="#Map_constructor_invokes_set">&#xA7;</a>constructor invokes set</span><script data-source="
+var passed = false;
+var _set = Map.prototype.set;
+
+Map.prototype.set = function(k, v) {
+  passed = true;
+};
+
+new Map([ [1, 2] ]);
+Map.prototype.set = _set;
+
+return passed;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nvar passed = false;\nvar _set = Map.prototype.set;\n\nMap.prototype.set = function(k, v) {\n  passed = true;\n};\n\nnew Map([ [1, 2] ]);\nMap.prototype.set = _set;\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="subtest" data-parent="Map" id="Map_iterator_closing"><td><span><a class="anchor" href="#Map_iterator_closing">&#xA7;</a>iterator closing</span><script data-source="
 var closed = false;
 var iter = global.__createIterableObject([1, 2, 3], {
@@ -17081,7 +17233,7 @@ try {
   new Map(iter);
 } catch(e){}
 return closed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("231");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new Map(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new Map(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17151,7 +17303,7 @@ return closed;
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.set_returns_this"><td><span><a class="anchor" href="#Map_Map.prototype.set_returns_this">&#xA7;</a>Map.prototype.set returns this</span><script data-source="
 var map = new Map();
 return map.set(0, 0) === map;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("232");return Function("asyncTestPassed","\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar map = new Map();\nreturn map.set(0, 0) === map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17226,7 +17378,7 @@ map.forEach(function (value, key) {
   k = 1 / key;
 });
 return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("233");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nvar map = new Map();\nmap.set(-0, \"foo\");\nvar k;\nmap.forEach(function (value, key) {\n  k = 1 / key;\n});\nreturn k === Infinity && map.get(+0) == \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17300,7 +17452,7 @@ var map = new Map();
 map.set(key, 123);
 
 return map.size === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");return Function("asyncTestPassed","\nvar key = {};\nvar map = new Map();\n\nmap.set(key, 123);\n\nreturn map.size === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17369,7 +17521,7 @@ return map.size === 1;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.delete"><td><span><a class="anchor" href="#Map_Map.prototype.delete">&#xA7;</a>Map.prototype.delete</span><script data-source="
 return typeof Map.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");return Function("asyncTestPassed","\nreturn typeof Map.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nreturn typeof Map.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17438,7 +17590,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.clear"><td><span><a class="anchor" href="#Map_Map.prototype.clear">&#xA7;</a>Map.prototype.clear</span><script data-source="
 return typeof Map.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");return Function("asyncTestPassed","\nreturn typeof Map.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nreturn typeof Map.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17507,7 +17659,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.forEach"><td><span><a class="anchor" href="#Map_Map.prototype.forEach">&#xA7;</a>Map.prototype.forEach</span><script data-source="
 return typeof Map.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");return Function("asyncTestPassed","\nreturn typeof Map.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nreturn typeof Map.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17576,7 +17728,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.keys"><td><span><a class="anchor" href="#Map_Map.prototype.keys">&#xA7;</a>Map.prototype.keys</span><script data-source="
 return typeof Map.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");return Function("asyncTestPassed","\nreturn typeof Map.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nreturn typeof Map.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17645,7 +17797,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.values"><td><span><a class="anchor" href="#Map_Map.prototype.values">&#xA7;</a>Map.prototype.values</span><script data-source="
 return typeof Map.prototype.values === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");return Function("asyncTestPassed","\nreturn typeof Map.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nreturn typeof Map.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17714,7 +17866,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype.entries"><td><span><a class="anchor" href="#Map_Map.prototype.entries">&#xA7;</a>Map.prototype.entries</span><script data-source="
 return typeof Map.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");return Function("asyncTestPassed","\nreturn typeof Map.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\nreturn typeof Map.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17783,7 +17935,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Map" id="Map_Map.prototype[Symbol.iterator]"><td><span><a class="anchor" href="#Map_Map.prototype[Symbol.iterator]">&#xA7;</a>Map.prototype[Symbol.iterator]</span><script data-source="
 return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");return Function("asyncTestPassed","\nreturn typeof Map.prototype[Symbol.iterator] === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nreturn typeof Map.prototype[Symbol.iterator] === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17862,7 +18014,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
   !proto1    .hasOwnProperty(Symbol.iterator) &amp;&amp;
   !iterator  .hasOwnProperty(Symbol.iterator) &amp;&amp;
   iterator[Symbol.iterator]() === iterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = new Map()[Symbol.iterator]();\n// %MapIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = new Map()[Symbol.iterator]();\n// %MapIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -17932,7 +18084,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <tr class="subtest" data-parent="Map" id="Map_Map[Symbol.species]"><td><span><a class="anchor" href="#Map_Map[Symbol.species]">&#xA7;</a>Map[Symbol.species]</span><script data-source="
 var prop = Object.getOwnPropertyDescriptor(Map, Symbol.species);
 return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Map, Symbol.species);\nreturn 'get' in prop && Map[Symbol.species] === Map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Map, Symbol.species);\nreturn 'get' in prop && Map[Symbol.species] === Map;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18000,70 +18152,70 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-set-objects">Set</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="babel" class="tally" data-tally="1">15/15</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="closure" class="tally" data-tally="0">0/15</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/15</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/15</td>
-<td data-browser="es6shim" class="tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/15</td>
-<td data-browser="ie11" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">5/15</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">5/15</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox31" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox38" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.26666666666666666">0/15</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/15</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.5333333333333333">0/15</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome43" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/15</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.9333333333333333" style="background-color:hsl(112,44%,50%)">14/15</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/15</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/15</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/15</td>
-<td data-browser="node" class="tally" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)" data-flagged-tally="0.8">11/15</td>
-<td data-browser="iojs" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/15</td>
-<td data-browser="ios8" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td data-browser="tr" class="tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="babel" class="tally" data-tally="1">17/17</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="closure" class="tally" data-tally="0">0/17</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/17</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/17</td>
+<td data-browser="es6shim" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/17</td>
+<td data-browser="ie11" class="tally" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)">8/17</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox38" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.23529411764705882">0/17</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0" data-flagged-tally="0.29411764705882354">0/17</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0" data-flagged-tally="0.47058823529411764">0/17</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="chrome43" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/17</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/17</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/17</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/17</td>
+<td data-browser="node" class="tally" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)" data-flagged-tally="0.7058823529411765">11/17</td>
+<td data-browser="iojs" class="tally" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.7058823529411765" style="background-color:hsl(84,54%,50%)">12/17</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/17</td>
+<td data-browser="ios8" class="tally" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_basic_functionality"><td><span><a class="anchor" href="#Set_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var obj = {};
@@ -18073,7 +18225,7 @@ set.add(123);
 set.add(123);
 
 return set.has(123);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18146,7 +18298,7 @@ var obj2 = {};
 var set = new Set([obj1, obj2]);
 
 return set.has(obj1) &amp;&amp; set.has(obj2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");return Function("asyncTestPassed","\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar obj1 = {};\nvar obj2 = {};\nvar set = new Set([obj1, obj2]);\n\nreturn set.has(obj1) && set.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18213,6 +18365,158 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="Set" id="Set_constructor_accepts_null"><td><span><a class="anchor" href="#Set_constructor_accepts_null">&#xA7;</a>constructor accepts null</span><script data-source="
+try {
+  new Set(null); return true;
+} catch (ex) {
+  return false;
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\ntry {\n  new Set(null); return true;\n} catch (ex) {\n  return false;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="Set" id="Set_constructor_invokes_add"><td><span><a class="anchor" href="#Set_constructor_invokes_add">&#xA7;</a>constructor invokes add</span><script data-source="
+var passed = false;
+var _add = Set.prototype.add;
+
+Set.prototype.add = function(v) {
+  passed = true;
+};
+
+new Set([ 1 ]);
+Set.prototype.add = _add;
+
+return passed;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar passed = false;\nvar _add = Set.prototype.add;\n\nSet.prototype.add = function(v) {\n  passed = true;\n};\n\nnew Set([ 1 ]);\nSet.prototype.add = _add;\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="subtest" data-parent="Set" id="Set_iterator_closing"><td><span><a class="anchor" href="#Set_iterator_closing">&#xA7;</a>iterator closing</span><script data-source="
 var closed = false;
 var iter = global.__createIterableObject([1, 2, 3], {
@@ -18225,7 +18529,7 @@ try {
 } catch(e){}
 Set.prototype.add = add;
 return closed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\nvar add = Set.prototype.add;\nSet.prototype.add = function(){ throw 0 };\ntry {\n  new Set(iter);\n} catch(e){}\nSet.prototype.add = add;\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\nvar add = Set.prototype.add;\nSet.prototype.add = function(){ throw 0 };\ntry {\n  new Set(iter);\n} catch(e){}\nSet.prototype.add = add;\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18295,7 +18599,7 @@ return closed;
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.add_returns_this"><td><span><a class="anchor" href="#Set_Set.prototype.add_returns_this">&#xA7;</a>Set.prototype.add returns this</span><script data-source="
 var set = new Set();
 return set.add(0) === set;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");return Function("asyncTestPassed","\nvar set = new Set();\nreturn set.add(0) === set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nvar set = new Set();\nreturn set.add(0) === set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18370,7 +18674,7 @@ set.forEach(function (value) {
   k = 1 / value;
 });
 return k === Infinity &amp;&amp; set.has(+0);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");return Function("asyncTestPassed","\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nvar set = new Set();\nset.add(-0);\nvar k;\nset.forEach(function (value) {\n  k = 1 / value;\n});\nreturn k === Infinity && set.has(+0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18446,7 +18750,7 @@ set.add(123);
 set.add(456);
 
 return set.size === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");return Function("asyncTestPassed","\nvar obj = {};\nvar set = new Set();\n\nset.add(123);\nset.add(123);\nset.add(456);\n\nreturn set.size === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18515,7 +18819,7 @@ return set.size === 2;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.delete"><td><span><a class="anchor" href="#Set_Set.prototype.delete">&#xA7;</a>Set.prototype.delete</span><script data-source="
 return typeof Set.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");return Function("asyncTestPassed","\nreturn typeof Set.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nreturn typeof Set.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18584,7 +18888,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.clear"><td><span><a class="anchor" href="#Set_Set.prototype.clear">&#xA7;</a>Set.prototype.clear</span><script data-source="
 return typeof Set.prototype.clear === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");return Function("asyncTestPassed","\nreturn typeof Set.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nreturn typeof Set.prototype.clear === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18653,7 +18957,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.forEach"><td><span><a class="anchor" href="#Set_Set.prototype.forEach">&#xA7;</a>Set.prototype.forEach</span><script data-source="
 return typeof Set.prototype.forEach === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");return Function("asyncTestPassed","\nreturn typeof Set.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nreturn typeof Set.prototype.forEach === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18722,7 +19026,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.keys"><td><span><a class="anchor" href="#Set_Set.prototype.keys">&#xA7;</a>Set.prototype.keys</span><script data-source="
 return typeof Set.prototype.keys === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");return Function("asyncTestPassed","\nreturn typeof Set.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\nreturn typeof Set.prototype.keys === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18791,7 +19095,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.values"><td><span><a class="anchor" href="#Set_Set.prototype.values">&#xA7;</a>Set.prototype.values</span><script data-source="
 return typeof Set.prototype.values === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");return Function("asyncTestPassed","\nreturn typeof Set.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");return Function("asyncTestPassed","\nreturn typeof Set.prototype.values === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18860,7 +19164,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype.entries"><td><span><a class="anchor" href="#Set_Set.prototype.entries">&#xA7;</a>Set.prototype.entries</span><script data-source="
 return typeof Set.prototype.entries === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");return Function("asyncTestPassed","\nreturn typeof Set.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");return Function("asyncTestPassed","\nreturn typeof Set.prototype.entries === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -18929,7 +19233,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Set" id="Set_Set.prototype[Symbol.iterator]"><td><span><a class="anchor" href="#Set_Set.prototype[Symbol.iterator]">&#xA7;</a>Set.prototype[Symbol.iterator]</span><script data-source="
 return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");return Function("asyncTestPassed","\nreturn typeof Set.prototype[Symbol.iterator] === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nreturn typeof Set.prototype[Symbol.iterator] === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19008,7 +19312,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
   !proto1    .hasOwnProperty(Symbol.iterator) &amp;&amp;
   !iterator  .hasOwnProperty(Symbol.iterator) &amp;&amp;
   iterator[Symbol.iterator]() === iterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = new Set()[Symbol.iterator]();\n// %SetIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = new Set()[Symbol.iterator]();\n// %SetIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19078,7 +19382,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <tr class="subtest" data-parent="Set" id="Set_Set[Symbol.species]"><td><span><a class="anchor" href="#Set_Set[Symbol.species]">&#xA7;</a>Set[Symbol.species]</span><script data-source="
 var prop = Object.getOwnPropertyDescriptor(Set, Symbol.species);
 return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Set, Symbol.species);\nreturn 'get' in prop && Set[Symbol.species] === Set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Set, Symbol.species);\nreturn 'get' in prop && Set[Symbol.species] === Set;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19146,70 +19450,70 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-weakmap-objects">WeakMap</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/7</td>
-<td data-browser="babel" class="tally" data-tally="1">7/7</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="closure" class="tally" data-tally="0">0/7</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/7</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/7</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/7</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/7</td>
-<td data-browser="ie11" class="tally" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox31" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="firefox38" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.42857142857142855">0/7</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome43" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/7</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/7</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/7</td>
-<td data-browser="node" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="iojs" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/7</td>
-<td data-browser="ios8" class="tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td data-browser="tr" class="tally" data-tally="0">0/10</td>
+<td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="closure" class="tally" data-tally="0">0/10</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/10</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/10</td>
+<td data-browser="es6shim" class="tally" data-tally="0">0/10</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/10</td>
+<td data-browser="ie11" class="tally" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox31" class="tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
+<td data-browser="firefox38" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.3">0/10</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="chrome43" class="tally" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/10</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">10/10</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/10</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/10</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/10</td>
+<td data-browser="node" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="iojs" class="tally" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/10</td>
+<td data-browser="ios8" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
 </tr>
 <tr class="subtest" data-parent="WeakMap" id="WeakMap_basic_functionality"><td><span><a class="anchor" href="#WeakMap_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var key = {};
@@ -19218,7 +19522,7 @@ var weakmap = new WeakMap();
 weakmap.set(key, 123);
 
 return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");return Function("asyncTestPassed","\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");return Function("asyncTestPassed","\nvar key = {};\nvar weakmap = new WeakMap();\n\nweakmap.set(key, 123);\n\nreturn weakmap.has(key) && weakmap.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19292,7 +19596,7 @@ var weakmap = new WeakMap([[key1, 123], [key2, 456]]);
 
 return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
        weakmap.has(key2) &amp;&amp; weakmap.get(key2) === 456;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nvar key1 = {};\nvar key2 = {};\nvar weakmap = new WeakMap([[key1, 123], [key2, 456]]);\n\nreturn weakmap.has(key1) && weakmap.get(key1) === 123 &&\n       weakmap.has(key2) && weakmap.get(key2) === 456;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19359,12 +19663,164 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="WeakMap" id="WeakMap_constructor_accepts_null"><td><span><a class="anchor" href="#WeakMap_constructor_accepts_null">&#xA7;</a>constructor accepts null</span><script data-source="
+try {
+  new WeakMap(null); return true;
+} catch (ex) {
+  return false;
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\ntry {\n  new WeakMap(null); return true;\n} catch (ex) {\n  return false;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="WeakMap" id="WeakMap_constructor_invokes_set"><td><span><a class="anchor" href="#WeakMap_constructor_invokes_set">&#xA7;</a>constructor invokes set</span><script data-source="
+var passed = false;
+var _set = WeakMap.prototype.set;
+
+WeakMap.prototype.set = function(k, v) {
+  passed = true;
+};
+
+new WeakMap([ [{ }, 42] ]);
+WeakMap.prototype.set = _set;
+
+return passed;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");return Function("asyncTestPassed","\nvar passed = false;\nvar _set = WeakMap.prototype.set;\n\nWeakMap.prototype.set = function(k, v) {\n  passed = true;\n};\n\nnew WeakMap([ [{ }, 42] ]);\nWeakMap.prototype.set = _set;\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="subtest" data-parent="WeakMap" id="WeakMap_frozen_objects_as_keys"><td><span><a class="anchor" href="#WeakMap_frozen_objects_as_keys">&#xA7;</a>frozen objects as keys</span><script data-source="
 var f = Object.freeze({});
 var m = new WeakMap;
 m.set(f, 42);
 return m.get(f) === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");return Function("asyncTestPassed","\nvar f = Object.freeze({});\nvar m = new WeakMap;\nm.set(f, 42);\nreturn m.get(f) === 42;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nvar f = Object.freeze({});\nvar m = new WeakMap;\nm.set(f, 42);\nreturn m.get(f) === 42;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19440,7 +19896,7 @@ try {
   new WeakMap(iter);
 } catch(e){}
 return closed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new WeakMap(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new WeakMap(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19511,7 +19967,7 @@ return closed;
 var weakmap = new WeakMap();
 var key = {};
 return weakmap.set(key, 0) === weakmap;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");return Function("asyncTestPassed","\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar weakmap = new WeakMap();\nvar key = {};\nreturn weakmap.set(key, 0) === weakmap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19580,7 +20036,7 @@ return weakmap.set(key, 0) === weakmap;
 </tr>
 <tr class="subtest" data-parent="WeakMap" id="WeakMap_WeakMap.prototype.delete"><td><span><a class="anchor" href="#WeakMap_WeakMap.prototype.delete">&#xA7;</a>WeakMap.prototype.delete</span><script data-source="
 return typeof WeakMap.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");return Function("asyncTestPassed","\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nreturn typeof WeakMap.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19647,13 +20103,12 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="subtest" data-parent="WeakMap" id="WeakMap_WeakMap[Symbol.species]"><td><span><a class="anchor" href="#WeakMap_WeakMap[Symbol.species]">&#xA7;</a>WeakMap[Symbol.species]</span><script data-source="
-var prop = Object.getOwnPropertyDescriptor(WeakMap, Symbol.species);
-return &apos;get&apos; in prop &amp;&amp; WeakMap[Symbol.species] === WeakMap;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(WeakMap, Symbol.species);\nreturn 'get' in prop && WeakMap[Symbol.species] === WeakMap;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+<tr class="subtest" data-parent="WeakMap" id="WeakMap_WeakMap.prototype.clear_is_missing"><td><span><a class="anchor" href="#WeakMap_WeakMap.prototype.clear_is_missing">&#xA7;</a>WeakMap.prototype.clear is missing</span><script data-source="
+return !(&quot;clear&quot; in WeakMap.prototype);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nreturn !(\"clear\" in WeakMap.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -19699,89 +20154,158 @@ return &apos;get&apos; in prop &amp;&amp; WeakMap[Symbol.species] === WeakMap;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="chrome42">No</td>
-<td class="no" data-browser="chrome43">No</td>
-<td class="no unstable" data-browser="chrome44">No</td>
-<td class="no unstable" data-browser="chrome45">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="WeakMap" id="WeakMap_WeakMap[Symbol.species]_is_missing"><td><span><a class="anchor" href="#WeakMap_WeakMap[Symbol.species]_is_missing">&#xA7;</a>WeakMap[Symbol.species] is missing</span><script data-source="
+return !(Symbol.species in WeakMap);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nreturn !(Symbol.species in WeakMap);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="firefox37">No</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-weakset-objects">WeakSet</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0">0/6</td>
-<td data-browser="babel" class="tally" data-tally="1">6/6</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="closure" class="tally" data-tally="0">0/6</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/6</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/6</td>
-<td data-browser="es6shim" class="tally" data-tally="0">0/6</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/6</td>
-<td data-browser="ie11" class="tally" data-tally="0">0/6</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox31" class="tally" data-tally="0">0/6</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox38" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome43" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/6</td>
-<td data-browser="safari71_8" class="tally" data-tally="0">0/6</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/6</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/6</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/6</td>
-<td data-browser="node" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="iojs" class="tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/6</td>
-<td data-browser="ios8" class="tally" data-tally="0">0/6</td>
+<td data-browser="tr" class="tally" data-tally="0">0/9</td>
+<td data-browser="babel" class="tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="closure" class="tally" data-tally="0">0/9</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/9</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/9</td>
+<td data-browser="es6shim" class="tally" data-tally="0">0/9</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/9</td>
+<td data-browser="ie11" class="tally" data-tally="0">0/9</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox31" class="tally" data-tally="0">0/9</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">6/9</td>
+<td data-browser="firefox38" class="tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0" data-flagged-tally="0.2222222222222222">0/9</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0" data-flagged-tally="0.2222222222222222">0/9</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0" data-flagged-tally="0.2222222222222222">0/9</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0" data-flagged-tally="0.2222222222222222">0/9</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0" data-flagged-tally="0.2222222222222222">0/9</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome43" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/9</td>
+<td data-browser="safari71_8" class="tally" data-tally="0">0/9</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">9/9</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/9</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/9</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/9</td>
+<td data-browser="node" class="tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="iojs" class="tally" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/9</td>
+<td data-browser="ios8" class="tally" data-tally="0">0/9</td>
 </tr>
 <tr class="subtest" data-parent="WeakSet" id="WeakSet_basic_functionality"><td><span><a class="anchor" href="#WeakSet_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var obj1 = {};
@@ -19791,7 +20315,7 @@ weakset.add(obj1);
 weakset.add(obj1);
 
 return weakset.has(obj1);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");return Function("asyncTestPassed","\nvar obj1 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nvar obj1 = {};\nvar weakset = new WeakSet();\n\nweakset.add(obj1);\nweakset.add(obj1);\n\nreturn weakset.has(obj1);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19863,7 +20387,7 @@ var obj1 = {}, obj2 = {};
 var weakset = new WeakSet([obj1, obj2]);
 
 return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nvar obj1 = {}, obj2 = {};\nvar weakset = new WeakSet([obj1, obj2]);\n\nreturn weakset.has(obj1) && weakset.has(obj2);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -19930,6 +20454,158 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="WeakSet" id="WeakSet_constructor_accepts_null"><td><span><a class="anchor" href="#WeakSet_constructor_accepts_null">&#xA7;</a>constructor accepts null</span><script data-source="
+try {
+  new WeakSet(null); return true;
+} catch (ex) {
+  return false;
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\ntry {\n  new WeakSet(null); return true;\n} catch (ex) {\n  return false;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="WeakSet" id="WeakSet_constructor_invokes_add"><td><span><a class="anchor" href="#WeakSet_constructor_invokes_add">&#xA7;</a>constructor invokes add</span><script data-source="
+var passed = false;
+var _add = WeakSet.prototype.add;
+
+WeakSet.prototype.add = function(v) {
+  passed = true;
+};
+
+new WeakSet([ { } ]);
+WeakSet.prototype.add = _add;
+
+return passed;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nvar passed = false;\nvar _add = WeakSet.prototype.add;\n\nWeakSet.prototype.add = function(v) {\n  passed = true;\n};\n\nnew WeakSet([ { } ]);\nWeakSet.prototype.add = _add;\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="subtest" data-parent="WeakSet" id="WeakSet_iterator_closing"><td><span><a class="anchor" href="#WeakSet_iterator_closing">&#xA7;</a>iterator closing</span><script data-source="
 var closed = false;
 var iter = global.__createIterableObject([1, 2, 3], {
@@ -19939,7 +20615,7 @@ try {
   new WeakSet(iter);
 } catch(e){}
 return closed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new WeakSet(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  new WeakSet(iter);\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -20010,7 +20686,7 @@ return closed;
 var weakset = new WeakSet();
 var obj = {};
 return weakset.add(obj) === weakset;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nvar weakset = new WeakSet();\nvar obj = {};\nreturn weakset.add(obj) === weakset;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -20079,7 +20755,7 @@ return weakset.add(obj) === weakset;
 </tr>
 <tr class="subtest" data-parent="WeakSet" id="WeakSet_WeakSet.prototype.delete"><td><span><a class="anchor" href="#WeakSet_WeakSet.prototype.delete">&#xA7;</a>WeakSet.prototype.delete</span><script data-source="
 return typeof WeakSet.prototype.delete === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nreturn typeof WeakSet.prototype.delete === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -20146,13 +20822,12 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="subtest" data-parent="WeakSet" id="WeakSet_WeakSet[Symbol.species]"><td><span><a class="anchor" href="#WeakSet_WeakSet[Symbol.species]">&#xA7;</a>WeakSet[Symbol.species]</span><script data-source="
-var prop = Object.getOwnPropertyDescriptor(WeakSet, Symbol.species);
-return &apos;get&apos; in prop &amp;&amp; WeakSet[Symbol.species] === WeakSet;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(WeakSet, Symbol.species);\nreturn 'get' in prop && WeakSet[Symbol.species] === WeakSet;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+<tr class="subtest" data-parent="WeakSet" id="WeakSet_WeakSet.prototype.clear_is_missing"><td><span><a class="anchor" href="#WeakSet_WeakSet.prototype.clear_is_missing">&#xA7;</a>WeakSet.prototype.clear is missing</span><script data-source="
+return !(&quot;clear&quot; in WeakSet.prototype);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nreturn !(\"clear\" in WeakSet.prototype);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
-<td class="yes" data-browser="babel">Yes</td>
+<td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
 <td class="no" data-browser="jsx">No</td>
@@ -20198,20 +20873,89 @@ return &apos;get&apos; in prop &amp;&amp; WeakSet[Symbol.species] === WeakSet;
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>
 <td class="no obsolete" data-browser="chrome42">No</td>
-<td class="no" data-browser="chrome43">No</td>
-<td class="no unstable" data-browser="chrome44">No</td>
-<td class="no unstable" data-browser="chrome45">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
 <td class="no" data-browser="phantom">No</td>
 <td class="no" data-browser="node">No</td>
-<td class="no" data-browser="iojs">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
+<tr class="subtest" data-parent="WeakSet" id="WeakSet_WeakSet[Symbol.species]_is_missing"><td><span><a class="anchor" href="#WeakSet_WeakSet[Symbol.species]_is_missing">&#xA7;</a>WeakSet[Symbol.species] is missing</span><script data-source="
+return !(Symbol.species in WeakSet);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nreturn !(Symbol.species in WeakSet);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="firefox37">No</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
@@ -20290,7 +21034,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("286");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n});\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20365,7 +21109,7 @@ var proxy = Object.create(new Proxy(proxied, {
   }
 }));
 return proxy.foo === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nvar proxied = { };\nvar proxy = Object.create(new Proxy(proxied, {\n  get: function (t, k, r) {\n    return t === proxied && k === \"foo\" && r === proxy && 5;\n  }\n}));\nreturn proxy.foo === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20442,7 +21186,7 @@ var proxy = new Proxy(proxied, {
 });
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n});\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20519,7 +21263,7 @@ var proxy = Object.create(new Proxy(proxied, {
 }));
 proxy.foo = &quot;bar&quot;;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nvar proxied = { };\nvar passed = false;\nvar proxy = Object.create(new Proxy(proxied, {\n  set: function (t, k, v, r) {\n    passed = t === proxied && k + v === \"foobar\" && r === proxy;\n  }\n}));\nproxy.foo = \"bar\";\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20595,7 +21339,7 @@ var passed = false;
   }
 });
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n});\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20671,7 +21415,7 @@ var passed = false;
   }
 }));
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\n\"foo\" in Object.create(new Proxy(proxied, {\n  has: function (t, k) {\n    passed = t === proxied && k === \"foo\";\n  }\n}));\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20747,7 +21491,7 @@ var proxied = {};
     }
   }).foo;
   return passed;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("292");return Function("asyncTestPassed","\nvar proxied = {};\n  var passed = false;\n  delete new Proxy(proxied, {\n    deleteProperty: function (t, k) {\n      passed = t === proxied && k === \"foo\";\n    }\n  }).foo;\n  return passed;\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20829,7 +21573,7 @@ return (returnedDesc.value     === fakeDesc.value
   &amp;&amp; returnedDesc.configurable === fakeDesc.configurable
   &amp;&amp; returnedDesc.writable     === false
   &amp;&amp; returnedDesc.enumerable   === false);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("293");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeDesc = { value: \"foo\", configurable: true };\nvar returnedDesc = Object.getOwnPropertyDescriptor(\n  new Proxy(proxied, {\n    getOwnPropertyDescriptor: function (t, k) {\n      return t === proxied && k === \"foo\" && fakeDesc;\n    }\n  }),\n  \"foo\"\n);\nreturn (returnedDesc.value     === fakeDesc.value\n  && returnedDesc.configurable === fakeDesc.configurable\n  && returnedDesc.writable     === false\n  && returnedDesc.enumerable   === false);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20910,7 +21654,7 @@ Object.defineProperty(
   { value: 5, configurable: true }
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("284");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.defineProperty(\n  new Proxy(proxied, {\n    defineProperty: function (t, k, d) {\n      passed = t === proxied && k === \"foo\" && d.value === 5;\n      return true;\n    }\n  }),\n  \"foo\",\n  { value: 5, configurable: true }\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -20986,7 +21730,7 @@ var proxy = new Proxy(proxied, {
   }
 });
 return Object.getPrototypeOf(proxy) === fakeProto;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("285");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nvar proxied = {};\nvar fakeProto = {};\nvar proxy = new Proxy(proxied, {\n  getPrototypeOf: function (t) {\n    return t === proxied && fakeProto;\n  }\n});\nreturn Object.getPrototypeOf(proxy) === fakeProto;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21067,7 +21811,7 @@ Object.setPrototypeOf(
   newProto
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("286");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("296");return Function("asyncTestPassed","\nvar proxied = {};\nvar newProto = {};\nvar passed = false;\nObject.setPrototypeOf(\n  new Proxy(proxied, {\n    setPrototypeOf: function (t, p) {\n      passed = t === proxied && p === newProto;\n      return true;\n    }\n  }),\n  newProto\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21145,7 +21889,7 @@ Object.isExtensible(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.isExtensible(\n  new Proxy(proxied, {\n    isExtensible: function (t) {\n      passed = t === proxied; return true;\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21224,7 +21968,7 @@ Object.preventExtensions(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("288");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.preventExtensions(\n  new Proxy(proxied, {\n    preventExtensions: function (t) {\n      passed = t === proxied;\n      return Object.preventExtensions(proxied);\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21305,7 +22049,7 @@ for (var i in
   })
 ) { }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("289");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("299");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nfor (var i in\n  new Proxy(proxied, {\n    enumerate: function (t) {\n      passed = t === proxied;\n      return {\n        next: function(){ return { done: true, value: null };}\n      };\n    }\n  })\n) { }\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21383,7 +22127,7 @@ Object.keys(
   })
 );
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("290");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nvar proxied = {};\nvar passed = false;\nObject.keys(\n  new Proxy(proxied, {\n    ownKeys: function (t) {\n      passed = t === proxied; return [];\n    }\n  })\n);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21462,7 +22206,7 @@ var host = {
 };
 host.method(&quot;foo&quot;, &quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("291");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nvar host = {\n  method: new Proxy(proxied, {\n    apply: function (t, thisArg, args) {\n      passed = t === proxied && thisArg === host && args + \"\" === \"foo,bar\";\n    }\n  })\n};\nhost.method(\"foo\", \"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21539,7 +22283,7 @@ new new Proxy(proxied, {
   }
 })(&quot;foo&quot;,&quot;bar&quot;);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("292");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nvar proxied = function(){};\nvar passed = false;\nnew new Proxy(proxied, {\n  construct: function (t, args) {\n    passed = t === proxied && args + \"\" === \"foo,bar\";\n    return {};\n  }\n})(\"foo\",\"bar\");\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21616,7 +22360,7 @@ try {
   passed &amp;= e instanceof TypeError;
 }
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("293");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nvar obj = Proxy.revocable({}, { get: function() { return 5; } });\nvar passed = (obj.proxy.foo === 5);\nobj.revoke();\ntry {\n  obj.proxy.foo;\n} catch(e) {\n  passed &= e instanceof TypeError;\n}\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21685,7 +22429,7 @@ return passed;
 </tr>
 <tr class="subtest" data-parent="Proxy" id="Proxy_Array.isArray_support"><td><span><a class="anchor" href="#Proxy_Array.isArray_support">&#xA7;</a>Array.isArray support</span><script data-source="
 return Array.isArray(new Proxy([], {}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("294");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nreturn Array.isArray(new Proxy([], {}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21754,7 +22498,7 @@ return Array.isArray(new Proxy([], {}));
 </tr>
 <tr class="subtest" data-parent="Proxy" id="Proxy_JSON.stringify_support"><td><span><a class="anchor" href="#Proxy_JSON.stringify_support">&#xA7;</a>JSON.stringify support</span><script data-source="
 return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quot;]&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("295");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nreturn JSON.stringify(new Proxy(['foo'], {})) === '[\"foo\"]';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -21889,7 +22633,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 </tr>
 <tr class="subtest" data-parent="Reflect" id="Reflect_Reflect.get"><td><span><a class="anchor" href="#Reflect_Reflect.get">&#xA7;</a>Reflect.get</span><script data-source="
 return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("297");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nreturn Reflect.get({ qux: 987 }, \"qux\") === 987;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -21960,7 +22704,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 var obj = {};
 Reflect.set(obj, &quot;quux&quot;, 654);
 return obj.quux === 654;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("298");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nvar obj = {};\nReflect.set(obj, \"quux\", 654);\nreturn obj.quux === 654;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22029,7 +22773,7 @@ return obj.quux === 654;
 </tr>
 <tr class="subtest" data-parent="Reflect" id="Reflect_Reflect.has"><td><span><a class="anchor" href="#Reflect_Reflect.has">&#xA7;</a>Reflect.has</span><script data-source="
 return Reflect.has({ qux: 987 }, &quot;qux&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("299");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("309");return Function("asyncTestPassed","\nreturn Reflect.has({ qux: 987 }, \"qux\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22100,7 +22844,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 var obj = { bar: 456 };
 Reflect.deleteProperty(obj, &quot;bar&quot;);
 return !(&quot;bar&quot; in obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("300");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nvar obj = { bar: 456 };\nReflect.deleteProperty(obj, \"bar\");\nreturn !(\"bar\" in obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22172,7 +22916,7 @@ var obj = { baz: 789 };
 var desc = Reflect.getOwnPropertyDescriptor(obj, &quot;baz&quot;);
 return desc.value === 789 &amp;&amp;
   desc.configurable &amp;&amp; desc.writable &amp;&amp; desc.enumerable;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("301");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nvar obj = { baz: 789 };\nvar desc = Reflect.getOwnPropertyDescriptor(obj, \"baz\");\nreturn desc.value === 789 &&\n  desc.configurable && desc.writable && desc.enumerable;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22243,7 +22987,7 @@ return desc.value === 789 &amp;&amp;
 var obj = {};
 Reflect.defineProperty(obj, &quot;foo&quot;, { value: 123 });
 return obj.foo === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("302");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nvar obj = {};\nReflect.defineProperty(obj, \"foo\", { value: 123 });\nreturn obj.foo === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22312,7 +23056,7 @@ return obj.foo === 123;
 </tr>
 <tr class="subtest" data-parent="Reflect" id="Reflect_Reflect.getPrototypeOf"><td><span><a class="anchor" href="#Reflect_Reflect.getPrototypeOf">&#xA7;</a>Reflect.getPrototypeOf</span><script data-source="
 return Reflect.getPrototypeOf([]) === Array.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("303");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("313");return Function("asyncTestPassed","\nreturn Reflect.getPrototypeOf([]) === Array.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22383,7 +23127,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 var obj = {};
 Reflect.setPrototypeOf(obj, Array.prototype);
 return obj instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("304");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nvar obj = {};\nReflect.setPrototypeOf(obj, Array.prototype);\nreturn obj instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -22453,7 +23197,7 @@ return obj instanceof Array;
 <tr class="subtest" data-parent="Reflect" id="Reflect_Reflect.isExtensible"><td><span><a class="anchor" href="#Reflect_Reflect.isExtensible">&#xA7;</a>Reflect.isExtensible</span><script data-source="
 return Reflect.isExtensible({}) &amp;&amp;
   !Reflect.isExtensible(Object.preventExtensions({}));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("305");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nreturn Reflect.isExtensible({}) &&\n  !Reflect.isExtensible(Object.preventExtensions({}));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22524,7 +23268,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 var obj = {};
 Reflect.preventExtensions(obj);
 return !Object.isExtensible(obj);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("306");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nvar obj = {};\nReflect.preventExtensions(obj);\nreturn !Object.isExtensible(obj);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22605,7 +23349,7 @@ passed &amp;= item.value === &quot;bar&quot; &amp;&amp; item.done === false;
 item = iterator.next();
 passed &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("307");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1;\nif (typeof Symbol === 'function' && 'iterator' in Symbol) {\n  passed &= Symbol.iterator in iterator;\n}\nvar item = iterator.next();\npassed &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === undefined && item.done === true;\nreturn passed === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nvar obj = { foo: 1, bar: 2 };\nvar iterator = Reflect.enumerate(obj);\nvar passed = 1;\nif (typeof Symbol === 'function' && 'iterator' in Symbol) {\n  passed &= Symbol.iterator in iterator;\n}\nvar item = iterator.next();\npassed &= item.value === \"foo\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === \"bar\" && item.done === false;\nitem = iterator.next();\npassed &= item.value === undefined && item.done === true;\nreturn passed === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22691,7 +23435,7 @@ delete obj[2];
 obj[2] = true;
 
 return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("308");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Reflect.ownKeys(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("318");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Reflect.ownKeys(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#forin-order-note"><sup>[22]</sup></a></td>
@@ -22775,7 +23519,7 @@ Object.defineProperty(obj, &apos;D&apos;, { value: true, enumerable: true });
 var result = Reflect.ownKeys(obj);
 var l = result.length;
 return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-1] === sym3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("309");return Function("asyncTestPassed","\nvar sym1 = Symbol(), sym2 = Symbol(), sym3 = Symbol();\nvar obj = {\n  1:    true,\n  A:    true,\n};\nobj.B = true;\nobj[sym1] = true;\nobj[2] = true;\nobj[sym2] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, sym3,{ value: true, enumerable: true });\nObject.defineProperty(obj, 'D', { value: true, enumerable: true });\n\nvar result = Reflect.ownKeys(obj);\nvar l = result.length;\nreturn result[l-3] === sym1 && result[l-2] === sym2 && result[l-1] === sym3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nvar sym1 = Symbol(), sym2 = Symbol(), sym3 = Symbol();\nvar obj = {\n  1:    true,\n  A:    true,\n};\nobj.B = true;\nobj[sym1] = true;\nobj[2] = true;\nobj[sym2] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, sym3,{ value: true, enumerable: true });\nObject.defineProperty(obj, 'D', { value: true, enumerable: true });\n\nvar result = Reflect.ownKeys(obj);\nvar l = result.length;\nreturn result[l-3] === sym1 && result[l-2] === sym2 && result[l-1] === sym3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22844,7 +23588,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 </tr>
 <tr class="subtest" data-parent="Reflect" id="Reflect_Reflect.apply"><td><span><a class="anchor" href="#Reflect_Reflect.apply">&#xA7;</a>Reflect.apply</span><script data-source="
 return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("310");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22915,7 +23659,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 return Reflect.construct(function(a, b, c) {
   this.qux = a + b + c;
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;]).qux === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("311");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  this.qux = a + b + c;\n}, [\"foo\", \"bar\", \"baz\"]).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -22988,7 +23732,7 @@ return Reflect.construct(function(a, b, c) {
     this.qux = a + b + c;
   }
 }, [&quot;foo&quot;, &quot;bar&quot;, &quot;baz&quot;], Object).qux === &quot;foobarbaz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("312");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  if (new.target === Object) {\n    this.qux = a + b + c;\n  }\n}, [\"foo\", \"bar\", \"baz\"], Object).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nreturn Reflect.construct(function(a, b, c) {\n  if (new.target === Object) {\n    this.qux = a + b + c;\n  }\n}, [\"foo\", \"bar\", \"baz\"], Object).qux === \"foobarbaz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -23056,70 +23800,70 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="babel" class="tally" data-tally="1">4/4</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="closure" class="tally" data-tally="0">0/4</td>
-<td data-browser="jsx" class="tally" data-tally="0">0/4</td>
-<td data-browser="typescript" class="tally" data-tally="0">0/4</td>
-<td data-browser="es6shim" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="ie10" class="tally" data-tally="0">0/4</td>
-<td data-browser="ie11" class="tally" data-tally="0">0/4</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox31" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox38" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome43" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="safari7" class="tally" data-tally="0">0/4</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="konq49" class="tally" data-tally="0">0/4</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
-<td data-browser="phantom" class="tally" data-tally="0">0/4</td>
-<td data-browser="node" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="iojs" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td data-browser="ios7" class="tally" data-tally="0">0/4</td>
-<td data-browser="ios8" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="babel" class="tally" data-tally="1">6/6</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="closure" class="tally" data-tally="0">0/6</td>
+<td data-browser="jsx" class="tally" data-tally="0">0/6</td>
+<td data-browser="typescript" class="tally" data-tally="0">0/6</td>
+<td data-browser="es6shim" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="ie10" class="tally" data-tally="0">0/6</td>
+<td data-browser="ie11" class="tally" data-tally="0">0/6</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox31" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="firefox38" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="chrome43" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="safari7" class="tally" data-tally="0">0/6</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="konq49" class="tally" data-tally="0">0/6</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0">0/6</td>
+<td data-browser="phantom" class="tally" data-tally="0">0/6</td>
+<td data-browser="node" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="iojs" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
+<td data-browser="ios7" class="tally" data-tally="0">0/6</td>
+<td data-browser="ios8" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
 </tr>
 <tr class="subtest" data-parent="Promise" id="Promise_basic_functionality"><td><span><a class="anchor" href="#Promise_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var p1 = new Promise(function(resolve, reject) { resolve(&quot;foo&quot;); });
@@ -23144,7 +23888,7 @@ p1.then(function() {
 function check() {
   if (score === 4) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("314");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nvar p1 = new Promise(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new Promise(function(resolve, reject) { reject(\"quux\"); });\nvar score = 0;\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // Promise.prototype.then() should return a new Promise\n  score += p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23227,7 +23971,7 @@ rejects.catch(function(result) { score += (result === &quot;qux&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("315");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nvar fulfills = Promise.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = Promise.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23293,6 +24037,89 @@ function check() {
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
+</tr>
+<tr class="subtest" data-parent="Promise" id="Promise_Promise.all_supports_iterables"><td><span><a class="anchor" href="#Promise_Promise.all_supports_iterables">&#xA7;</a>Promise.all supports iterables</span><script data-source="
+var fulfills = Promise.all(new Set([
+  new Promise(function(resolve)   { setTimeout(resolve,200,&quot;foo&quot;); }),
+  new Promise(function(resolve)   { setTimeout(resolve,100,&quot;bar&quot;); }),
+]));
+var rejects = Promise.all(new Set([
+  new Promise(function(_, reject) { setTimeout(reject, 200,&quot;baz&quot;); }),
+  new Promise(function(_, reject) { setTimeout(reject, 100,&quot;qux&quot;); }),
+]));
+var score = 0;
+fulfills.then(function(result) { score += (result + &quot;&quot; === &quot;foo,bar&quot;); check(); });
+rejects.catch(function(result) { score += (result === &quot;qux&quot;); check(); });
+
+function check() {
+  if (score === 2) asyncTestPassed();
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nvar fulfills = Promise.all(new Set([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]));\nvar rejects = Promise.all(new Set([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]));\nvar score = 0;\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="firefox37">No</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="no" data-browser="iojs">No</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="subtest" data-parent="Promise" id="Promise_Promise.race"><td><span><a class="anchor" href="#Promise_Promise.race">&#xA7;</a>Promise.race</span><script data-source="
 var fulfills = Promise.race([
@@ -23310,7 +24137,7 @@ rejects.catch(function(result) { score += (result === &quot;baz&quot;); check();
 function check() {
   if (score === 2) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("316");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nvar fulfills = Promise.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = Promise.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23377,10 +24204,93 @@ function check() {
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
+<tr class="subtest" data-parent="Promise" id="Promise_Promise.race_supports_iterables"><td><span><a class="anchor" href="#Promise_Promise.race_supports_iterables">&#xA7;</a>Promise.race supports iterables</span><script data-source="
+var fulfills = Promise.race(new Set([
+  new Promise(function(resolve)   { setTimeout(resolve,200,&quot;foo&quot;); }),
+  new Promise(function(_, reject) { setTimeout(reject, 300,&quot;bar&quot;); }),
+]));
+var rejects = Promise.race(new Set([
+  new Promise(function(_, reject) { setTimeout(reject, 200,&quot;baz&quot;); }),
+  new Promise(function(resolve)   { setTimeout(resolve,300,&quot;qux&quot;); }),
+]));
+var score = 0;
+fulfills.then(function(result) { score += (result === &quot;foo&quot;); check(); });
+rejects.catch(function(result) { score += (result === &quot;baz&quot;); check(); });
+
+function check() {
+  if (score === 2) asyncTestPassed();
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("328");return Function("asyncTestPassed","\nvar fulfills = Promise.race(new Set([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]));\nvar rejects = Promise.race(new Set([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]));\nvar score = 0;\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="yes" data-browser="babel">Yes</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="firefox37">No</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="no" data-browser="iojs">No</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="subtest" data-parent="Promise" id="Promise_Promise[Symbol.species]"><td><span><a class="anchor" href="#Promise_Promise[Symbol.species]">&#xA7;</a>Promise[Symbol.species]</span><script data-source="
 var prop = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
 return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("317");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Promise, Symbol.species);\nreturn 'get' in prop && Promise[Symbol.species] === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Promise, Symbol.species);\nreturn 'get' in prop && Promise[Symbol.species] === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23519,7 +24429,7 @@ var symbol = Symbol();
 var value = {};
 object[symbol] = value;
 return object[symbol] === value;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("319");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\nobject[symbol] = value;\nreturn object[symbol] === value;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23588,7 +24498,7 @@ return object[symbol] === value;
 </tr>
 <tr class="subtest" data-parent="Symbol" id="Symbol_typeof_support"><td><span><a class="anchor" href="#Symbol_typeof_support">&#xA7;</a>typeof support</span><script data-source="
 return typeof Symbol() === &quot;symbol&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("320");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn typeof Symbol() === \"symbol\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no flagged" data-browser="tr">Flag</td>
 <td class="no flagged" data-browser="babel">Flag</td>
@@ -23669,7 +24579,7 @@ if (Object.keys &amp;&amp; Object.getOwnPropertyNames) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("321");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = !x;\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nobject[symbol] = 1;\n\nfor (var x in object){}\nvar passed = !x;\n\nif (Object.keys && Object.getOwnPropertyNames) {\n  passed &= Object.keys(object).length === 0\n    && Object.getOwnPropertyNames(object).length === 0;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23747,7 +24657,7 @@ if (Object.defineProperty) {
 }
 
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("322");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nvar object = {};\nvar symbol = Symbol();\nvar value = {};\n\nif (Object.defineProperty) {\n  Object.defineProperty(object, symbol, { value: value });\n  return object[symbol] === value;\n}\n\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -23829,7 +24739,7 @@ try {
 } catch(e) {}
 
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("323");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\nvar symbol = Symbol();\n\ntry {\n  symbol + \"\";\n  return false;\n}\ncatch(e) {}\n\ntry {\n  symbol + 0;\n  return false;\n} catch(e) {}\n\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -23898,7 +24808,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Symbol" id="Symbol_can_convert_with_String()"><td><span><a class="anchor" href="#Symbol_can_convert_with_String()">&#xA7;</a>can convert with String()</span><script data-source="
 return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("324");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nreturn String(Symbol(\"foo\")) === \"Symbol(foo)\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -23972,7 +24882,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("325");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("337");return Function("asyncTestPassed","\nvar symbol = Symbol();\ntry {\n  new Symbol();\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -24047,7 +24957,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
   symbolObject == symbol &amp;&amp;
   symbolObject !== symbol &amp;&amp;
   symbolObject.valueOf() === symbol;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("326");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject !== symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("338");return Function("asyncTestPassed","\nvar symbol = Symbol();\nvar symbolObject = Object(symbol);\n\nreturn typeof symbolObject === \"object\" &&\n  symbolObject == symbol &&\n  symbolObject !== symbol &&\n  symbolObject.valueOf() === symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24118,7 +25028,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 var symbol = Symbol.for(&apos;foo&apos;);
 return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
    Symbol.keyFor(symbol) === &apos;foo&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("327");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nvar symbol = Symbol.for('foo');\nreturn Symbol.for('foo') === symbol &&\n   Symbol.keyFor(symbol) === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -24260,7 +25170,7 @@ Object.defineProperty(C, Symbol.hasInstance, {
 });
 obj instanceof C;
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("329");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { foo: true };\nvar C = function(){};\nObject.defineProperty(C, Symbol.hasInstance, {\n  value: function(inst) { passed = inst.foo; return false; }\n});\nobj instanceof C;\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24332,7 +25242,7 @@ var a = [], b = [];
 b[Symbol.isConcatSpreadable] = false;
 a = a.concat(b);
 return a[0] === b;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("330");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nvar a = [], b = [];\nb[Symbol.isConcatSpreadable] = false;\na = a.concat(b);\nreturn a[0] === b;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24401,7 +25311,7 @@ return a[0] === b;
 </tr>
 <tr class="subtest" data-parent="well-known_symbols" id="well-known_symbols_Symbol.iterator,_existence"><td><span><a class="anchor" href="#well-known_symbols_Symbol.iterator,_existence">&#xA7;</a>Symbol.iterator, existence</span><script data-source="
 return &quot;iterator&quot; in Symbol;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("331");return Function("asyncTestPassed","\nreturn \"iterator\" in Symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nreturn \"iterator\" in Symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -24473,7 +25383,7 @@ return (function() {
   return typeof arguments[Symbol.iterator] === &apos;function&apos;
     &amp;&amp; Object.hasOwnProperty.call(arguments, Symbol.iterator);
 }());
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("332");return Function("asyncTestPassed","\nreturn (function() {\n  return typeof arguments[Symbol.iterator] === 'function'\n    && Object.hasOwnProperty.call(arguments, Symbol.iterator);\n}());\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("344");return Function("asyncTestPassed","\nreturn (function() {\n  return typeof arguments[Symbol.iterator] === 'function'\n    && Object.hasOwnProperty.call(arguments, Symbol.iterator);\n}());\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24542,7 +25452,7 @@ return (function() {
 </tr>
 <tr class="subtest" data-parent="well-known_symbols" id="well-known_symbols_Symbol.species,_existence"><td><span><a class="anchor" href="#well-known_symbols_Symbol.species,_existence">&#xA7;</a>Symbol.species, existence</span><script data-source="
 return &quot;species&quot; in Symbol;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("333");return Function("asyncTestPassed","\nreturn \"species\" in Symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nreturn \"species\" in Symbol;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -24615,7 +25525,7 @@ obj[Symbol.species] = function() {
   return { foo: 1 };
 };
 return Array.prototype.concat.call(obj, []).foo === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("334");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.concat.call(obj, []).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.concat.call(obj, []).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24688,7 +25598,7 @@ obj[Symbol.species] = function() {
   return { foo: 1 };
 };
 return Array.prototype.filter.call(obj, Boolean).foo === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("335");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.filter.call(obj, Boolean).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.filter.call(obj, Boolean).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24761,7 +25671,7 @@ obj[Symbol.species] = function() {
   return { foo: 1 };
 };
 return Array.prototype.map.call(obj, Boolean).foo === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("336");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.map.call(obj, Boolean).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.map.call(obj, Boolean).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24834,7 +25744,7 @@ obj[Symbol.species] = function() {
   return { foo: 1 };
 };
 return Array.prototype.slice.call(obj, 0).foo === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("337");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.slice.call(obj, 0).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("349");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.slice.call(obj, 0).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24907,7 +25817,7 @@ obj[Symbol.species] = function() {
   return { foo: 1 };
 };
 return Array.prototype.splice.call(obj, 0).foo === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("338");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.splice.call(obj, 0).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\nvar obj = { constructor: false };\nobj[Symbol.species] = function() {\n  return { foo: 1 };\n};\nreturn Array.prototype.splice.call(obj, 0).foo === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -24984,7 +25894,7 @@ obj[Symbol.species] = function() {
 };
 &quot;&quot;.split(obj);
 return passed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("339");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { constructor: false };\nobj[Symbol.split] = RegExp.prototype[Symbol.split];\nobj[Symbol.species] = function() {\n  passed = true;\n  return /./;\n};\n\"\".split(obj);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("351");return Function("asyncTestPassed","\nvar passed = false;\nvar obj = { constructor: false };\nobj[Symbol.split] = RegExp.prototype[Symbol.split];\nobj[Symbol.species] = function() {\n  passed = true;\n  return /./;\n};\n\"\".split(obj);\nreturn passed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -25062,7 +25972,7 @@ a &gt;= 0;
 b in {};
 c == 0;
 return passed === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("340");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("352");return Function("asyncTestPassed","\nvar a = {}, b = {}, c = {};\nvar passed = 0;\na[Symbol.toPrimitive] = function(hint) { passed += hint === \"number\";  return 0; };\nb[Symbol.toPrimitive] = function(hint) { passed += hint === \"string\";  return 0; };\nc[Symbol.toPrimitive] = function(hint) { passed += hint === \"default\"; return 0; };\n\na >= 0;\nb in {};\nc == 0;\nreturn passed === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -25133,7 +26043,7 @@ return passed === 3;
 var a = {};
 a[Symbol.toStringTag] = &quot;foo&quot;;
 return (a + &quot;&quot;) === &quot;[object foo]&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("341");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\nvar a = {};\na[Symbol.toStringTag] = \"foo\";\nreturn (a + \"\") === \"[object foo]\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25204,7 +26114,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 var s = Symbol.toStringTag;
 return Math[s] === &quot;Math&quot;
   &amp;&amp; JSON[s] === &quot;JSON&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("342");return Function("asyncTestPassed","\nvar s = Symbol.toStringTag;\nreturn Math[s] === \"Math\"\n  && JSON[s] === \"JSON\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("354");return Function("asyncTestPassed","\nvar s = Symbol.toStringTag;\nreturn Math[s] === \"Math\"\n  && JSON[s] === \"JSON\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25277,7 +26187,7 @@ a[Symbol.unscopables] = { bar: true };
 with (a) {
   return foo === 1 &amp;&amp; typeof bar === &quot;undefined&quot;;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("343");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("355");return Function("asyncTestPassed","\nvar a = { foo: 1, bar: 2 };\na[Symbol.unscopables] = { bar: true };\nwith (a) {\n  return foo === 1 && typeof bar === \"undefined\";\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -25415,7 +26325,7 @@ with (a) {
 <tr class="subtest" data-parent="Object_static_methods" id="Object_static_methods_Object.assign"><td><span><a class="anchor" href="#Object_static_methods_Object.assign">&#xA7;</a>Object.assign</span><script data-source="
 var o = Object.assign({a:true}, {b:true}, {c:true});
 return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot; in o;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("345");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\nvar o = Object.assign({a:true}, {b:true}, {c:true});\nreturn \"a\" in o && \"b\" in o && \"c\" in o;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25486,7 +26396,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 return typeof Object.is === &apos;function&apos; &amp;&amp;
   Object.is(NaN, NaN) &amp;&amp;
  !Object.is(-0, 0);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("346");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\nreturn typeof Object.is === 'function' &&\n  Object.is(NaN, NaN) &&\n !Object.is(-0, 0);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25563,7 +26473,7 @@ var result = Object.getOwnPropertySymbols(o);
 return result[0] === sym
   &amp;&amp; result[1] === sym2
   &amp;&amp; result[2] === sym3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("347");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol(), sym2 = Symbol(), sym3 = Symbol();\no[sym]  = true;\no[sym2] = true;\no[sym3] = true;\nvar result = Object.getOwnPropertySymbols(o);\nreturn result[0] === sym\n  && result[1] === sym2\n  && result[2] === sym3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\nvar o = {};\nvar sym = Symbol(), sym2 = Symbol(), sym3 = Symbol();\no[sym]  = true;\no[sym2] = true;\no[sym3] = true;\nvar result = Object.getOwnPropertySymbols(o);\nreturn result[0] === sym\n  && result[1] === sym2\n  && result[2] === sym3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25632,7 +26542,7 @@ return result[0] === sym
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="Object_static_methods_Object.setPrototypeOf"><td><span><a class="anchor" href="#Object_static_methods_Object.setPrototypeOf">&#xA7;</a>Object.setPrototypeOf</span><script data-source="
 return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("348");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("360");return Function("asyncTestPassed","\nreturn Object.setPrototypeOf({}, Array.prototype) instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -25769,7 +26679,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 function foo(){};
 return foo.name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("350");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\nfunction foo(){};\nreturn foo.name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25839,7 +26749,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_function_expressions"><td><span><a class="anchor" href="#function_name_property_function_expressions">&#xA7;</a>function expressions</span><script data-source="
 return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
   (function(){}).name === &apos;&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("351");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\nreturn (function foo(){}).name === 'foo' &&\n  (function(){}).name === '';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -25908,7 +26818,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_new_Function"><td><span><a class="anchor" href="#function_name_property_new_Function">&#xA7;</a>new Function</span><script data-source="
 return (new Function).name === &quot;anonymous&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("352");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nreturn (new Function).name === \"anonymous\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -25979,7 +26889,7 @@ return (new Function).name === &quot;anonymous&quot;;
 function foo() {};
 return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
   (function(){}).bind({}).name === &quot;bound &quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("353");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nfunction foo() {};\nreturn foo.bind({}).name === \"bound foo\" &&\n  (function(){}).bind({}).name === \"bound \";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -26050,7 +26960,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 var foo = function() {};
 var bar = function baz() {};
 return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("354");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("366");return Function("asyncTestPassed","\nvar foo = function() {};\nvar bar = function baz() {};\nreturn foo.name === \"foo\" && bar.name === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26123,7 +27033,7 @@ o.qux = function(){};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("355");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("367");return Function("asyncTestPassed","\nvar o = { foo: function(){}, bar: function baz(){}};\no.qux = function(){};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26195,7 +27105,7 @@ var o = { get foo(){}, set foo(x){} };
 var descriptor = Object.getOwnPropertyDescriptor(o, &quot;foo&quot;);
 return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
        descriptor.set.name === &quot;set foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("356");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("368");return Function("asyncTestPassed","\nvar o = { get foo(){}, set foo(x){} };\nvar descriptor = Object.getOwnPropertyDescriptor(o, \"foo\");\nreturn descriptor.get.name === \"get foo\" &&\n       descriptor.set.name === \"set foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -26265,7 +27175,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_shorthand_methods"><td><span><a class="anchor" href="#function_name_property_shorthand_methods">&#xA7;</a>shorthand methods</span><script data-source="
 var o = { foo(){} };
 return o.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("357");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("369");return Function("asyncTestPassed","\nvar o = { foo(){} };\nreturn o.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26335,7 +27245,7 @@ return o.foo.name === &quot;foo&quot;;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_shorthand_methods_(no_lexical_binding)"><td><span><a class="anchor" href="#function_name_property_shorthand_methods_(no_lexical_binding)">&#xA7;</a>shorthand methods (no lexical binding)</span><script data-source="
 var f = &quot;foo&quot;;
 return ({f() { return f; }}).f() === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("358");return Function("asyncTestPassed","\nvar f = \"foo\";\nreturn ({f() { return f; }}).f() === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("370");return Function("asyncTestPassed","\nvar f = \"foo\";\nreturn ({f() { return f; }}).f() === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26412,7 +27322,7 @@ var o = {
 
 return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
        o[sym2].name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("359");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("371");return Function("asyncTestPassed","\nvar sym1 = Symbol(\"foo\");\nvar sym2 = Symbol();\nvar o = {\n  [sym1]: function(){},\n  [sym2]: function(){}\n};\n\nreturn o[sym1].name === \"[foo]\" &&\n       o[sym2].name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -26484,7 +27394,7 @@ class foo {};
 class bar { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
   typeof bar.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("360");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("372");return Function("asyncTestPassed","\nclass foo {};\nclass bar { static name() {} };\nreturn foo.name === \"foo\" &&\n  typeof bar.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[25]</sup></a></td>
@@ -26554,7 +27464,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_class_expressions"><td><span><a class="anchor" href="#function_name_property_class_expressions">&#xA7;</a>class expressions</span><script data-source="
 return class foo {}.name === &quot;foo&quot; &amp;&amp;
   typeof class bar { static name() {} }.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("361");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("373");return Function("asyncTestPassed","\nreturn class foo {}.name === \"foo\" &&\n  typeof class bar { static name() {} }.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[25]</sup></a></td>
@@ -26628,7 +27538,7 @@ var qux = class { static name() {} };
 return foo.name === &quot;foo&quot; &amp;&amp;
        bar.name === &quot;baz&quot; &amp;&amp;
        typeof qux.name === &quot;function&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("362");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("374");return Function("asyncTestPassed","\nvar foo = class {};\nvar bar = class baz {};\nvar qux = class { static name() {} };\nreturn foo.name === \"foo\" &&\n       bar.name === \"baz\" &&\n       typeof qux.name === \"function\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26701,7 +27611,7 @@ o.qux = class {};
 return o.foo.name === &quot;foo&quot; &amp;&amp;
        o.bar.name === &quot;baz&quot; &amp;&amp;
        o.qux.name === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("363");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("375");return Function("asyncTestPassed","\nvar o = { foo: class {}, bar: class baz {}};\no.qux = class {};\nreturn o.foo.name === \"foo\" &&\n       o.bar.name === \"baz\" &&\n       o.qux.name === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26771,7 +27681,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_class_prototype_methods"><td><span><a class="anchor" href="#function_name_property_class_prototype_methods">&#xA7;</a>class prototype methods</span><script data-source="
 class C { foo(){} };
 return (new C).foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("364");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("376");return Function("asyncTestPassed","\nclass C { foo(){} };\nreturn (new C).foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26841,7 +27751,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <tr class="subtest" data-parent="function_name_property" id="function_name_property_class_static_methods"><td><span><a class="anchor" href="#function_name_property_class_static_methods">&#xA7;</a>class static methods</span><script data-source="
 class C { static foo(){} };
 return C.foo.name === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("365");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("377");return Function("asyncTestPassed","\nclass C { static foo(){} };\nreturn C.foo.name === \"foo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -26913,7 +27823,7 @@ var descriptor = Object.getOwnPropertyDescriptor(function f(){},&quot;name&quot;
 return descriptor.enumerable   === false &amp;&amp;
        descriptor.writable     === false &amp;&amp;
        descriptor.configurable === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("366");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("378");return Function("asyncTestPassed","\nvar descriptor = Object.getOwnPropertyDescriptor(function f(){},\"name\");\nreturn descriptor.enumerable   === false &&\n       descriptor.writable     === false &&\n       descriptor.configurable === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -27048,7 +27958,7 @@ return descriptor.enumerable   === false &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="String_static_methods" id="String_static_methods_String.raw"><td><span><a class="anchor" href="#String_static_methods_String.raw">&#xA7;</a>String.raw</span><script data-source="
 return typeof String.raw === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("368");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("380");return Function("asyncTestPassed","\nreturn typeof String.raw === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27117,7 +28027,7 @@ return typeof String.raw === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String_static_methods" id="String_static_methods_String.fromCodePoint"><td><span><a class="anchor" href="#String_static_methods_String.fromCodePoint">&#xA7;</a>String.fromCodePoint</span><script data-source="
 return typeof String.fromCodePoint === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("369");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("381");return Function("asyncTestPassed","\nreturn typeof String.fromCodePoint === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27252,7 +28162,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype.codePointAt"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype.codePointAt">&#xA7;</a>String.prototype.codePointAt</span><script data-source="
 return typeof String.prototype.codePointAt === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("371");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("383");return Function("asyncTestPassed","\nreturn typeof String.prototype.codePointAt === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27323,7 +28233,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 return typeof String.prototype.normalize === &quot;function&quot;
   &amp;&amp; &quot;c\u0327\u0301&quot;.normalize(&quot;NFC&quot;) === &quot;\u1e09&quot;
   &amp;&amp; &quot;\u1e09&quot;.normalize(&quot;NFD&quot;) === &quot;c\u0327\u0301&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("372");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("384");return Function("asyncTestPassed","\nreturn typeof String.prototype.normalize === \"function\"\n  && \"c\\u0327\\u0301\".normalize(\"NFC\") === \"\\u1e09\"\n  && \"\\u1e09\".normalize(\"NFD\") === \"c\\u0327\\u0301\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -27393,7 +28303,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype.repeat"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype.repeat">&#xA7;</a>String.prototype.repeat</span><script data-source="
 return typeof String.prototype.repeat === &apos;function&apos;
   &amp;&amp; &quot;foo&quot;.repeat(3) === &quot;foofoofoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("373");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("385");return Function("asyncTestPassed","\nreturn typeof String.prototype.repeat === 'function'\n  && \"foo\".repeat(3) === \"foofoofoo\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27463,7 +28373,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype.startsWith"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype.startsWith">&#xA7;</a>String.prototype.startsWith</span><script data-source="
 return typeof String.prototype.startsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.startsWith(&quot;foo&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("374");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("386");return Function("asyncTestPassed","\nreturn typeof String.prototype.startsWith === 'function'\n  && \"foobar\".startsWith(\"foo\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27533,7 +28443,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype.endsWith"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype.endsWith">&#xA7;</a>String.prototype.endsWith</span><script data-source="
 return typeof String.prototype.endsWith === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.endsWith(&quot;bar&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("375");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("387");return Function("asyncTestPassed","\nreturn typeof String.prototype.endsWith === 'function'\n  && \"foobar\".endsWith(\"bar\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27603,7 +28513,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype.includes"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype.includes">&#xA7;</a>String.prototype.includes</span><script data-source="
 return typeof String.prototype.includes === &apos;function&apos;
   &amp;&amp; &quot;foobar&quot;.includes(&quot;oba&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("376");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("388");return Function("asyncTestPassed","\nreturn typeof String.prototype.includes === 'function'\n  && \"foobar\".includes(\"oba\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27672,7 +28582,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 </tr>
 <tr class="subtest" data-parent="String.prototype_methods" id="String.prototype_methods_String.prototype[Symbol.iterator]"><td><span><a class="anchor" href="#String.prototype_methods_String.prototype[Symbol.iterator]">&#xA7;</a>String.prototype[Symbol.iterator]</span><script data-source="
 return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("377");return Function("asyncTestPassed","\nreturn typeof String.prototype[Symbol.iterator] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("389");return Function("asyncTestPassed","\nreturn typeof String.prototype[Symbol.iterator] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27751,7 +28661,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
   !proto1    .hasOwnProperty(Symbol.iterator) &amp;&amp;
   !iterator  .hasOwnProperty(Symbol.iterator) &amp;&amp;
   iterator[Symbol.iterator]() === iterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("378");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = ''[Symbol.iterator]();\n// %StringIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("390");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = ''[Symbol.iterator]();\n// %StringIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27886,7 +28796,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp.prototype.flags"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp.prototype.flags">&#xA7;</a>RegExp.prototype.flags</span><script data-source="
 return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("380");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("392");return Function("asyncTestPassed","\nreturn /./igm.flags === \"gim\" && /./.flags === \"\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -27955,7 +28865,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp.prototype[Symbol.match]"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp.prototype[Symbol.match]">&#xA7;</a>RegExp.prototype[Symbol.match]</span><script data-source="
 return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("381");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("393");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.match] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -28024,7 +28934,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp.prototype[Symbol.replace]"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp.prototype[Symbol.replace]">&#xA7;</a>RegExp.prototype[Symbol.replace]</span><script data-source="
 return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("382");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("394");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.replace] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -28093,7 +29003,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp.prototype[Symbol.split]"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp.prototype[Symbol.split]">&#xA7;</a>RegExp.prototype[Symbol.split]</span><script data-source="
 return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("383");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("395");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.split] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -28162,7 +29072,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp.prototype[Symbol.search]"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp.prototype[Symbol.search]">&#xA7;</a>RegExp.prototype[Symbol.search]</span><script data-source="
 return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("384");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("396");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype[Symbol.search] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -28232,7 +29142,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <tr class="subtest" data-parent="RegExp.prototype_properties" id="RegExp.prototype_properties_RegExp[Symbol.species]"><td><span><a class="anchor" href="#RegExp.prototype_properties_RegExp[Symbol.species]">&#xA7;</a>RegExp[Symbol.species]</span><script data-source="
 var prop = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);
 return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("385");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);\nreturn 'get' in prop && RegExp[Symbol.species] === RegExp;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("397");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);\nreturn 'get' in prop && RegExp[Symbol.species] === RegExp;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28367,7 +29277,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 </tr>
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array.from,_array-like_objects"><td><span><a class="anchor" href="#Array_static_methods_Array.from,_array-like_objects">&#xA7;</a>Array.from, array-like objects</span><script data-source="
 return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos;&apos; === &quot;foo,bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("387");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("399");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }) + '' === \"foo,bar\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28437,7 +29347,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array.from,_generator_instances"><td><span><a class="anchor" href="#Array_static_methods_Array.from,_generator_instances">&#xA7;</a>Array.from, generator instances</span><script data-source="
 var iterable = (function*(){ yield 1; yield 2; yield 3; }());
 return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("388");return Function("asyncTestPassed","\nvar iterable = (function*(){ yield 1; yield 2; yield 3; }());\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("400");return Function("asyncTestPassed","\nvar iterable = (function*(){ yield 1; yield 2; yield 3; }());\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28507,7 +29417,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array.from,_generic_iterables"><td><span><a class="anchor" href="#Array_static_methods_Array.from,_generic_iterables">&#xA7;</a>Array.from, generic iterables</span><script data-source="
 var iterable = global.__createIterableObject([1, 2, 3]);
 return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("389");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("401");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Array.from(iterable) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28577,7 +29487,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array.from,_instances_of_generic_iterables"><td><span><a class="anchor" href="#Array_static_methods_Array.from,_instances_of_generic_iterables">&#xA7;</a>Array.from, instances of generic iterables</span><script data-source="
 var iterable = global.__createIterableObject([1, 2, 3]);
 return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("390");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("402");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([1, 2, 3]);\nreturn Array.from(Object.create(iterable)) + '' === \"1,2,3\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28648,7 +29558,7 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, function(e, i) {
   return e + this.baz + i;
 }, { baz: &quot;d&quot; }) + &apos;&apos; === &quot;food0,bard1&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("391");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("403");return Function("asyncTestPassed","\nreturn Array.from({ 0: \"foo\", 1: \"bar\", length: 2 }, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28720,7 +29630,7 @@ var iterable = (function*(){ yield &quot;foo&quot;; yield &quot;bar&quot;; yield
 return Array.from(iterable, function(e, i) {
   return e + this.baz + i;
 }, { baz: &quot;d&quot; }) + &apos;&apos; === &quot;food0,bard1,bald2&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("392");return Function("asyncTestPassed","\nvar iterable = (function*(){ yield \"foo\"; yield \"bar\"; yield \"bal\"; }());\nreturn Array.from(iterable, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("404");return Function("asyncTestPassed","\nvar iterable = (function*(){ yield \"foo\"; yield \"bar\"; yield \"bal\"; }());\nreturn Array.from(iterable, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28792,7 +29702,7 @@ var iterable = global.__createIterableObject([&quot;foo&quot;, &quot;bar&quot;, 
 return Array.from(iterable, function(e, i) {
   return e + this.baz + i;
 }, { baz: &quot;d&quot; }) + &apos;&apos; === &quot;food0,bard1,bald2&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("393");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"foo\", \"bar\", \"bal\"]);\nreturn Array.from(iterable, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("405");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"foo\", \"bar\", \"bal\"]);\nreturn Array.from(iterable, function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28864,7 +29774,7 @@ var iterable = global.__createIterableObject([&quot;foo&quot;, &quot;bar&quot;, 
 return Array.from(Object.create(iterable), function(e, i) {
   return e + this.baz + i;
 }, { baz: &quot;d&quot; }) + &apos;&apos; === &quot;food0,bard1,bald2&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("394");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"foo\", \"bar\", \"bal\"]);\nreturn Array.from(Object.create(iterable), function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("406");return Function("asyncTestPassed","\nvar iterable = global.__createIterableObject([\"foo\", \"bar\", \"bal\"]);\nreturn Array.from(Object.create(iterable), function(e, i) {\n  return e + this.baz + i;\n}, { baz: \"d\" }) + '' === \"food0,bard1,bald2\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -28940,7 +29850,7 @@ try {
   Array.from(iter, function() { throw 42 });
 } catch(e){}
 return closed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("395");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  Array.from(iter, function() { throw 42 });\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("407");return Function("asyncTestPassed","\nvar closed = false;\nvar iter = global.__createIterableObject([1, 2, 3], {\n  'return': function(){ closed = true; return {}; }\n});\ntry {\n  Array.from(iter, function() { throw 42 });\n} catch(e){}\nreturn closed;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29010,7 +29920,7 @@ return closed;
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array.of"><td><span><a class="anchor" href="#Array_static_methods_Array.of">&#xA7;</a>Array.of</span><script data-source="
 return typeof Array.of === &apos;function&apos; &amp;&amp;
   Array.of(2)[0] === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("396");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("408");return Function("asyncTestPassed","\nreturn typeof Array.of === 'function' &&\n  Array.of(2)[0] === 2;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29080,7 +29990,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <tr class="subtest" data-parent="Array_static_methods" id="Array_static_methods_Array[Symbol.species]"><td><span><a class="anchor" href="#Array_static_methods_Array[Symbol.species]">&#xA7;</a>Array[Symbol.species]</span><script data-source="
 var prop = Object.getOwnPropertyDescriptor(Array, Symbol.species);
 return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("397");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Array, Symbol.species);\nreturn 'get' in prop && Array[Symbol.species] === Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("409");return Function("asyncTestPassed","\nvar prop = Object.getOwnPropertyDescriptor(Array, Symbol.species);\nreturn 'get' in prop && Array[Symbol.species] === Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29215,7 +30125,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.copyWithin"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.copyWithin">&#xA7;</a>Array.prototype.copyWithin</span><script data-source="
 return typeof Array.prototype.copyWithin === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("399");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("411");return Function("asyncTestPassed","\nreturn typeof Array.prototype.copyWithin === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29284,7 +30194,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.find"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.find">&#xA7;</a>Array.prototype.find</span><script data-source="
 return typeof Array.prototype.find === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("400");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("412");return Function("asyncTestPassed","\nreturn typeof Array.prototype.find === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29353,7 +30263,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.findIndex"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.findIndex">&#xA7;</a>Array.prototype.findIndex</span><script data-source="
 return typeof Array.prototype.findIndex === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("401");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("413");return Function("asyncTestPassed","\nreturn typeof Array.prototype.findIndex === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29422,7 +30332,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.fill"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.fill">&#xA7;</a>Array.prototype.fill</span><script data-source="
 return typeof Array.prototype.fill === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("402");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("414");return Function("asyncTestPassed","\nreturn typeof Array.prototype.fill === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29491,7 +30401,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.keys"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.keys">&#xA7;</a>Array.prototype.keys</span><script data-source="
 return typeof Array.prototype.keys === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("403");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("415");return Function("asyncTestPassed","\nreturn typeof Array.prototype.keys === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29560,7 +30470,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.values"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.values">&#xA7;</a>Array.prototype.values</span><script data-source="
 return typeof Array.prototype.values === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("404");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("416");return Function("asyncTestPassed","\nreturn typeof Array.prototype.values === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29629,7 +30539,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype.entries"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype.entries">&#xA7;</a>Array.prototype.entries</span><script data-source="
 return typeof Array.prototype.entries === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("405");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("417");return Function("asyncTestPassed","\nreturn typeof Array.prototype.entries === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29698,7 +30608,7 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype_methods" id="Array.prototype_methods_Array.prototype[Symbol.iterator]"><td><span><a class="anchor" href="#Array.prototype_methods_Array.prototype[Symbol.iterator]">&#xA7;</a>Array.prototype[Symbol.iterator]</span><script data-source="
 return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("406");return Function("asyncTestPassed","\nreturn typeof Array.prototype[Symbol.iterator] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("418");return Function("asyncTestPassed","\nreturn typeof Array.prototype[Symbol.iterator] === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29777,7 +30687,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
   !proto1    .hasOwnProperty(Symbol.iterator) &amp;&amp;
   !iterator  .hasOwnProperty(Symbol.iterator) &amp;&amp;
   iterator[Symbol.iterator]() === iterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("407");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = [][Symbol.iterator]();\n// %ArrayIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("419");return Function("asyncTestPassed","\n// Iterator instance\nvar iterator = [][Symbol.iterator]();\n// %ArrayIteratorPrototype%\nvar proto1 = Object.getPrototypeOf(iterator);\n// %IteratorPrototype%\nvar proto2 = Object.getPrototypeOf(proto1);\n\nreturn proto2.hasOwnProperty(Symbol.iterator) &&\n  !proto1    .hasOwnProperty(Symbol.iterator) &&\n  !iterator  .hasOwnProperty(Symbol.iterator) &&\n  iterator[Symbol.iterator]() === iterator;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29854,7 +30764,7 @@ for (var i = 0; i &lt; ns.length; i++) {
   if (Array.prototype[ns[i]] &amp;&amp; !unscopables[ns[i]]) return false;
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("408");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("420");return Function("asyncTestPassed","\nvar unscopables = Array.prototype[Symbol.unscopables];\nif (!unscopables) {\n  return false;\n}\nvar ns = \"find,findIndex,fill,copyWithin,entries,keys,values\".split(\",\");\nfor (var i = 0; i < ns.length; i++) {\n  if (Array.prototype[ns[i]] && !unscopables[ns[i]]) return false;\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -29989,7 +30899,7 @@ return true;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.isFinite"><td><span><a class="anchor" href="#Number_properties_Number.isFinite">&#xA7;</a>Number.isFinite</span><script data-source="
 return typeof Number.isFinite === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("410");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("422");return Function("asyncTestPassed","\nreturn typeof Number.isFinite === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30058,7 +30968,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.isInteger"><td><span><a class="anchor" href="#Number_properties_Number.isInteger">&#xA7;</a>Number.isInteger</span><script data-source="
 return typeof Number.isInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("411");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("423");return Function("asyncTestPassed","\nreturn typeof Number.isInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30127,7 +31037,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.isSafeInteger"><td><span><a class="anchor" href="#Number_properties_Number.isSafeInteger">&#xA7;</a>Number.isSafeInteger</span><script data-source="
 return typeof Number.isSafeInteger === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("412");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("424");return Function("asyncTestPassed","\nreturn typeof Number.isSafeInteger === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30196,7 +31106,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.isNaN"><td><span><a class="anchor" href="#Number_properties_Number.isNaN">&#xA7;</a>Number.isNaN</span><script data-source="
 return typeof Number.isNaN === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("413");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("425");return Function("asyncTestPassed","\nreturn typeof Number.isNaN === 'function';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30265,7 +31175,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.EPSILON"><td><span><a class="anchor" href="#Number_properties_Number.EPSILON">&#xA7;</a>Number.EPSILON</span><script data-source="
 return typeof Number.EPSILON === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("414");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("426");return Function("asyncTestPassed","\nreturn typeof Number.EPSILON === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30334,7 +31244,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.MIN_SAFE_INTEGER"><td><span><a class="anchor" href="#Number_properties_Number.MIN_SAFE_INTEGER">&#xA7;</a>Number.MIN_SAFE_INTEGER</span><script data-source="
 return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("415");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("427");return Function("asyncTestPassed","\nreturn typeof Number.MIN_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30403,7 +31313,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Number_properties" id="Number_properties_Number.MAX_SAFE_INTEGER"><td><span><a class="anchor" href="#Number_properties_Number.MAX_SAFE_INTEGER">&#xA7;</a>Number.MAX_SAFE_INTEGER</span><script data-source="
 return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("416");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("428");return Function("asyncTestPassed","\nreturn typeof Number.MAX_SAFE_INTEGER === 'number';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30538,7 +31448,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.clz32"><td><span><a class="anchor" href="#Math_methods_Math.clz32">&#xA7;</a>Math.clz32</span><script data-source="
 return typeof Math.clz32 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("418");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("430");return Function("asyncTestPassed","\nreturn typeof Math.clz32 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30607,7 +31517,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.imul"><td><span><a class="anchor" href="#Math_methods_Math.imul">&#xA7;</a>Math.imul</span><script data-source="
 return typeof Math.imul === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("419");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("431");return Function("asyncTestPassed","\nreturn typeof Math.imul === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30676,7 +31586,7 @@ return typeof Math.imul === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.sign"><td><span><a class="anchor" href="#Math_methods_Math.sign">&#xA7;</a>Math.sign</span><script data-source="
 return typeof Math.sign === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("420");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("432");return Function("asyncTestPassed","\nreturn typeof Math.sign === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30745,7 +31655,7 @@ return typeof Math.sign === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.log10"><td><span><a class="anchor" href="#Math_methods_Math.log10">&#xA7;</a>Math.log10</span><script data-source="
 return typeof Math.log10 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("421");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("433");return Function("asyncTestPassed","\nreturn typeof Math.log10 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30814,7 +31724,7 @@ return typeof Math.log10 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.log2"><td><span><a class="anchor" href="#Math_methods_Math.log2">&#xA7;</a>Math.log2</span><script data-source="
 return typeof Math.log2 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("422");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("434");return Function("asyncTestPassed","\nreturn typeof Math.log2 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30883,7 +31793,7 @@ return typeof Math.log2 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.log1p"><td><span><a class="anchor" href="#Math_methods_Math.log1p">&#xA7;</a>Math.log1p</span><script data-source="
 return typeof Math.log1p === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("423");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("435");return Function("asyncTestPassed","\nreturn typeof Math.log1p === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -30952,7 +31862,7 @@ return typeof Math.log1p === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.expm1"><td><span><a class="anchor" href="#Math_methods_Math.expm1">&#xA7;</a>Math.expm1</span><script data-source="
 return typeof Math.expm1 === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("424");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("436");return Function("asyncTestPassed","\nreturn typeof Math.expm1 === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31021,7 +31931,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.cosh"><td><span><a class="anchor" href="#Math_methods_Math.cosh">&#xA7;</a>Math.cosh</span><script data-source="
 return typeof Math.cosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("425");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("437");return Function("asyncTestPassed","\nreturn typeof Math.cosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31090,7 +32000,7 @@ return typeof Math.cosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.sinh"><td><span><a class="anchor" href="#Math_methods_Math.sinh">&#xA7;</a>Math.sinh</span><script data-source="
 return typeof Math.sinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("426");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("438");return Function("asyncTestPassed","\nreturn typeof Math.sinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31159,7 +32069,7 @@ return typeof Math.sinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.tanh"><td><span><a class="anchor" href="#Math_methods_Math.tanh">&#xA7;</a>Math.tanh</span><script data-source="
 return typeof Math.tanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("427");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("439");return Function("asyncTestPassed","\nreturn typeof Math.tanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31228,7 +32138,7 @@ return typeof Math.tanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.acosh"><td><span><a class="anchor" href="#Math_methods_Math.acosh">&#xA7;</a>Math.acosh</span><script data-source="
 return typeof Math.acosh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("428");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("440");return Function("asyncTestPassed","\nreturn typeof Math.acosh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31297,7 +32207,7 @@ return typeof Math.acosh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.asinh"><td><span><a class="anchor" href="#Math_methods_Math.asinh">&#xA7;</a>Math.asinh</span><script data-source="
 return typeof Math.asinh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("429");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("441");return Function("asyncTestPassed","\nreturn typeof Math.asinh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31366,7 +32276,7 @@ return typeof Math.asinh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.atanh"><td><span><a class="anchor" href="#Math_methods_Math.atanh">&#xA7;</a>Math.atanh</span><script data-source="
 return typeof Math.atanh === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("430");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("442");return Function("asyncTestPassed","\nreturn typeof Math.atanh === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31435,7 +32345,7 @@ return typeof Math.atanh === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.trunc"><td><span><a class="anchor" href="#Math_methods_Math.trunc">&#xA7;</a>Math.trunc</span><script data-source="
 return typeof Math.trunc === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("431");return Function("asyncTestPassed","\nreturn typeof Math.trunc === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("443");return Function("asyncTestPassed","\nreturn typeof Math.trunc === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31504,7 +32414,7 @@ return typeof Math.trunc === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.fround"><td><span><a class="anchor" href="#Math_methods_Math.fround">&#xA7;</a>Math.fround</span><script data-source="
 return typeof Math.fround === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("432");return Function("asyncTestPassed","\nreturn typeof Math.fround === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("444");return Function("asyncTestPassed","\nreturn typeof Math.fround === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31573,7 +32483,7 @@ return typeof Math.fround === &quot;function&quot;;
 </tr>
 <tr class="subtest" data-parent="Math_methods" id="Math_methods_Math.cbrt"><td><span><a class="anchor" href="#Math_methods_Math.cbrt">&#xA7;</a>Math.cbrt</span><script data-source="
 return typeof Math.cbrt === &quot;function&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("433");return Function("asyncTestPassed","\nreturn typeof Math.cbrt === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("445");return Function("asyncTestPassed","\nreturn typeof Math.cbrt === \"function\";\n")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31645,7 +32555,7 @@ return Math.hypot() === 0 &amp;&amp;
   Math.hypot(1) === 1 &amp;&amp;
   Math.hypot(9, 12, 20) === 25 &amp;&amp;
   Math.hypot(27, 36, 60, 100) === 125;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("434");return Function("asyncTestPassed","\nreturn Math.hypot() === 0 &&\n  Math.hypot(1) === 1 &&\n  Math.hypot(9, 12, 20) === 25 &&\n  Math.hypot(27, 36, 60, 100) === 125;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("446");return Function("asyncTestPassed","\nreturn Math.hypot() === 0 &&\n  Math.hypot(1) === 1 &&\n  Math.hypot(9, 12, 20) === 25 &&\n  Math.hypot(27, 36, 60, 100) === 125;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -31787,7 +32697,7 @@ var len1 = c.length;
 c[2] = &apos;foo&apos;;
 var len2 = c.length;
 return len1 === 0 &amp;&amp; len2 === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("436");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nvar len1 = c.length;\nc[2] = 'foo';\nvar len2 = c.length;\nreturn len1 === 0 && len2 === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("448");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nvar len1 = c.length;\nc[2] = 'foo';\nvar len2 = c.length;\nreturn len1 === 0 && len2 === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -31860,7 +32770,7 @@ var c = new C();
 c[2] = &apos;foo&apos;;
 c.length = 1;
 return c.length === 1 &amp;&amp; !(2 in c);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("437");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nc[2] = 'foo';\nc.length = 1;\nreturn c.length === 1 && !(2 in c);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("449");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nc[2] = 'foo';\nc.length = 1;\nreturn c.length === 1 && !(2 in c);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -31931,7 +32841,7 @@ return c.length === 1 &amp;&amp; !(2 in c);
 class C extends Array {}
 var c = new C();
 return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototypeOf(C) === Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("438");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof C && c instanceof Array && Object.getPrototypeOf(C) === Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("450");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nreturn c instanceof C && c instanceof Array && Object.getPrototypeOf(C) === Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -32001,7 +32911,7 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <tr class="subtest" data-parent="Array_is_subclassable" id="Array_is_subclassable_Array.isArray_support"><td><span><a class="anchor" href="#Array_is_subclassable_Array.isArray_support">&#xA7;</a>Array.isArray support</span><script data-source="
 class C extends Array {}
 return Array.isArray(new C());
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("439");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn Array.isArray(new C());\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("451");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn Array.isArray(new C());\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32073,7 +32983,7 @@ class C extends Array {}
 var c = new C();
 c.push(2,4,6);
 return c.slice(1,2) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("440");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nc.push(2,4,6);\nreturn c.slice(1,2) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("452");return Function("asyncTestPassed","\nclass C extends Array {}\nvar c = new C();\nc.push(2,4,6);\nreturn c.slice(1,2) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32143,7 +33053,7 @@ return c.slice(1,2) instanceof C;
 <tr class="subtest" data-parent="Array_is_subclassable" id="Array_is_subclassable_Array.from"><td><span><a class="anchor" href="#Array_is_subclassable_Array.from">&#xA7;</a>Array.from</span><script data-source="
 class C extends Array {}
 return C.from({ length: 0 }) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("441");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("453");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.from({ length: 0 }) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -32213,7 +33123,7 @@ return C.from({ length: 0 }) instanceof C;
 <tr class="subtest" data-parent="Array_is_subclassable" id="Array_is_subclassable_Array.of"><td><span><a class="anchor" href="#Array_is_subclassable_Array.of">&#xA7;</a>Array.of</span><script data-source="
 class C extends Array {}
 return C.of(0) instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("442");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("454");return Function("asyncTestPassed","\nclass C extends Array {}\nreturn C.of(0) instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -32350,7 +33260,7 @@ return C.of(0) instanceof C;
 class R extends RegExp {}
 var r = new R(&quot;baz&quot;,&quot;g&quot;);
 return r.global &amp;&amp; r.source === &quot;baz&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("444");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.global && r.source === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("456");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.global && r.source === \"baz\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32421,7 +33331,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 class R extends RegExp {}
 var r = new R(&quot;baz&quot;,&quot;g&quot;);
 return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getPrototypeOf(R) === RegExp;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("445");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r instanceof R && r instanceof RegExp && Object.getPrototypeOf(R) === RegExp;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("457");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r instanceof R && r instanceof RegExp && Object.getPrototypeOf(R) === RegExp;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -32492,7 +33402,7 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 class R extends RegExp {}
 var r = new R(&quot;baz&quot;,&quot;g&quot;);
 return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastIndex === 9;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("446");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.exec(\"foobarbaz\")[0] === \"baz\" && r.lastIndex === 9;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("458");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\",\"g\");\nreturn r.exec(\"foobarbaz\")[0] === \"baz\" && r.lastIndex === 9;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32563,7 +33473,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 class R extends RegExp {}
 var r = new R(&quot;baz&quot;);
 return r.test(&quot;foobarbaz&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("447");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\");\nreturn r.test(\"foobarbaz\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("459");return Function("asyncTestPassed","\nclass R extends RegExp {}\nvar r = new R(\"baz\");\nreturn r.test(\"foobarbaz\");\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32700,7 +33610,7 @@ return r.test(&quot;foobarbaz&quot;);
 class C extends Function {}
 var c = new C(&quot;return &apos;foo&apos;;&quot;);
 return c() === &apos;foo&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("449");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c() === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("461");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c() === 'foo';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32771,7 +33681,7 @@ return c() === &apos;foo&apos;;
 class C extends Function {}
 var c = new C(&quot;return &apos;foo&apos;;&quot;);
 return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getPrototypeOf(C) === Function;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("450");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c instanceof C && c instanceof Function && Object.getPrototypeOf(C) === Function;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("462");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"return 'foo';\");\nreturn c instanceof C && c instanceof Function && Object.getPrototypeOf(C) === Function;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[15]</sup></a></td>
@@ -32843,7 +33753,7 @@ class C extends Function {}
 var c = new C(&quot;this.bar = 2;&quot;);
 c.prototype.baz = 3;
 return new c().bar === 2 &amp;&amp; new c().baz === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("451");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"this.bar = 2;\");\nc.prototype.baz = 3;\nreturn new c().bar === 2 && new c().baz === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("463");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"this.bar = 2;\");\nc.prototype.baz = 3;\nreturn new c().bar === 2 && new c().baz === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32914,7 +33824,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 class C extends Function {}
 var c = new C(&quot;x&quot;, &quot;return this.bar + x;&quot;);
 return c.call({bar:1}, 2) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("452");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.call({bar:1}, 2) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("464");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.call({bar:1}, 2) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -32985,7 +33895,7 @@ return c.call({bar:1}, 2) === 3;
 class C extends Function {}
 var c = new C(&quot;x&quot;, &quot;return this.bar + x;&quot;);
 return c.apply({bar:1}, [2]) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("453");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.apply({bar:1}, [2]) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("465");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"return this.bar + x;\");\nreturn c.apply({bar:1}, [2]) === 3;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33056,7 +33966,7 @@ return c.apply({bar:1}, [2]) === 3;
 class C extends Function {}
 var c = new C(&quot;x&quot;, &quot;y&quot;, &quot;return this.bar + x + y;&quot;).bind({bar:1}, 2);
 return c(6) === 9 &amp;&amp; c instanceof C;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("454");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"y\", \"return this.bar + x + y;\").bind({bar:1}, 2);\nreturn c(6) === 9 && c instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("466");return Function("asyncTestPassed","\nclass C extends Function {}\nvar c = new C(\"x\", \"y\", \"return this.bar + x + y;\").bind({bar:1}, 2);\nreturn c(6) === 9 && c instanceof C;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33213,7 +34123,7 @@ p1.then(function() {
 function check() {
   if (score === 5) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("456");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar p1 = new P(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new P(function(resolve, reject) { reject(\"quux\"); });\nvar score = +(p1 instanceof P);\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // P.prototype.then() should return a new P\n  score += p1.then() instanceof P && p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("468");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar p1 = new P(function(resolve, reject) { resolve(\"foo\"); });\nvar p2 = new P(function(resolve, reject) { reject(\"quux\"); });\nvar score = +(p1 instanceof P);\n\nfunction thenFn(result)  { score += (result === \"foo\");  check(); }\nfunction catchFn(result) { score += (result === \"quux\"); check(); }\nfunction shouldNotRun(result)  { score = -Infinity;   }\n\np1.then(thenFn, shouldNotRun);\np2.then(shouldNotRun, catchFn);\np1.catch(shouldNotRun);\np2.catch(catchFn);\n\np1.then(function() {\n  // P.prototype.then() should return a new P\n  score += p1.then() instanceof P && p1.then() !== p1;\n  check();\n});\n\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33284,7 +34194,7 @@ function check() {
 class C extends Promise {}
 var c = new C(function(resolve, reject) { resolve(&quot;foo&quot;); });
 return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getPrototypeOf(C) === Promise;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("457");return Function("asyncTestPassed","\nclass C extends Promise {}\nvar c = new C(function(resolve, reject) { resolve(\"foo\"); });\nreturn c instanceof C && c instanceof Promise && Object.getPrototypeOf(C) === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("469");return Function("asyncTestPassed","\nclass C extends Promise {}\nvar c = new C(function(resolve, reject) { resolve(\"foo\"); });\nreturn c instanceof C && c instanceof Promise && Object.getPrototypeOf(C) === Promise;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33368,7 +34278,7 @@ rejects.catch(function(result) { score += (result === &quot;qux&quot;); check();
 function check() {
   if (score === 3) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("458");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = P.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("470");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.all([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,100,\"bar\"); }),\n]);\nvar rejects = P.all([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 100,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result + \"\" === \"foo,bar\"); check(); });\nrejects.catch(function(result) { score += (result === \"qux\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33452,7 +34362,7 @@ rejects.catch(function(result) { score += (result === &quot;baz&quot;); check();
 function check() {
   if (score === 3) asyncTestPassed();
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("459");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = P.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("471");return Function("asyncTestPassed","\nclass P extends Promise {}\nvar fulfills = P.race([\n  new Promise(function(resolve)   { setTimeout(resolve,200,\"foo\"); }),\n  new Promise(function(_, reject) { setTimeout(reject, 300,\"bar\"); }),\n]);\nvar rejects = P.race([\n  new Promise(function(_, reject) { setTimeout(reject, 200,\"baz\"); }),\n  new Promise(function(resolve)   { setTimeout(resolve,300,\"qux\"); }),\n]);\nvar score = +(fulfills instanceof P);\nfulfills.then(function(result) { score += (result === \"foo\"); check(); });\nrejects.catch(function(result) { score += (result === \"baz\"); check(); });\n\nfunction check() {\n  if (score === 3) asyncTestPassed();\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33590,7 +34500,7 @@ class C extends Boolean {}
 var c = new C(true);
 return c instanceof Boolean
   &amp;&amp; c == true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("461");return Function("asyncTestPassed","\nclass C extends Boolean {}\nvar c = new C(true);\nreturn c instanceof Boolean\n  && c == true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("473");return Function("asyncTestPassed","\nclass C extends Boolean {}\nvar c = new C(true);\nreturn c instanceof Boolean\n  && c == true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33662,7 +34572,7 @@ class C extends Number {}
 var c = new C(6);
 return c instanceof Number
   &amp;&amp; +c === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("462");return Function("asyncTestPassed","\nclass C extends Number {}\nvar c = new C(6);\nreturn c instanceof Number\n  && +c === 6;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("474");return Function("asyncTestPassed","\nclass C extends Number {}\nvar c = new C(6);\nreturn c instanceof Number\n  && +c === 6;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33736,7 +34646,7 @@ return c instanceof String
   &amp;&amp; c + &apos;&apos; === &quot;golly&quot;
   &amp;&amp; c[0] === &quot;g&quot;
   &amp;&amp; c.length === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("463");return Function("asyncTestPassed","\nclass C extends String {}\nvar c = new C(\"golly\");\nreturn c instanceof String\n  && c + '' === \"golly\"\n  && c[0] === \"g\"\n  && c.length === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("475");return Function("asyncTestPassed","\nclass C extends String {}\nvar c = new C(\"golly\");\nreturn c instanceof String\n  && c + '' === \"golly\"\n  && c[0] === \"g\"\n  && c.length === 5;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33811,7 +34721,7 @@ var map = new M();
 map.set(key, 123);
 
 return map.has(key) &amp;&amp; map.get(key) === 123;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("464");return Function("asyncTestPassed","\nvar key = {};\nclass M extends Map {}\nvar map = new M();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("476");return Function("asyncTestPassed","\nvar key = {};\nclass M extends Map {}\nvar map = new M();\n\nmap.set(key, 123);\n\nreturn map.has(key) && map.get(key) === 123;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -33887,7 +34797,7 @@ set.add(123);
 set.add(123);
 
 return set.has(123);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("465");return Function("asyncTestPassed","\nvar obj = {};\nclass S extends Set {}\nvar set = new S();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("477");return Function("asyncTestPassed","\nvar obj = {};\nclass S extends Set {}\nvar set = new S();\n\nset.add(123);\nset.add(123);\n\nreturn set.has(123);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34037,7 +34947,7 @@ function correctProtoBound(proto) {
 return correctProtoBound(Function.prototype)
   &amp;&amp; correctProtoBound({})
   &amp;&amp; correctProtoBound(null);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("467");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = function(){};\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("479");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = function(){};\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34119,7 +35029,7 @@ function correctProtoBound(proto) {
 return correctProtoBound(Function.prototype)
   &amp;&amp; correctProtoBound({})
   &amp;&amp; correctProtoBound(null);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("468");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = function*(){};\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("480");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = function*(){};\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34201,7 +35111,7 @@ function correctProtoBound(proto) {
 return correctProtoBound(Function.prototype)
   &amp;&amp; correctProtoBound({})
   &amp;&amp; correctProtoBound(null);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("469");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = ()=>5;\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("481");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  var f = ()=>5;\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(f, proto);\n  }\n  else {\n    f.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(f, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34283,7 +35193,7 @@ function correctProtoBound(proto) {
 return correctProtoBound(Function.prototype)
   &amp;&amp; correctProtoBound({})
   &amp;&amp; correctProtoBound(null);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("470");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  class C {}\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(C, proto);\n  }\n  else {\n    C.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(C, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("482");return Function("asyncTestPassed","\nfunction correctProtoBound(proto) {\n  class C {}\n  if (Object.setPrototypeOf) {\n    Object.setPrototypeOf(C, proto);\n  }\n  else {\n    C.__proto__ = proto;\n  } \n  var boundF = Function.prototype.bind.call(C, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(Function.prototype)\n  && correctProtoBound({})\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34358,12 +35268,12 @@ function correctProtoBound(superclass) {
     }
   }
   var boundF = Function.prototype.bind.call(C, null);
-  return Object.getPrototypeOf(boundF) === proto;
+  return Object.getPrototypeOf(boundF) === Object.getPrototypeOf(C);
 }
 return correctProtoBound(function(){})
   &amp;&amp; correctProtoBound(Array)
   &amp;&amp; correctProtoBound(null);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("471");return Function("asyncTestPassed","\nfunction correctProtoBound(superclass) {\n  class C extends superclass {\n    constructor() {\n      return Object.create(null);\n    }\n  }\n  var boundF = Function.prototype.bind.call(C, null);\n  return Object.getPrototypeOf(boundF) === proto;\n}\nreturn correctProtoBound(function(){})\n  && correctProtoBound(Array)\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("483");return Function("asyncTestPassed","\nfunction correctProtoBound(superclass) {\n  class C extends superclass {\n    constructor() {\n      return Object.create(null);\n    }\n  }\n  var boundF = Function.prototype.bind.call(C, null);\n  return Object.getPrototypeOf(boundF) === Object.getPrototypeOf(C);\n}\nreturn correctProtoBound(function(){})\n  && correctProtoBound(Array)\n  && correctProtoBound(null);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -34498,7 +35408,7 @@ return correctProtoBound(function(){})
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.getPrototypeOf"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.getPrototypeOf">&#xA7;</a>Object.getPrototypeOf</span><script data-source="
 return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("473");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("485");return Function("asyncTestPassed","\nreturn Object.getPrototypeOf('a').constructor === String;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34567,7 +35477,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.getOwnPropertyDescriptor"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.getOwnPropertyDescriptor">&#xA7;</a>Object.getOwnPropertyDescriptor</span><script data-source="
 return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("474");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("486");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyDescriptor('a', 'foo') === undefined;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34638,7 +35548,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 var s = Object.getOwnPropertyNames(&apos;a&apos;);
 return s.length === 2 &amp;&amp;
   ((s[0] === &apos;length&apos; &amp;&amp; s[1] === &apos;0&apos;) || (s[0] === &apos;0&apos; &amp;&amp; s[1] === &apos;length&apos;));
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("475");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("487");return Function("asyncTestPassed","\nvar s = Object.getOwnPropertyNames('a');\nreturn s.length === 2 &&\n  ((s[0] === 'length' && s[1] === '0') || (s[0] === '0' && s[1] === 'length'));\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34707,7 +35617,7 @@ return s.length === 2 &amp;&amp;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.seal"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.seal">&#xA7;</a>Object.seal</span><script data-source="
 return Object.seal(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("476");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("488");return Function("asyncTestPassed","\nreturn Object.seal('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34776,7 +35686,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.freeze"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.freeze">&#xA7;</a>Object.freeze</span><script data-source="
 return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("477");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("489");return Function("asyncTestPassed","\nreturn Object.freeze('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34845,7 +35755,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.preventExtensions"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.preventExtensions">&#xA7;</a>Object.preventExtensions</span><script data-source="
 return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("478");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("490");return Function("asyncTestPassed","\nreturn Object.preventExtensions('a') === 'a';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34914,7 +35824,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.isSealed"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.isSealed">&#xA7;</a>Object.isSealed</span><script data-source="
 return Object.isSealed(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("479");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("491");return Function("asyncTestPassed","\nreturn Object.isSealed('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -34983,7 +35893,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.isFrozen"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.isFrozen">&#xA7;</a>Object.isFrozen</span><script data-source="
 return Object.isFrozen(&apos;a&apos;) === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("480");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("492");return Function("asyncTestPassed","\nreturn Object.isFrozen('a') === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -35052,7 +35962,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 </tr>
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.isExtensible"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.isExtensible">&#xA7;</a>Object.isExtensible</span><script data-source="
 return Object.isExtensible(&apos;a&apos;) === false;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("481");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("493");return Function("asyncTestPassed","\nreturn Object.isExtensible('a') === false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -35122,7 +36032,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <tr class="subtest" data-parent="Object_static_methods_accept_primitives" id="Object_static_methods_accept_primitives_Object.keys"><td><span><a class="anchor" href="#Object_static_methods_accept_primitives_Object.keys">&#xA7;</a>Object.keys</span><script data-source="
 var s = Object.keys(&apos;a&apos;);
 return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("482");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("494");return Function("asyncTestPassed","\nvar s = Object.keys('a');\nreturn s.length === 1 && s[0] === '0';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -35278,7 +36188,7 @@ for(var i in obj) {
   result += i;
 }
 return result === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("484");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nvar result = '';\nfor(var i in obj) {\n  result += i;\n}\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("496");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nvar result = '';\nfor(var i in obj) {\n  result += i;\n}\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35364,7 +36274,7 @@ delete obj[2];
 obj[2] = true;
 
 return Object.keys(obj).join(&apos;&apos;) === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("485");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Object.keys(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("497");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Object.keys(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35450,7 +36360,7 @@ delete obj[2];
 obj[2] = true;
 
 return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("486");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Object.getOwnPropertyNames(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("498");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn Object.getOwnPropertyNames(obj).join('') === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35546,7 +36456,7 @@ obj[2] = true;
 Object.assign({}, obj);
 
 return result === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("487");return Function("asyncTestPassed","\nfunction f(key) {\n  return {\n    get: function() { result += key; return true; },\n    set: Object,\n    enumerable: true\n  };\n};\nvar result = '';\nvar obj = Object.defineProperties({}, {\n  2:    f(2),\n  0:    f(0),\n  1:    f(1),\n  ' ':  f(' '),\n  9:    f(9),\n  D:    f('D'),\n  B:    f('B'),\n  '-1': f('-1'),\n});\nObject.defineProperty(obj,'A',f('A'));\nObject.defineProperty(obj,'3',f('3'));\nObject.defineProperty(obj,'C',f('C'));\nObject.defineProperty(obj,'4',f('4'));\ndelete obj[2];\nobj[2] = true;\n\nObject.assign({}, obj);\n\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("499");return Function("asyncTestPassed","\nfunction f(key) {\n  return {\n    get: function() { result += key; return true; },\n    set: Object,\n    enumerable: true\n  };\n};\nvar result = '';\nvar obj = Object.defineProperties({}, {\n  2:    f(2),\n  0:    f(0),\n  1:    f(1),\n  ' ':  f(' '),\n  9:    f(9),\n  D:    f('D'),\n  B:    f('B'),\n  '-1': f('-1'),\n});\nObject.defineProperty(obj,'A',f('A'));\nObject.defineProperty(obj,'3',f('3'));\nObject.defineProperty(obj,'C',f('C'));\nObject.defineProperty(obj,'4',f('4'));\ndelete obj[2];\nobj[2] = true;\n\nObject.assign({}, obj);\n\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35633,7 +36543,7 @@ obj[2] = true;
 
 return JSON.stringify(obj) ===
   &apos;{&quot;0&quot;:true,&quot;1&quot;:true,&quot;2&quot;:true,&quot;3&quot;:true,&quot;4&quot;:true,&quot;9&quot;:true,&quot; &quot;:true,&quot;D&quot;:true,&quot;B&quot;:true,&quot;-1&quot;:true,&quot;A&quot;:true,&quot;C&quot;:true}&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("488");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn JSON.stringify(obj) ===\n  '{\"0\":true,\"1\":true,\"2\":true,\"3\":true,\"4\":true,\"9\":true,\" \":true,\"D\":true,\"B\":true,\"-1\":true,\"A\":true,\"C\":true}';\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("500");return Function("asyncTestPassed","\nvar obj = {\n  2:    true,\n  0:    true,\n  1:    true,\n  ' ':  true,\n  9:    true,\n  D:    true,\n  B:    true,\n  '-1': true,\n};\nobj.A = true;\nobj[3] = true;\nObject.defineProperty(obj, 'C', { value: true, enumerable: true });\nObject.defineProperty(obj, '4', { value: true, enumerable: true });\ndelete obj[2];\nobj[2] = true;\n\nreturn JSON.stringify(obj) ===\n  '{\"0\":true,\"1\":true,\"2\":true,\"3\":true,\"4\":true,\"9\":true,\" \":true,\"D\":true,\"B\":true,\"-1\":true,\"A\":true,\"C\":true}';\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35710,7 +36620,7 @@ JSON.parse(
   }
 );
 return result === &quot;012349 DB-1AC&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("489");return Function("asyncTestPassed","\nvar result = '';\nJSON.parse(\n  '{\"0\":true,\"1\":true,\"2\":true,\"3\":true,\"4\":true,\"9\":true,\" \":true,\"D\":true,\"B\":true,\"-1\":true,\"A\":true,\"C\":true}',\n  function reviver(k,v) {\n    result += k;\n    return v;\n  }\n);\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("501");return Function("asyncTestPassed","\nvar result = '';\nJSON.parse(\n  '{\"0\":true,\"1\":true,\"2\":true,\"3\":true,\"4\":true,\"9\":true,\" \":true,\"D\":true,\"B\":true,\"-1\":true,\"A\":true,\"C\":true}',\n  function reviver(k,v) {\n    result += k;\n    return v;\n  }\n);\nreturn result === \"012349 DB-1AC\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35778,70 +36688,70 @@ return result === &quot;012349 DB-1AC&quot;;
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
-<td data-browser="tr" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="es6tr" class="obsolete tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="closure" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="jsx" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="typescript" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="es6shim" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="ie10" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="ie11" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="edge" class="unstable tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
-<td data-browser="firefox11" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox13" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox16" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox17" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox18" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox23" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox24" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox25" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox27" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox28" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox29" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox30" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox31" class="tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox32" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox33" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="firefox34" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="firefox35" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="firefox36" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="firefox37" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="firefox38" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="firefox39" class="unstable tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
-<td data-browser="firefox40" class="unstable tally" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
-<td data-browser="chrome" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome30" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome31" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome33" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome34" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome35" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome36" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome37" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome38" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome39" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome40" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome41" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="chrome42" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="chrome43" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="chrome44" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="chrome45" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="safari51" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="safari6" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="safari7" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="safari71_8" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="opera" class="obsolete tally" data-tally="0.375" style="background-color:hsl(45,69%,50%)">3/8</td>
-<td data-browser="konq49" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="rhino17" class="obsolete tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="phantom" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="node" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="iojs" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td data-browser="ejs" class="unstable tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td data-browser="ios7" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
-<td data-browser="ios8" class="tally" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
+<td data-browser="tr" class="tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="babel" class="tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="es6tr" class="obsolete tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="closure" class="tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="jsx" class="tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="typescript" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="es6shim" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="ie10" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="ie11" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="edge" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">6/9</td>
+<td data-browser="firefox11" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox13" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox16" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox17" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox18" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox23" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox24" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox25" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox27" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox28" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox29" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox30" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox31" class="tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox32" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox33" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="firefox34" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox35" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox36" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox37" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="firefox38" class="tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
+<td data-browser="firefox39" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">6/9</td>
+<td data-browser="firefox40" class="unstable tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">6/9</td>
+<td data-browser="chrome" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome19dev" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome21dev" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome30" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome31" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome33" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome34" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome35" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome36" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome37" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome38" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome39" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome40" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome41" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="chrome42" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="chrome43" class="tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
+<td data-browser="chrome44" class="unstable tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
+<td data-browser="chrome45" class="unstable tally" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
+<td data-browser="safari51" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="safari6" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="safari7" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="safari71_8" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="opera" class="obsolete tally" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
+<td data-browser="konq49" class="tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="rhino17" class="obsolete tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="phantom" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="node" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="iojs" class="tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
+<td data-browser="ejs" class="unstable tally" data-tally="0.1111111111111111" style="background-color:hsl(13,81%,50%)">1/9</td>
+<td data-browser="ios7" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td data-browser="ios8" class="tally" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 </tr>
 <tr class="subtest" data-parent="miscellaneous" id="miscellaneous_no_escaped_reserved_words_as_identifiers"><td><span><a class="anchor" href="#miscellaneous_no_escaped_reserved_words_as_identifiers">&#xA7;</a>no escaped reserved words as identifiers</span><script data-source="
 var \u0061;
@@ -35850,7 +36760,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("491");return Function("asyncTestPassed","\nvar \\u0061;\ntry {\n  eval('var v\\\\u0061r');\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("503");return Function("asyncTestPassed","\nvar \\u0061;\ntry {\n  eval('var v\\\\u0061r');\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -35920,7 +36830,7 @@ try {
 <tr class="subtest" data-parent="miscellaneous" id="miscellaneous_duplicate_property_names_in_strict_mode"><td><span><a class="anchor" href="#miscellaneous_duplicate_property_names_in_strict_mode">&#xA7;</a>duplicate property names in strict mode</span><script data-source="
 &apos;use strict&apos;;
 return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("492");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("504");return Function("asyncTestPassed","\n'use strict';\nreturn this === undefined && ({ a:1, a:1 }).a === 1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -35989,7 +36899,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 </tr>
 <tr class="subtest" data-parent="miscellaneous" id="miscellaneous_no_semicolon_needed_after_do-while"><td><span><a class="anchor" href="#miscellaneous_no_semicolon_needed_after_do-while">&#xA7;</a>no semicolon needed after do-while</span><script data-source="
 do {} while (false) return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("493");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("505");return Function("asyncTestPassed","\ndo {} while (false) return true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -36063,7 +36973,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("494");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("506");return Function("asyncTestPassed","\ntry {\n  eval('for (var i = 0 in {}) {}');\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -36136,7 +37046,7 @@ try {
 } catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("495");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("507");return Function("asyncTestPassed","\ntry {\n  new (Object.getOwnPropertyDescriptor({get a(){}}, 'a')).get;\n} catch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -36205,7 +37115,7 @@ try {
 </tr>
 <tr class="subtest" data-parent="miscellaneous" id="miscellaneous_Invalid_Date"><td><span><a class="anchor" href="#miscellaneous_Invalid_Date">&#xA7;</a>Invalid Date</span><script data-source="
 return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("496");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("508");return Function("asyncTestPassed","\nreturn new Date(NaN) + \"\" === \"Invalid Date\";\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -36274,7 +37184,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 </tr>
 <tr class="subtest" data-parent="miscellaneous" id="miscellaneous_RegExp_constructor_can_alter_flags"><td><span><a class="anchor" href="#miscellaneous_RegExp_constructor_can_alter_flags">&#xA7;</a>RegExp constructor can alter flags</span><script data-source="
 return new RegExp(/./im, &quot;g&quot;).global === true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("497");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("509");return Function("asyncTestPassed","\nreturn new RegExp(/./im, \"g\").global === true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -36358,7 +37268,7 @@ try {
   Date.prototype.valueOf(); return false;
 } catch(e) {}
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("498");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("510");return Function("asyncTestPassed","\ntry {\n  Boolean.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  Number.prototype.valueOf(); return false;\n} catch(e) {}\ntry {\n  String.prototype.toString(); return false;\n} catch(e) {}\ntry {\n  RegExp.prototype.source; return false;\n} catch(e) {}\ntry {\n  Date.prototype.valueOf(); return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -36425,6 +37335,83 @@ return true;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="miscellaneous" id="miscellaneous_function_length_is_configurable"><td><span><a class="anchor" href="#miscellaneous_function_length_is_configurable">&#xA7;</a>function &quot;length&quot; is configurable</span><script data-source="
+var fn = function(a, b) {};
+
+var desc = Object.getOwnPropertyDescriptor(fn, &quot;length&quot;);
+if (desc.configurable) {
+  Object.defineProperty(fn, &quot;length&quot;, { value: 1 });
+  return fn.length === 1;
+}
+
+return false;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("511");return Function("asyncTestPassed","\nvar fn = function(a, b) {};\n\nvar desc = Object.getOwnPropertyDescriptor(fn, \"length\");\nif (desc.configurable) {\n  Object.defineProperty(fn, \"length\", { value: 1 });\n  return fn.length === 1;\n}\n\nreturn false;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="tr">No</td>
+<td class="no" data-browser="babel">No</td>
+<td class="no obsolete" data-browser="es6tr">No</td>
+<td class="no" data-browser="closure">No</td>
+<td class="no" data-browser="jsx">No</td>
+<td class="no" data-browser="typescript">No</td>
+<td class="no" data-browser="es6shim">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no unstable" data-browser="edge">No</td>
+<td class="no obsolete" data-browser="firefox11">No</td>
+<td class="no obsolete" data-browser="firefox13">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox18">No</td>
+<td class="no obsolete" data-browser="firefox23">No</td>
+<td class="no obsolete" data-browser="firefox24">No</td>
+<td class="no obsolete" data-browser="firefox25">No</td>
+<td class="no obsolete" data-browser="firefox27">No</td>
+<td class="no obsolete" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no obsolete" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="firefox37">No</td>
+<td class="yes" data-browser="firefox38">Yes</td>
+<td class="yes unstable" data-browser="firefox39">Yes</td>
+<td class="yes unstable" data-browser="firefox40">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome19dev">No</td>
+<td class="no obsolete" data-browser="chrome21dev">No</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome31">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
+<td class="no obsolete" data-browser="chrome34">No</td>
+<td class="no obsolete" data-browser="chrome35">No</td>
+<td class="no obsolete" data-browser="chrome36">No</td>
+<td class="no obsolete" data-browser="chrome37">No</td>
+<td class="no obsolete" data-browser="chrome38">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="yes" data-browser="chrome43">Yes</td>
+<td class="yes unstable" data-browser="chrome44">Yes</td>
+<td class="yes unstable" data-browser="chrome45">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="no unstable" data-browser="webkit">No</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="rhino17">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no" data-browser="node">No</td>
+<td class="no" data-browser="iojs">No</td>
+<td class="no unstable" data-browser="ejs">No</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="category"><td colspan="66">Annex b</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="hoisted_block-level_function_declaration"><span><a class="anchor" href="#hoisted_block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-block-level-function-declarations-web-legacy-compatibility-semantics">hoisted block-level function declaration</a></span><script data-source="
@@ -36436,7 +37423,7 @@ return true;
   function h() { return 2; }
 
 return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("499");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("512");return Function("asyncTestPassed","\n// Note: only available outside of strict mode.\n{ function f() { return 1; } }\n  function g() { return 1; }\n{ function g() { return 2; } }\n{ function h() { return 1; } }\n  function h() { return 2; }\n\nreturn f() === 1 && g() === 2 && h() === 1;\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -36572,7 +37559,7 @@ return f() === 1 &amp;&amp; g() === 2 &amp;&amp; h() === 1;
 <tr class="subtest" data-parent="__proto___in_object_literals" id="__proto___in_object_literals_basic_support"><td><span><a class="anchor" href="#__proto___in_object_literals_basic_support">&#xA7;</a>basic support</span><script data-source="
 return { __proto__ : [] } instanceof Array
   &amp;&amp; !({ __proto__ : null } instanceof Object);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("501");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("514");return Function("asyncTestPassed","\nreturn { __proto__ : [] } instanceof Array\n  && !({ __proto__ : null } instanceof Object);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -36646,7 +37633,7 @@ try {
 catch(e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("502");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("515");return Function("asyncTestPassed","\ntry {\n  eval(\"({ __proto__ : [], __proto__: {} })\");\n}\ncatch(e) {\n  return true;\n}\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -36719,7 +37706,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var a = &quot;__proto__&quot;;
 return !({ [a] : [] } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("503");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("516");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar a = \"__proto__\";\nreturn !({ [a] : [] } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -36792,7 +37779,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
 }
 var __proto__ = [];
 return !({ __proto__ } instanceof Array);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("504");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("517");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nvar __proto__ = [];\nreturn !({ __proto__ } instanceof Array);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -36864,7 +37851,7 @@ if (!({ __proto__ : [] } instanceof Array)) {
   return false;
 }
 return !({ __proto__(){} } instanceof Function);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("505");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("518");return Function("asyncTestPassed","\nif (!({ __proto__ : [] } instanceof Array)) {\n  return false;\n}\nreturn !({ __proto__(){} } instanceof Function);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37000,7 +37987,7 @@ return !({ __proto__(){} } instanceof Function);
 <tr class="subtest" data-parent="Object.prototype.__proto__" id="Object.prototype.__proto___get_prototype"><td><span><a class="anchor" href="#Object.prototype.__proto___get_prototype">&#xA7;</a>get prototype</span><script data-source="
 var A = function(){};
 return (new A()).__proto__ === A.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("507");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("520");return Function("asyncTestPassed","\nvar A = function(){};\nreturn (new A()).__proto__ === A.prototype;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37071,7 +38058,7 @@ return (new A()).__proto__ === A.prototype;
 var o = {};
 o.__proto__ = Array.prototype;
 return o instanceof Array;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("508");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("521");return Function("asyncTestPassed","\nvar o = {};\no.__proto__ = Array.prototype;\nreturn o instanceof Array;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37142,7 +38129,7 @@ return o instanceof Array;
 var o = Object.create(null), p = {};
 o.__proto__ = p;
 return Object.getPrototypeOf(o) !== p;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("509");return Function("asyncTestPassed","\nvar o = Object.create(null), p = {};\no.__proto__ = p;\nreturn Object.getPrototypeOf(o) !== p;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("522");return Function("asyncTestPassed","\nvar o = Object.create(null), p = {};\no.__proto__ = p;\nreturn Object.getPrototypeOf(o) !== p;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37211,7 +38198,7 @@ return Object.getPrototypeOf(o) !== p;
 </tr>
 <tr class="subtest" data-parent="Object.prototype.__proto__" id="Object.prototype.__proto___present_in_hasOwnProperty()"><td><span><a class="anchor" href="#Object.prototype.__proto___present_in_hasOwnProperty()">&#xA7;</a>present in hasOwnProperty()</span><script data-source="
 return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("510");return Function("asyncTestPassed","\nreturn Object.prototype.hasOwnProperty('__proto__');\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("523");return Function("asyncTestPassed","\nreturn Object.prototype.hasOwnProperty('__proto__');\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37287,7 +38274,7 @@ return (desc
   &amp;&amp; &quot;set&quot; in desc
   &amp;&amp; desc.configurable
   &amp;&amp; !desc.enumerable);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("511");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("524");return Function("asyncTestPassed","\nvar desc = Object.getOwnPropertyDescriptor(Object.prototype,\"__proto__\");\nvar A = function(){};\n\nreturn (desc\n  && \"get\" in desc\n  && \"set\" in desc\n  && desc.configurable\n  && !desc.enumerable);\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37356,7 +38343,7 @@ return (desc
 </tr>
 <tr class="subtest" data-parent="Object.prototype.__proto__" id="Object.prototype.__proto___present_in_Object.getOwnPropertyNames()"><td><span><a class="anchor" href="#Object.prototype.__proto___present_in_Object.getOwnPropertyNames()">&#xA7;</a>present in Object.getOwnPropertyNames()</span><script data-source="
 return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos;) &gt; -1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("512");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyNames(Object.prototype).indexOf('__proto__') > -1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("525");return Function("asyncTestPassed","\nreturn Object.getOwnPropertyNames(Object.prototype).indexOf('__proto__') > -1;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37498,7 +38485,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("514");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("527");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (typeof String.prototype[names[i]] !== 'function') {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37574,7 +38561,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("515");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (\"\"[names[i]]().toLowerCase() !== \"\"[names[i]]()) {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("528");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"big\", \"bold\", \"fixed\", \"fontcolor\", \"fontsize\",\n  \"italics\", \"link\", \"small\", \"strike\", \"sub\", \"sup\"];\nfor (i = 0; i < names.length; i++) {\n  if (\"\"[names[i]]().toLowerCase() !== \"\"[names[i]]()) {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37649,7 +38636,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("516");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"fontcolor\", \"fontsize\", \"link\"];\nfor (i = 0; i < names.length; i++) {\n  if (\"\"[names[i]]('\"') !== \"\"[names[i]]('&' + 'quot;')) {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("529");return Function("asyncTestPassed","\nvar i, names = [\"anchor\", \"fontcolor\", \"fontsize\", \"link\"];\nfor (i = 0; i < names.length; i++) {\n  if (\"\"[names[i]]('\"') !== \"\"[names[i]]('&' + 'quot;')) {\n    return false;\n  }\n}\nreturn true;\n      ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -37718,7 +38705,7 @@ return true;
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("517");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("530");return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed);}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
1. `@@species` are missing in `WeakMap` and `WeakSet` constructors. Added the test to check for that: c48968a.
2. Some implementations (V8 prior to 4.3 and some polyfills) do not support iterables in `Promise.all` and `Promise.race`. Added tests to check that: 75bb18b.
3. In ES6 version of specification, contrary to ES5, `length` property of `function` instances is `configurable`. Added test for that: 091df00.
4. In early versions of ES6 spec weak collections prototypes had `clear` methods that were later removed. Added tests for their absence: f08d8f5.
5. Firefox 36 throws on `null` in constructors (5c1d6f3) and does not invoke monkey-patched `set` and `add` methods (56ee56c).
