### PR TITLE
replacing (function(){}).length with (function(){}).prototype

### DIFF
--- a/strict-mode/index.html
+++ b/strict-mode/index.html
@@ -213,10 +213,10 @@
       (function(){
         var error;
         try {
-          eval('delete (function(){}).length;');
+          eval('delete (function(){}).prototype;');
         }
         catch (err) { error = err; }
-        print('<span class="test"><code>delete (function(){}).length;<\/code> is a TypeError<\/span>' + colorResult(error instanceof TypeError));
+        print('<span class="test"><code>delete (function(){}).prototype;<\/code> is a TypeError<\/span>' + colorResult(error instanceof TypeError));
       })();
 
       (function(){


### PR DESCRIPTION
`(function(){}).length` is now configurable in ES6; replacing it with `(function(){}).prototype`, so that the test "attempting to delete an unconfigurable property should throw a TypeError" remains valid.
