### PR TITLE
CSS - Enforce default background and color

### DIFF
--- a/master.css
+++ b/master.css
@@ -5,6 +5,8 @@ html {
   box-sizing: inherit;
 }
 body {
+    background-color: #fff;
+    color: #000;
     font-family: 'Open Sans', sans-serif; margin: 0; font-weight: 300; display: inline-block;
     width: 100%;
 }


### PR DESCRIPTION
Without specifying these explicit colors, the site is unreadable for people who have configured their browser to display white on black texts.
