### PR TITLE
FF doesn't pass subtest "default function parameters > arguments object interaction"

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1163,7 +1163,6 @@ exports.tests = [
         babel:       true,
         es6tr:       true,
         ejs:         true,
-        firefox16:   true,
         webkit:      true,
       },
     },


### PR DESCRIPTION
Only older versions of FF used to pass a previous version of that subtest. Now, it doesn't pass it anymore. See #615 for details.
