### PR TITLE
"Object(symbol)" subtest: add "instanceof Symbol" check

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -8746,6 +8746,7 @@ exports.tests = [
         var symbolObject = Object(symbol);
 
         return typeof symbolObject === "object" &&
+          symbolObject instanceof Symbol &&
           symbolObject == symbol &&
           symbolObject !== symbol &&
           symbolObject.valueOf() === symbol;


### PR DESCRIPTION
Polyfills (such as mine) that use improbable strings as ersatz for symbols will pass the old test, but they shouldn’t (unless they tamper with the `Object` builtin, of course). 
