### PR TITLE
Add subtest "super() invokes the correct constructor"

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2303,6 +2303,7 @@ exports.tests = [
         node4:       strict,
         chrome41:    strict,
       },
+    },
     'super() invokes the correct constructor': {
       exec: function() {/*
         // checks that super() is *not* a synonym of super.constructor()

--- a/data-es6.js
+++ b/data-es6.js
@@ -2303,6 +2303,25 @@ exports.tests = [
         node4:       strict,
         chrome41:    strict,
       },
+    'super() invokes the correct constructor': {
+      exec: function() {/*
+        // checks that super() is *not* a synonym of super.constructor()
+        var passed;
+        class B { 
+            constructor() { 
+                passed = true; 
+            } 
+        };
+        B.prototype.constructor = function () { 
+            passed = false;
+        };
+        class C extends B { };
+        new C;
+        return passed;
+      */},
+      res: {
+        // to be completed...
+      },
     },
   },
 },


### PR DESCRIPTION
This test checks that `super()` is _not_ a synonym of `super.constructor()`.
