### PR TITLE
Add a "test-" prefix so that things like "Symbol" don't shadow the global Symbol

### DIFF
--- a/build.js
+++ b/build.js
@@ -434,7 +434,7 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler) {
         t.significance === "medium" ? 0.5 : 1)
       .addClass(isOptional(t.category) ? 'optional-feature' : '')
       .append($('<td></td>')
-        .attr('id',id)
+        .attr('id', 'test-' + id)
         .append('<span><a class="anchor" href="#' + id + '">&sect;</a>' + name + footnoteHTML(t) + '</span></td>')
         .append(testScript(t.exec, compiler, rowNum++))
       );

--- a/es5/index.html
+++ b/es5/index.html
@@ -134,7 +134,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr significance="1"><td id="Object.create"><span><a class="anchor" href="#Object.create">&#xA7;</a>Object.create</span><script data-source="function () {
+      <tr significance="1"><td id="test-Object.create"><span><a class="anchor" href="#Object.create">&#xA7;</a>Object.create</span><script data-source="function () {
 return typeof Object.create == &apos;function&apos;;
   }">test(
 function () {
@@ -177,7 +177,7 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.defineProperty"><span><a class="anchor" href="#Object.defineProperty">&#xA7;</a>Object.defineProperty</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.defineProperty"><span><a class="anchor" href="#Object.defineProperty">&#xA7;</a>Object.defineProperty</span><script data-source="function () {
 return typeof Object.defineProperty == &apos;function&apos;;
   }">test(
 function () {
@@ -220,7 +220,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.defineProperties"><span><a class="anchor" href="#Object.defineProperties">&#xA7;</a>Object.defineProperties</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.defineProperties"><span><a class="anchor" href="#Object.defineProperties">&#xA7;</a>Object.defineProperties</span><script data-source="function () {
 return typeof Object.defineProperties == &apos;function&apos;;
   }">test(
 function () {
@@ -263,7 +263,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.getPrototypeOf"><span><a class="anchor" href="#Object.getPrototypeOf">&#xA7;</a>Object.getPrototypeOf</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.getPrototypeOf"><span><a class="anchor" href="#Object.getPrototypeOf">&#xA7;</a>Object.getPrototypeOf</span><script data-source="function () {
 return typeof Object.getPrototypeOf == &apos;function&apos;;
   }">test(
 function () {
@@ -306,7 +306,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.keys"><span><a class="anchor" href="#Object.keys">&#xA7;</a>Object.keys</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.keys"><span><a class="anchor" href="#Object.keys">&#xA7;</a>Object.keys</span><script data-source="function () {
 return typeof Object.keys == &apos;function&apos;;
   }">test(
 function () {
@@ -349,7 +349,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.seal"><span><a class="anchor" href="#Object.seal">&#xA7;</a>Object.seal</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.seal"><span><a class="anchor" href="#Object.seal">&#xA7;</a>Object.seal</span><script data-source="function () {
 return typeof Object.seal == &apos;function&apos;;
   }">test(
 function () {
@@ -392,7 +392,7 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.freeze"><span><a class="anchor" href="#Object.freeze">&#xA7;</a>Object.freeze</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.freeze"><span><a class="anchor" href="#Object.freeze">&#xA7;</a>Object.freeze</span><script data-source="function () {
 return typeof Object.freeze == &apos;function&apos;;
   }">test(
 function () {
@@ -435,7 +435,7 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.preventExtensions"><span><a class="anchor" href="#Object.preventExtensions">&#xA7;</a>Object.preventExtensions</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.preventExtensions"><span><a class="anchor" href="#Object.preventExtensions">&#xA7;</a>Object.preventExtensions</span><script data-source="function () {
 return typeof Object.preventExtensions == &apos;function&apos;;
   }">test(
 function () {
@@ -478,7 +478,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.isSealed"><span><a class="anchor" href="#Object.isSealed">&#xA7;</a>Object.isSealed</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.isSealed"><span><a class="anchor" href="#Object.isSealed">&#xA7;</a>Object.isSealed</span><script data-source="function () {
 return typeof Object.isSealed == &apos;function&apos;;
   }">test(
 function () {
@@ -521,7 +521,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.isFrozen"><span><a class="anchor" href="#Object.isFrozen">&#xA7;</a>Object.isFrozen</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.isFrozen"><span><a class="anchor" href="#Object.isFrozen">&#xA7;</a>Object.isFrozen</span><script data-source="function () {
 return typeof Object.isFrozen == &apos;function&apos;;
   }">test(
 function () {
@@ -564,7 +564,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.isExtensible"><span><a class="anchor" href="#Object.isExtensible">&#xA7;</a>Object.isExtensible</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.isExtensible"><span><a class="anchor" href="#Object.isExtensible">&#xA7;</a>Object.isExtensible</span><script data-source="function () {
 return typeof Object.isExtensible == &apos;function&apos;;
   }">test(
 function () {
@@ -607,7 +607,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.getOwnPropertyDescriptor"><span><a class="anchor" href="#Object.getOwnPropertyDescriptor">&#xA7;</a>Object.getOwnPropertyDescriptor</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.getOwnPropertyDescriptor"><span><a class="anchor" href="#Object.getOwnPropertyDescriptor">&#xA7;</a>Object.getOwnPropertyDescriptor</span><script data-source="function () {
 return typeof Object.getOwnPropertyDescriptor == &apos;function&apos;;
   }">test(
 function () {
@@ -650,7 +650,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Object.getOwnPropertyNames"><span><a class="anchor" href="#Object.getOwnPropertyNames">&#xA7;</a>Object.getOwnPropertyNames</span><script data-source="function () {
+<tr significance="1"><td id="test-Object.getOwnPropertyNames"><span><a class="anchor" href="#Object.getOwnPropertyNames">&#xA7;</a>Object.getOwnPropertyNames</span><script data-source="function () {
 return typeof Object.getOwnPropertyNames == &apos;function&apos;;
   }">test(
 function () {
@@ -695,7 +695,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 </tr>
 <tr><th colspan="39" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&#xA7;</a>Date.prototype.toISOString</span><script data-source="function () {
+<tr significance="1"><td id="test-Date.prototype.toISOString"><span><a class="anchor" href="#Date.prototype.toISOString">&#xA7;</a>Date.prototype.toISOString</span><script data-source="function () {
 return typeof Date.prototype.toISOString == &apos;function&apos;;
   }">test(
 function () {
@@ -738,7 +738,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Date.now"><span><a class="anchor" href="#Date.now">&#xA7;</a>Date.now</span><script data-source="function () {
+<tr significance="1"><td id="test-Date.now"><span><a class="anchor" href="#Date.now">&#xA7;</a>Date.now</span><script data-source="function () {
 return typeof Date.now == &apos;function&apos;;
   }">test(
 function () {
@@ -781,7 +781,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.isArray"><span><a class="anchor" href="#Array.isArray">&#xA7;</a>Array.isArray</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.isArray"><span><a class="anchor" href="#Array.isArray">&#xA7;</a>Array.isArray</span><script data-source="function () {
 return typeof Array.isArray == &apos;function&apos;;
   }">test(
 function () {
@@ -824,7 +824,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="JSON"><span><a class="anchor" href="#JSON">&#xA7;</a>JSON</span><script data-source="function () {
+<tr significance="1"><td id="test-JSON"><span><a class="anchor" href="#JSON">&#xA7;</a>JSON</span><script data-source="function () {
 return typeof JSON == &apos;object&apos;;
   }">test(
 function () {
@@ -867,7 +867,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Function.prototype.bind"><span><a class="anchor" href="#Function.prototype.bind">&#xA7;</a>Function.prototype.bind</span><script data-source="function () {
+<tr significance="1"><td id="test-Function.prototype.bind"><span><a class="anchor" href="#Function.prototype.bind">&#xA7;</a>Function.prototype.bind</span><script data-source="function () {
 return typeof Function.prototype.bind == &apos;function&apos;;
   }">test(
 function () {
@@ -910,7 +910,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="String.prototype.trim"><span><a class="anchor" href="#String.prototype.trim">&#xA7;</a>String.prototype.trim</span><script data-source="function () {
+<tr significance="1"><td id="test-String.prototype.trim"><span><a class="anchor" href="#String.prototype.trim">&#xA7;</a>String.prototype.trim</span><script data-source="function () {
 return typeof String.prototype.trim == &apos;function&apos;;
   }">test(
 function () {
@@ -955,7 +955,7 @@ return typeof String.prototype.trim == 'function';
 </tr>
 <tr><th colspan="39" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&#xA7;</a>Array.prototype.indexOf</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.indexOf"><span><a class="anchor" href="#Array.prototype.indexOf">&#xA7;</a>Array.prototype.indexOf</span><script data-source="function () {
 return typeof Array.prototype.indexOf == &apos;function&apos;;
   }">test(
 function () {
@@ -998,7 +998,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.lastIndexOf"><span><a class="anchor" href="#Array.prototype.lastIndexOf">&#xA7;</a>Array.prototype.lastIndexOf</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.lastIndexOf"><span><a class="anchor" href="#Array.prototype.lastIndexOf">&#xA7;</a>Array.prototype.lastIndexOf</span><script data-source="function () {
 return typeof Array.prototype.lastIndexOf == &apos;function&apos;;
   }">test(
 function () {
@@ -1041,7 +1041,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.every"><span><a class="anchor" href="#Array.prototype.every">&#xA7;</a>Array.prototype.every</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.every"><span><a class="anchor" href="#Array.prototype.every">&#xA7;</a>Array.prototype.every</span><script data-source="function () {
 return typeof Array.prototype.every == &apos;function&apos;;
   }">test(
 function () {
@@ -1084,7 +1084,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.some"><span><a class="anchor" href="#Array.prototype.some">&#xA7;</a>Array.prototype.some</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.some"><span><a class="anchor" href="#Array.prototype.some">&#xA7;</a>Array.prototype.some</span><script data-source="function () {
 return typeof Array.prototype.some == &apos;function&apos;;
   }">test(
 function () {
@@ -1127,7 +1127,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.forEach"><span><a class="anchor" href="#Array.prototype.forEach">&#xA7;</a>Array.prototype.forEach</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.forEach"><span><a class="anchor" href="#Array.prototype.forEach">&#xA7;</a>Array.prototype.forEach</span><script data-source="function () {
 return typeof Array.prototype.forEach == &apos;function&apos;;
   }">test(
 function () {
@@ -1170,7 +1170,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.map"><span><a class="anchor" href="#Array.prototype.map">&#xA7;</a>Array.prototype.map</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.map"><span><a class="anchor" href="#Array.prototype.map">&#xA7;</a>Array.prototype.map</span><script data-source="function () {
 return typeof Array.prototype.map == &apos;function&apos;;
   }">test(
 function () {
@@ -1213,7 +1213,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.filter"><span><a class="anchor" href="#Array.prototype.filter">&#xA7;</a>Array.prototype.filter</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.filter"><span><a class="anchor" href="#Array.prototype.filter">&#xA7;</a>Array.prototype.filter</span><script data-source="function () {
 return typeof Array.prototype.filter == &apos;function&apos;;
   }">test(
 function () {
@@ -1256,7 +1256,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.reduce"><span><a class="anchor" href="#Array.prototype.reduce">&#xA7;</a>Array.prototype.reduce</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.reduce"><span><a class="anchor" href="#Array.prototype.reduce">&#xA7;</a>Array.prototype.reduce</span><script data-source="function () {
 return typeof Array.prototype.reduce == &apos;function&apos;;
   }">test(
 function () {
@@ -1299,7 +1299,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Array.prototype.reduceRight"><span><a class="anchor" href="#Array.prototype.reduceRight">&#xA7;</a>Array.prototype.reduceRight</span><script data-source="function () {
+<tr significance="1"><td id="test-Array.prototype.reduceRight"><span><a class="anchor" href="#Array.prototype.reduceRight">&#xA7;</a>Array.prototype.reduceRight</span><script data-source="function () {
 return typeof Array.prototype.reduceRight == &apos;function&apos;;
   }">test(
 function () {
@@ -1344,7 +1344,7 @@ return typeof Array.prototype.reduceRight == 'function';
 </tr>
 <tr><th colspan="39" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&#xA7;</a>Getter in property initializer</span><script data-source="
+<tr significance="1"><td id="test-Getter_in_property_initializer"><span><a class="anchor" href="#Getter_in_property_initializer">&#xA7;</a>Getter in property initializer</span><script data-source="
 return ({ get x(){ return 1 } }).x === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn ({ get x(){ return 1 } }).x === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn ({ get x(){ return 1 } }).x === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -1385,7 +1385,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Setter_in_property_initializer"><span><a class="anchor" href="#Setter_in_property_initializer">&#xA7;</a>Setter in property initializer</span><script data-source="
+<tr significance="1"><td id="test-Setter_in_property_initializer"><span><a class="anchor" href="#Setter_in_property_initializer">&#xA7;</a>Setter in property initializer</span><script data-source="
 var value = 0;
 ({ set x(v){ value = v; } }).x = 1;
 return value === 1;
@@ -1430,7 +1430,7 @@ return value === 1;
 </tr>
 <tr><th colspan="39" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&#xA7;</a>Property access on strings</span><script data-source="function () {
+<tr significance="1"><td id="test-Property_access_on_strings"><span><a class="anchor" href="#Property_access_on_strings">&#xA7;</a>Property access on strings</span><script data-source="function () {
 return &quot;foobar&quot;[3] === &quot;b&quot;;
   }">test(
 function () {
@@ -1473,7 +1473,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
+<tr significance="1"><td id="test-Reserved_words_as_property_names"><span><a class="anchor" href="#Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
 return ({ if: 1 }).if === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn ({ if: 1 }).if === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn ({ if: 1 }).if === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -1516,7 +1516,7 @@ return ({ if: 1 }).if === 1;
 </tr>
 <tr><th colspan="39" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
+<tr significance="1"><td id="test-Zero-width_chars_in_identifiers"><span><a class="anchor" href="#Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
 var _\u200c\u200d = true;
 return _\u200c\u200d;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nvar _\\u200c\\u200d = true;\nreturn _\\u200c\\u200d;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nvar _\\u200c\\u200d = true;\nreturn _\\u200c\\u200d;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -1558,7 +1558,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="parseInt()_ignores_leading_zeros"><span><a class="anchor" href="#parseInt()_ignores_leading_zeros">&#xA7;</a>parseInt() ignores leading zeros</span><script data-source="function () {
+<tr significance="1"><td id="test-parseInt()_ignores_leading_zeros"><span><a class="anchor" href="#parseInt()_ignores_leading_zeros">&#xA7;</a>parseInt() ignores leading zeros</span><script data-source="function () {
 return parseInt(&apos;010&apos;) === 10;
   }">test(
 function () {
@@ -1601,7 +1601,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Immutable_undefined"><span><a class="anchor" href="#Immutable_undefined">&#xA7;</a>Immutable undefined</span><script data-source="
+<tr significance="1"><td id="test-Immutable_undefined"><span><a class="anchor" href="#Immutable_undefined">&#xA7;</a>Immutable undefined</span><script data-source="
 undefined = 12345;
 var result = typeof undefined == &apos;undefined&apos;;
 undefined = void 0;
@@ -1645,7 +1645,7 @@ return result;
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr significance="1"><td id="Strict_mode"><span><a class="anchor" href="#Strict_mode">&#xA7;</a><a href="../strict-mode/">Strict mode</a></span><script data-source="function () {
+<tr significance="1"><td id="test-Strict_mode"><span><a class="anchor" href="#Strict_mode">&#xA7;</a><a href="../strict-mode/">Strict mode</a></span><script data-source="function () {
 &quot;use strict&quot;;
 return !this;
   }">test(

--- a/es6/index.html
+++ b/es6/index.html
@@ -198,7 +198,7 @@
         <!-- TABLE BODY -->
       <tr class="category"><td colspan="62">Optimisation</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0" data-flagged-tally="1">0/2</td>
 <td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/2</td>
@@ -411,7 +411,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 </tr>
 <tr class="category"><td colspan="62">Syntax</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td data-browser="babel" class="tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -952,7 +952,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions">rest parameters</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-rest_parameters"><span><a class="anchor" href="#rest_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions">rest parameters</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
@@ -1357,7 +1357,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
+<tr class="supertest" significance="1"><td id="test-spread_(...)_operator"><span><a class="anchor" href="#spread_(...)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists-runtime-semantics-argumentlistevaluation">spread (...) operator</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">15/15</td>
 <td data-browser="babel" class="tally" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
@@ -2406,7 +2406,7 @@ try {
 <td class="no" data-browser="ios7">No</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-object-initialiser">object literal extensions</a></span></td>
+<tr class="supertest" significance="1"><td id="test-object_literal_extensions"><span><a class="anchor" href="#object_literal_extensions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-object-initialiser">object literal extensions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">6/6</td>
 <td data-browser="babel" class="tally" data-tally="1">6/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="1">6/6</td>
@@ -2868,7 +2868,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="for..of_loops"><span><a class="anchor" href="#for..of_loops">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
+<tr class="supertest" significance="1"><td id="test-for..of_loops"><span><a class="anchor" href="#for..of_loops">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-for-in-and-for-of-statements">for..of loops</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">9/9</td>
 <td data-browser="babel" class="tally" data-tally="1">9/9</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
@@ -3554,7 +3554,7 @@ return closed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-literals-numeric-literals">octal and binary literals</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-octal_and_binary_literals"><span><a class="anchor" href="#octal_and_binary_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-literals-numeric-literals">octal and binary literals</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="babel" class="tally" data-tally="1">4/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3876,7 +3876,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="template_strings"><span><a class="anchor" href="#template_strings">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-template-literals">template strings</a></span></td>
+<tr class="supertest" significance="1"><td id="test-template_strings"><span><a class="anchor" href="#template_strings">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-template-literals">template strings</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
@@ -4287,7 +4287,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-regexp.prototype.sticky">RegExp &quot;y&quot; and &quot;u&quot; flags</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-RegExp_y_and_u_flags"><span><a class="anchor" href="#RegExp_y_and_u_flags">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-regexp.prototype.sticky">RegExp &quot;y&quot; and &quot;u&quot; flags</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
@@ -4614,7 +4614,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-destructuring-assignment">destructuring</a></span></td>
+<tr class="supertest" significance="1"><td id="test-destructuring"><span><a class="anchor" href="#destructuring">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-destructuring-assignment">destructuring</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">30/36</td>
 <td data-browser="babel" class="tally" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)" data-flagged-tally="0.9444444444444444">33/36</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">24/36</td>
@@ -7130,7 +7130,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-literals-string-literals">Unicode code point escapes</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Unicode_code_point_escapes"><span><a class="anchor" href="#Unicode_code_point_escapes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-literals-string-literals">Unicode code point escapes</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -7323,7 +7323,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="new.target"><span><a class="anchor" href="#new.target">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-built-in-function-objects">new.target</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-new.target"><span><a class="anchor" href="#new.target">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-built-in-function-objects">new.target</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="0">0/2</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/2</td>
@@ -7533,7 +7533,7 @@ try {
 </tr>
 <tr class="category"><td colspan="62">Bindings</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="const"><span><a class="anchor" href="#const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)" data-flagged-tally="1">6/8</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
@@ -8143,7 +8143,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="let"><span><a class="anchor" href="#let">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">let</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-let"><span><a class="anchor" href="#let">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">let</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="babel" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="1">8/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
@@ -8900,7 +8900,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr significance="0.25"><td id="block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[13]</sup></a></span><script data-source="
+<tr significance="0.25"><td id="test-block-level_function_declaration"><span><a class="anchor" href="#block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[13]</sup></a></span><script data-source="
 &apos;use strict&apos;;
 function f() { return 1; }
 {
@@ -8972,7 +8972,7 @@ return f() === 1;
 </tr>
 <tr class="category"><td colspan="62">Functions</td>
 </tr>
-<tr class="supertest" significance="1"><td id="arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a></span></td>
+<tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">9/12</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">7/12</td>
@@ -9842,7 +9842,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="class"><span><a class="anchor" href="#class">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions">class</a></span></td>
+<tr class="supertest" significance="1"><td id="test-class"><span><a class="anchor" href="#class">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions">class</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.6956521739130435" style="background-color:hsl(83,55%,50%)">16/23</td>
 <td data-browser="babel" class="tally" data-tally="0.8260869565217391" style="background-color:hsl(99,49%,50%)">19/23</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.6956521739130435" style="background-color:hsl(83,55%,50%)">16/23</td>
@@ -11502,7 +11502,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="super"><span><a class="anchor" href="#super">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-super-keyword">super</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-super"><span><a class="anchor" href="#super">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-super-keyword">super</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -12149,7 +12149,7 @@ return passed;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions">generators</a></span></td>
+<tr class="supertest" significance="1"><td id="test-generators"><span><a class="anchor" href="#generators">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions">generators</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.88" style="background-color:hsl(105,47%,50%)">22/25</td>
 <td data-browser="babel" class="tally" data-tally="0.88" style="background-color:hsl(105,47%,50%)">22/25</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/25</td>
@@ -14105,7 +14105,7 @@ return passed;
 </tr>
 <tr class="category"><td colspan="62">Built-ins</td>
 </tr>
-<tr class="supertest" significance="1"><td id="typed_arrays"><span><a class="anchor" href="#typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a></span></td>
+<tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/46</td>
 <td data-browser="babel" class="tally" data-tally="0">0/46</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/46</td>
@@ -17759,7 +17759,7 @@ typeof Float64Array[object Object] === "function";
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">Map</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Map"><span><a class="anchor" href="#Map">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">Map</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.7222222222222222" style="background-color:hsl(86,54%,50%)">13/18</td>
 <td data-browser="babel" class="tally" data-tally="1">18/18</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/18</td>
@@ -19048,7 +19048,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-set-objects">Set</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Set"><span><a class="anchor" href="#Set">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-set-objects">Set</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.7222222222222222" style="background-color:hsl(86,54%,50%)">13/18</td>
 <td data-browser="babel" class="tally" data-tally="1">18/18</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/18</td>
@@ -20342,7 +20342,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-weakmap-objects">WeakMap</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-WeakMap"><span><a class="anchor" href="#WeakMap">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-weakmap-objects">WeakMap</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/10</td>
 <td data-browser="babel" class="tally" data-tally="1">10/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/10</td>
@@ -21100,7 +21100,7 @@ return m.has(key);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-weakset-objects">WeakSet</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-WeakSet"><span><a class="anchor" href="#WeakSet">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-weakset-objects">WeakSet</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/9</td>
 <td data-browser="babel" class="tally" data-tally="1">9/9</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/9</td>
@@ -21789,7 +21789,7 @@ return s.has(key);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Proxy"><span><a class="anchor" href="#Proxy">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Proxy"><span><a class="anchor" href="#Proxy">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/21</td>
 <td data-browser="babel" class="tally" data-tally="0">0/21</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/21</td>
@@ -23381,7 +23381,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflection">Reflect</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Reflect"><span><a class="anchor" href="#Reflect">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflection">Reflect</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/17</td>
 <td data-browser="babel" class="tally" data-tally="0.8823529411764706" style="background-color:hsl(105,47%,50%)">15/17</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
@@ -24594,7 +24594,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Promise"><span><a class="anchor" href="#Promise">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td data-browser="babel" class="tally" data-tally="1">7/7</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/7</td>
@@ -25195,7 +25195,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-symbol-constructor">Symbol</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Symbol"><span><a class="anchor" href="#Symbol">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-symbol-constructor">Symbol</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.3" style="background-color:hsl(36,72%,50%)" data-flagged-tally="0.4">3/10</td>
 <td data-browser="babel" class="tally" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="0.7">6/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/10</td>
@@ -25962,7 +25962,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">well-known symbols</a><a href="#symbol-iterator-functionality-note"><sup>[20]</sup></a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-well-known_symbols"><span><a class="anchor" href="#well-known_symbols">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">well-known symbols</a><a href="#symbol-iterator-functionality-note"><sup>[20]</sup></a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.043478260869565216" style="background-color:hsl(5,84%,50%)">1/23</td>
 <td data-browser="babel" class="tally" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)" data-flagged-tally="0.5652173913043478">12/23</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/23</td>
@@ -27622,7 +27622,7 @@ with (a) {
 </tr>
 <tr class="category"><td colspan="62">Built-in extensions</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="babel" class="tally" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
@@ -27955,7 +27955,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-function_name_property"><span><a class="anchor" href="#function_name_property">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-setfunctionname">function &quot;name&quot; property</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/17</td>
 <td data-browser="babel" class="tally" data-tally="0.5882352941176471" style="background-color:hsl(70,60%,50%)">10/17</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
@@ -29164,7 +29164,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="String_static_methods"><span><a class="anchor" href="#String_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-string-constructor">String static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-String_static_methods"><span><a class="anchor" href="#String_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-string-constructor">String static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">2/2</td>
 <td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/2</td>
@@ -29356,7 +29356,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-String.prototype_methods"><span><a class="anchor" href="#String.prototype_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-string-prototype-object">String.prototype methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td data-browser="babel" class="tally" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/8</td>
@@ -29954,7 +29954,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-RegExp.prototype_properties"><span><a class="anchor" href="#RegExp.prototype_properties">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype">RegExp.prototype properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
 <td data-browser="babel" class="tally" data-tally="1">6/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
@@ -30407,7 +30407,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array_static_methods"><span><a class="anchor" href="#Array_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-array-constructor">Array static methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td data-browser="babel" class="tally" data-tally="1">11/11</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/11</td>
@@ -31207,7 +31207,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array.prototype_methods"><span><a class="anchor" href="#Array.prototype_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-array-prototype-object">Array.prototype methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td data-browser="babel" class="tally" data-tally="1">10/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/10</td>
@@ -31937,7 +31937,7 @@ return true;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Number_properties"><span><a class="anchor" href="#Number_properties">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-isfinite-number">Number properties</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Number_properties"><span><a class="anchor" href="#Number_properties">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-isfinite-number">Number properties</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">7/7</td>
 <td data-browser="babel" class="tally" data-tally="1">7/7</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/7</td>
@@ -32454,7 +32454,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Math_methods"><span><a class="anchor" href="#Math_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-math">Math methods</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Math_methods"><span><a class="anchor" href="#Math_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-math">Math methods</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">17/17</td>
 <td data-browser="babel" class="tally" data-tally="1">17/17</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/17</td>
@@ -33626,7 +33626,7 @@ return Math.hypot() === 0 &amp;&amp;
 </tr>
 <tr class="category"><td colspan="62">Subclassing</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Array_is_subclassable"><span><a class="anchor" href="#Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="babel" class="tally" data-tally="0">0/11</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/11</td>
@@ -34429,7 +34429,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp-constructor">RegExp is subclassable</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-RegExp_is_subclassable"><span><a class="anchor" href="#RegExp_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp-constructor">RegExp is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="babel" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
@@ -34759,7 +34759,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-constructor">Function is subclassable</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Function_is_subclassable"><span><a class="anchor" href="#Function_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-constructor">Function is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
 <td data-browser="babel" class="tally" data-tally="0">0/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
@@ -35224,7 +35224,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="Promise_is_subclassable"><span><a class="anchor" href="#Promise_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-constructor">Promise is subclassable</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-Promise_is_subclassable"><span><a class="anchor" href="#Promise_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-function-constructor">Promise is subclassable</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="babel" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
@@ -35600,7 +35600,7 @@ function check() {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-miscellaneous_subclassables"><span><a class="anchor" href="#miscellaneous_subclassables">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boolean-constructor">miscellaneous subclassables</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="babel" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/5</td>
@@ -36016,7 +36016,7 @@ return set instanceof S &amp;&amp; set.has(123);
 </tr>
 <tr class="category"><td colspan="62">Misc</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="prototype_of_bound_functions"><span><a class="anchor" href="#prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/5</td>
 <td data-browser="babel" class="tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/5</td>
@@ -36466,7 +36466,7 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;get&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;get&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;get&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;get&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;get&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;get&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/35</td>
 <td data-browser="babel" class="tally" data-tally="0">0/35</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/35</td>
@@ -39005,7 +39005,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;set&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;set&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;set&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;set&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;set&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;set&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/11</td>
 <td data-browser="babel" class="tally" data-tally="0">0/11</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/11</td>
@@ -39826,7 +39826,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;defineProperty&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;defineProperty&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;defineProperty&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;defineProperty&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;defineProperty&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;defineProperty&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="0">0/2</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/2</td>
@@ -40026,7 +40026,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;deleteProperty&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;deleteProperty&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;deleteProperty&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;deleteProperty&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;deleteProperty&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;deleteProperty&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/6</td>
 <td data-browser="babel" class="tally" data-tally="0">0/6</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/6</td>
@@ -40502,7 +40502,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;getOwnPropertyDescriptor&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;getOwnPropertyDescriptor&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;getOwnPropertyDescriptor&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;getOwnPropertyDescriptor&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;getOwnPropertyDescriptor&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;getOwnPropertyDescriptor&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/4</td>
 <td data-browser="babel" class="tally" data-tally="0">0/4</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/4</td>
@@ -40844,7 +40844,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Proxy,_internal_&apos;ownKeys&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;ownKeys&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;ownKeys&apos; calls</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Proxy,_internal_&apos;ownKeys&apos;_calls"><span><a class="anchor" href="#Proxy,_internal_&apos;ownKeys&apos;_calls">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots">Proxy, internal &apos;ownKeys&apos; calls</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/3</td>
 <td data-browser="babel" class="tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/3</td>
@@ -41113,7 +41113,7 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="Object_static_methods_accept_primitives"><span><a class="anchor" href="#Object_static_methods_accept_primitives">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods accept primitives</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-Object_static_methods_accept_primitives"><span><a class="anchor" href="#Object_static_methods_accept_primitives">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods accept primitives</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/10</td>
 <td data-browser="babel" class="tally" data-tally="1">10/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/10</td>
@@ -41828,7 +41828,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.125"><td id="own_property_order"><span><a class="anchor" href="#own_property_order">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">own property order</a></span></td>
+<tr class="supertest" significance="0.125"><td id="test-own_property_order"><span><a class="anchor" href="#own_property_order">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">own property order</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/8</td>
 <td data-browser="babel" class="tally" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0">0/8</td>
@@ -42550,7 +42550,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-miscellaneous"><span><a class="anchor" href="#miscellaneous">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions">miscellaneous</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td data-browser="babel" class="tally" data-tally="0.4" style="background-color:hsl(48,68%,50%)">4/10</td>
 <td data-browser="es6tr" class="obsolete tally" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
@@ -43293,7 +43293,7 @@ return &quot;&#x10418;&quot;.toLowerCase() === &quot;&#x10440;&quot; &amp;&amp; 
 </tr>
 <tr class="category"><td colspan="62">Annex b</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="non-strict_function_semantics"><span><a class="anchor" href="#non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[28]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[28]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -43575,7 +43575,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[29]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-__proto___in_object_literals"><span><a class="anchor" href="#__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a><a href="#proto-in-object-literals-note"><sup>[29]</sup></a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/5</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
@@ -43979,7 +43979,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype.__proto__"><span><a class="anchor" href="#Object.prototype.__proto__">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-object.prototype.__proto__">Object.prototype.__proto__</a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/6</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/6</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
@@ -44443,7 +44443,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.anchor">String.prototype HTML methods</a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-String.prototype_HTML_methods"><span><a class="anchor" href="#String.prototype_HTML_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.anchor">String.prototype HTML methods</a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/3</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -44720,7 +44720,7 @@ return true;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr significance="0.125" class="optional-feature"><td id="RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
+<tr significance="0.125" class="optional-feature"><td id="test-RegExp.prototype.compile"><span><a class="anchor" href="#RegExp.prototype.compile">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
 return typeof RegExp.prototype.compile === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("642");try{return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("642");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -44785,7 +44785,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="RegExp_syntax_extensions"><span><a class="anchor" href="#RegExp_syntax_extensions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regular-expressions-patterns">RegExp syntax extensions</a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-RegExp_syntax_extensions"><span><a class="anchor" href="#RegExp_syntax_extensions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regular-expressions-patterns">RegExp syntax extensions</a></span></td>
 <td data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/8</td>
 <td data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." class="not-applicable tally" data-tally="0">0/8</td>
 <td data-browser="es6tr" class="obsolete not-applicable tally" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -45373,7 +45373,7 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr significance="0.125" class="optional-feature"><td id="HTML-style_comments"><span><a class="anchor" href="#HTML-style_comments">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-html-like-comments">HTML-style comments</a></span><script data-source="
+<tr significance="0.125" class="optional-feature"><td id="test-HTML-style_comments"><span><a class="anchor" href="#HTML-style_comments">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-html-like-comments">HTML-style comments</a></span><script data-source="
 --&gt; A comment
 &lt;!-- Another comment
 var a = 3; &lt;!-- Another comment

--- a/es7/index.html
+++ b/es7/index.html
@@ -133,7 +133,7 @@
         <!-- TABLE BODY -->
       <tr class="category"><td colspan="33">Candidate</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="exponentiation_(**)_operator"><span><a class="anchor" href="#exponentiation_(**)_operator">&#xA7;</a><a href="https://github.com/rwaldron/exponentiation-operator">exponentiation (**) operator</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#exponentiation_(**)_operator">&#xA7;</a><a href="https://github.com/rwaldron/exponentiation-operator">exponentiation (**) operator</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="babel" class="tally" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -243,7 +243,7 @@ try {
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes">Array.prototype.includes</a></span><script data-source="
+<tr significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes">Array.prototype.includes</a></span><script data-source="
 return [1, 2, 3].includes(1)
   &amp;&amp; ![1, 2, 3].includes(4)
   &amp;&amp; ![1, 2, 3].includes(1, 1)
@@ -283,7 +283,7 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a></span></td>
+<tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/50</td>
 <td data-browser="babel" class="tally" data-tally="0">0/50</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/50</td>
@@ -2116,7 +2116,7 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="String_trimming"><span><a class="anchor" href="#String_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">String trimming</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-String_trimming"><span><a class="anchor" href="#String_trimming">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-string-left-right-trim">String trimming</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -2223,7 +2223,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 </tr>
 <tr class="category"><td colspan="33">Draft</td>
 </tr>
-<tr significance="0.25"><td id="function.sent"><span><a class="anchor" href="#function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
+<tr significance="0.25"><td id="test-function.sent"><span><a class="anchor" href="#function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
 var result;
 function* generator() {
   result = function.sent;
@@ -2265,7 +2265,7 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="Object.values"><span><a class="anchor" href="#Object.values">&#xA7;</a><a href="https://github.com/ljharb/proposal-object-values-entries">Object.values</a></span><script data-source="
+<tr significance="0.25"><td id="test-Object.values"><span><a class="anchor" href="#Object.values">&#xA7;</a><a href="https://github.com/ljharb/proposal-object-values-entries">Object.values</a></span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
 obj.a = &quot;foo&quot;; obj.b = &quot;bar&quot;; obj.c = &quot;baz&quot;;
 var v = Object.values(obj);
@@ -2304,7 +2304,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="Object.entries"><span><a class="anchor" href="#Object.entries">&#xA7;</a><a href="https://github.com/ljharb/proposal-object-values-entries">Object.entries</a></span><script data-source="
+<tr significance="0.25"><td id="test-Object.entries"><span><a class="anchor" href="#Object.entries">&#xA7;</a><a href="https://github.com/ljharb/proposal-object-values-entries">Object.entries</a></span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
 obj.a = &quot;foo&quot;; obj.b = &quot;bar&quot;; obj.c = &quot;baz&quot;;
 var e = Object.entries(obj);
@@ -2347,7 +2347,7 @@ return Array.isArray(e)
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="1"><td id="Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
+<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
 var obj = {x: 1};
 Object.observe(obj, function(changes){
   var data = changes[0];
@@ -2390,7 +2390,7 @@ obj.x = 2;
 <td class="yes" data-browser="android50">Yes</td>
 <td class="yes" data-browser="android51">Yes</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="trailing_commas_in_function_syntax"><span><a class="anchor" href="#trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/tc39-notes/raw/master/es6/2014-09/trailing_comma_proposal.pdf">trailing commas in function syntax</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/tc39-notes/raw/master/es6/2014-09/trailing_comma_proposal.pdf">trailing commas in function syntax</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -2497,7 +2497,7 @@ return Math.min(1,2,3,) === 1;
 </tr>
 <tr class="category"><td colspan="33">Proposal</td>
 </tr>
-<tr class="supertest" significance="1"><td id="async_functions"><span><a class="anchor" href="#async_functions">&#xA7;</a><a href="https://tc39.github.io/ecmascript-asyncawait/">async functions</a></span></td>
+<tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#async_functions">&#xA7;</a><a href="https://tc39.github.io/ecmascript-asyncawait/">async functions</a></span></td>
 <td data-browser="tr" class="tally" data-tally="1">3/3</td>
 <td data-browser="babel" class="tally" data-tally="1">3/3</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/3</td>
@@ -2642,7 +2642,7 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="1"><td id="typed_objects"><span><a class="anchor" href="#typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">typed objects</a></span><script data-source="
+<tr significance="1"><td id="test-typed_objects"><span><a class="anchor" href="#typed_objects">&#xA7;</a><a href="https://github.com/dslomov-chromium/typed-objects-es7">typed objects</a></span><script data-source="
 return typeof StructType === &quot;function&quot;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nreturn typeof StructType === \"function\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof StructType === \"function\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -2678,7 +2678,7 @@ return typeof StructType === &quot;function&quot;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="ArrayBuffer.transfer"><span><a class="anchor" href="#ArrayBuffer.transfer">&#xA7;</a><a href="https://gist.github.com/lukewagner/2735af7eea411e18cf20">ArrayBuffer.transfer</a></span><script data-source="
+<tr significance="0.25"><td id="test-ArrayBuffer.transfer"><span><a class="anchor" href="#ArrayBuffer.transfer">&#xA7;</a><a href="https://gist.github.com/lukewagner/2735af7eea411e18cf20">ArrayBuffer.transfer</a></span><script data-source="
 return typeof ArrayBuffer.transfer === &apos;function&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -2714,7 +2714,7 @@ return typeof ArrayBuffer.transfer === &apos;function&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.5"><td id="class_decorators"><span><a class="anchor" href="#class_decorators">&#xA7;</a><a href="https://github.com/wycats/javascript-decorators">class decorators</a></span><script data-source="
+<tr significance="0.5"><td id="test-class_decorators"><span><a class="anchor" href="#class_decorators">&#xA7;</a><a href="https://github.com/wycats/javascript-decorators">class decorators</a></span><script data-source="
 class A {
   @nonconf
   get B() {}
@@ -2758,7 +2758,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.5"><td id="class_properties"><span><a class="anchor" href="#class_properties">&#xA7;</a><a href="https://github.com/jeffmo/es-class-properties">class properties</a></span><script data-source="
+<tr significance="0.5"><td id="test-class_properties"><span><a class="anchor" href="#class_properties">&#xA7;</a><a href="https://github.com/jeffmo/es-class-properties">class properties</a></span><script data-source="
 class C {
   x = &apos;x&apos;;
   static y = &apos;y&apos;;
@@ -2798,7 +2798,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="object_rest_properties"><span><a class="anchor" href="#object_rest_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object rest properties</a></span><script data-source="
+<tr significance="0.25"><td id="test-object_rest_properties"><span><a class="anchor" href="#object_rest_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object rest properties</a></span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
 return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp; rest.c === 3;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -2835,7 +2835,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.5"><td id="object_spread_properties"><span><a class="anchor" href="#object_spread_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object spread properties</a></span><script data-source="
+<tr significance="0.5"><td id="test-object_spread_properties"><span><a class="anchor" href="#object_spread_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object spread properties</a></span><script data-source="
 var spread = {b: 2, c: 3};
 var O = {a: 1, ...spread};
 return O.a + O.b + O.c === 6;
@@ -2873,7 +2873,7 @@ return O.a + O.b + O.c === 6;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="String_padding"><span><a class="anchor" href="#String_padding">&#xA7;</a><a href="https://github.com/ljharb/proposal-string-pad-left-right">String padding</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-String_padding"><span><a class="anchor" href="#String_padding">&#xA7;</a><a href="https://github.com/ljharb/proposal-string-pad-left-right">String padding</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -2986,7 +2986,7 @@ return &apos;hello&apos;.padRight(10) === &apos;hello     &apos;
 </tr>
 <tr class="category"><td colspan="33">Strawman</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="bind_(::)_operator"><span><a class="anchor" href="#bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td data-browser="tr" class="tally" data-tally="0">0/2</td>
 <td data-browser="babel" class="tally" data-tally="1">2/2</td>
 <td data-browser="jsx" class="tally" data-tally="0">0/2</td>
@@ -3094,7 +3094,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
+<tr significance="0.25"><td id="test-Object.getOwnPropertyDescriptors"><span><a class="anchor" href="#Object.getOwnPropertyDescriptors">&#xA7;</a><a href="https://gist.github.com/WebReflection/9353781">Object.getOwnPropertyDescriptors</a></span><script data-source="
 var object = {a: 1};
 var B = typeof Symbol === &apos;function&apos; ? Symbol(&apos;b&apos;) : &apos;b&apos;;
 object[B] = 2;
@@ -3138,7 +3138,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.125"><td id="Map.prototype.toJSON"><span><a class="anchor" href="#Map.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Map.prototype.toJSON</a></span><script data-source="
+<tr significance="0.125"><td id="test-Map.prototype.toJSON"><span><a class="anchor" href="#Map.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Map.prototype.toJSON</a></span><script data-source="
 var map = new Map();
 map.set(&apos;a&apos;, &apos;b&apos;);
 map.set(&apos;c&apos;, &apos;d&apos;);
@@ -3177,7 +3177,7 @@ return JSON.stringify(map) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quo
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.125"><td id="Set.prototype.toJSON"><span><a class="anchor" href="#Set.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Set.prototype.toJSON</a></span><script data-source="
+<tr significance="0.125"><td id="test-Set.prototype.toJSON"><span><a class="anchor" href="#Set.prototype.toJSON">&#xA7;</a><a href="https://github.com/DavidBruant/Map-Set.prototype.toJSON">Set.prototype.toJSON</a></span><script data-source="
 var set = new Set();
 [1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });
 return JSON.stringify(set) === &apos;[1,2,3]&apos;;
@@ -3215,7 +3215,7 @@ return JSON.stringify(set) === &apos;[1,2,3]&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.25"><td id="String.prototype.at"><span><a class="anchor" href="#String.prototype.at">&#xA7;</a><a href="https://github.com/mathiasbynens/String.prototype.at">String.prototype.at</a></span><script data-source="
+<tr significance="0.25"><td id="test-String.prototype.at"><span><a class="anchor" href="#String.prototype.at">&#xA7;</a><a href="https://github.com/mathiasbynens/String.prototype.at">String.prototype.at</a></span><script data-source="
 return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -3253,7 +3253,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 </tr>
 <tr class="category"><td colspan="33">Pre-strawman</td>
 </tr>
-<tr significance="0.5" class="optional-feature"><td id="array_comprehensions"><span><a class="anchor" href="#array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">array comprehensions</a></span><script data-source="
+<tr significance="0.5" class="optional-feature"><td id="test-array_comprehensions"><span><a class="anchor" href="#array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">array comprehensions</a></span><script data-source="
 return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -3289,7 +3289,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no not-applicable" data-browser="android50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="android51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr significance="0.5" class="optional-feature"><td id="generator_comprehensions"><span><a class="anchor" href="#generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">generator comprehensions</a></span><script data-source="
+<tr significance="0.5" class="optional-feature"><td id="test-generator_comprehensions"><span><a class="anchor" href="#generator_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">generator comprehensions</a></span><script data-source="
 var iterator = (for (a of [1,2]) a + 4);
 var item = iterator.next();
 var passed = item.value === 5 &amp;&amp; item.done === false;
@@ -3332,7 +3332,7 @@ return passed;
 <td class="no not-applicable" data-browser="android50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="android51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr significance="0.5" class="optional-feature"><td id="destructuring_in_comprehensions"><span><a class="anchor" href="#destructuring_in_comprehensions">&#xA7;</a><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=980828">destructuring in comprehensions</a></span><script data-source="
+<tr significance="0.5" class="optional-feature"><td id="test-destructuring_in_comprehensions"><span><a class="anchor" href="#destructuring_in_comprehensions">&#xA7;</a><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=980828">destructuring in comprehensions</a></span><script data-source="
 return [for([a, b] of [[&apos;a&apos;, &apos;b&apos;]])a + b][0] === &apos;ab&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -3368,7 +3368,7 @@ return [for([a, b] of [[&apos;a&apos;, &apos;b&apos;]])a + b][0] === &apos;ab&ap
 <td class="no not-applicable" data-browser="android50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="android51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr significance="0.25" class="optional-feature"><td id="Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="
+<tr significance="0.25" class="optional-feature"><td id="test-Reflect.Realm"><span><a class="anchor" href="#Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="
 var i, names =
   [&quot;eval&quot;, &quot;global&quot;, &quot;intrinsics&quot;, &quot;stdlib&quot;, &quot;directEval&quot;,
   &quot;indirectEval&quot;, &quot;initGlobal&quot;, &quot;nonEval&quot;];
@@ -3417,7 +3417,7 @@ return true;
 <td class="no not-applicable" data-browser="android50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="android51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr significance="0.25" class="optional-feature"><td id="RegExp.escape"><span><a class="anchor" href="#RegExp.escape">&#xA7;</a><a href="https://github.com/benjamingr/RexExp.escape">RegExp.escape</a></span><script data-source="
+<tr significance="0.25" class="optional-feature"><td id="test-RegExp.escape"><span><a class="anchor" href="#RegExp.escape">&#xA7;</a><a href="https://github.com/benjamingr/RexExp.escape">RegExp.escape</a></span><script data-source="
 return RegExp.escape(&apos;Hello, \\^$*+?.()|[]{}!&apos;) === &apos;Hello, \\\\\\^\\$\\*\\+\\?\\.\\(\\)\\|\\[\\]\\{\\}!&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -3455,7 +3455,7 @@ return RegExp.escape(&apos;Hello, \\^$*+?.()|[]{}!&apos;) === &apos;Hello, \\\\\
 </tr>
 <tr class="category"><td colspan="33">Errata</td>
 </tr>
-<tr significance="0.125"><td id="generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">generator functions can&apos;t be used with &quot;new&quot;</a></span><script data-source="
+<tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">generator functions can&apos;t be used with &quot;new&quot;</a></span><script data-source="
 function * generator() {
   yield 3;
 }
@@ -3498,7 +3498,7 @@ try {
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.125"><td id="strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">strict fn w/ non-strict non-simple params is error</a></span><script data-source="
+<tr significance="0.125"><td id="test-strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">strict fn w/ non-strict non-simple params is error</a></span><script data-source="
 function foo(...a){}
 try {
   Function(&quot;function bar(...a){&apos;use strict&apos;;}&quot;)();
@@ -3539,7 +3539,7 @@ try {
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="0.125"><td id="nested_rest_destructuring"><span><a class="anchor" href="#nested_rest_destructuring">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">nested rest destructuring</a></span><script data-source="
+<tr significance="0.125"><td id="test-nested_rest_destructuring"><span><a class="anchor" href="#nested_rest_destructuring">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">nested rest destructuring</a></span><script data-source="
 var [x, ...[y, ...z]] = [1,2,3,4];
 return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -145,7 +145,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="supertest" significance="1"><td id="Intl_object"><span><a class="anchor" href="#Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a></span></td>
+      <tr class="supertest" significance="1"><td id="test-Intl_object"><span><a class="anchor" href="#Intl_object">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-8">Intl object</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/2</td>
 <td data-browser="ie11" class="tally" data-tally="1">2/2</td>
@@ -250,7 +250,7 @@ return Intl.constructor === Object;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Intl.Collator"><span><a class="anchor" href="#Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11" class="tally" data-tally="1">5/5</td>
@@ -496,7 +496,7 @@ try {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Intl.Collator.prototype.compare"><span><a class="anchor" href="#Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/1</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -565,7 +565,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/1</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -634,7 +634,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="NumberFormat"><span><a class="anchor" href="#NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a></span></td>
+<tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/6</td>
 <td data-browser="ie11" class="tally" data-tally="1">6/6</td>
@@ -916,7 +916,7 @@ try {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="DateTimeFormat"><span><a class="anchor" href="#DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a></span></td>
+<tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie10" class="tally" data-tally="0">0/5</td>
 <td data-browser="ie11" class="tally" data-tally="1">5/5</td>
@@ -1162,7 +1162,7 @@ try {
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
-<tr class="supertest" significance="1"><td id="String.prototype.localeCompare"><span><a class="anchor" href="#String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a></span></td>
+<tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1231,7 +1231,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Number.prototype.toLocaleString"><span><a class="anchor" href="#Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1300,7 +1300,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Array.prototype.toLocaleString"><span><a class="anchor" href="#Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1369,7 +1369,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Object.prototype.toLocaleString"><span><a class="anchor" href="#Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1438,7 +1438,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Date.prototype.toLocaleString"><span><a class="anchor" href="#Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1507,7 +1507,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Date.prototype.toLocaleDateString"><span><a class="anchor" href="#Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>
@@ -1576,7 +1576,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="ios7">Yes</td>
 <td class="yes" data-browser="ios8">Yes</td>
 </tr>
-<tr class="supertest" significance="1"><td id="Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a></span></td>
+<tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a></span></td>
 <td data-browser="ie9" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie10" class="tally" data-tally="1">1/1</td>
 <td data-browser="ie11" class="tally" data-tally="1">1/1</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -125,7 +125,7 @@
         </thead>
         <tbody>
           <!-- TABLE BODY -->
-        <tr significance="1"><td id="uneval"><span><a class="anchor" href="#uneval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval</a></span><script data-source="function () {
+        <tr significance="1"><td id="test-uneval"><span><a class="anchor" href="#uneval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval</a></span><script data-source="function () {
 return typeof uneval == &apos;function&apos;;
   }">test(
 function () {
@@ -162,7 +162,7 @@ return typeof uneval == 'function';
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="toSource_method"><span><a class="anchor" href="#toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
+<tr significance="1"><td id="test-toSource_method"><span><a class="anchor" href="#toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
 return &apos;toSource&apos; in Object.prototype
     &amp;&amp; Number   .prototype.hasOwnProperty(&apos;toSource&apos;)
     &amp;&amp; Boolean  .prototype.hasOwnProperty(&apos;toSource&apos;)
@@ -217,7 +217,7 @@ return 'toSource' in Object.prototype
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="function_caller_property"><span><a class="anchor" href="#function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
 return &apos;caller&apos; in (function(){});
   }">test(
 function () {
@@ -254,7 +254,7 @@ return 'caller' in (function(){});
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="function_arity_property"><span><a class="anchor" href="#function_arity_property">&#xA7;</a>function &quot;arity&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="test-function_arity_property"><span><a class="anchor" href="#function_arity_property">&#xA7;</a>function &quot;arity&quot; property</span><script data-source="function () {
 return (function (){}).arity === 0 &amp;&amp;
   (function (x){}).arity === 1 &amp;&amp;
   (function (x, y){}).arity === 2;
@@ -295,7 +295,7 @@ return (function (){}).arity === 0 &&
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="function_arguments_property"><span><a class="anchor" href="#function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property</span><script data-source="function () {
+<tr significance="1"><td id="test-function_arguments_property"><span><a class="anchor" href="#function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property</span><script data-source="function () {
 function f(a, b) {
   return f.arguments &amp;&amp; f.arguments[0] === 1 &amp;&amp; f.arguments[1] === &apos;boo&apos;;
 }
@@ -338,7 +338,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="Function.prototype.isGenerator"><span><a class="anchor" href="#Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></span><script data-source="function () {
+<tr significance="1"><td id="test-Function.prototype.isGenerator"><span><a class="anchor" href="#Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></span><script data-source="function () {
 return typeof Function.prototype.isGenerator == &apos;function&apos;;
   }">test(
 function () {
@@ -377,7 +377,7 @@ return typeof Function.prototype.isGenerator == 'function';
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="__count__"><span><a class="anchor" href="#__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__count__"><span><a class="anchor" href="#__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span><script data-source="function () {
 return typeof ({}).__count__ === &apos;number&apos; &amp;&amp;
   ({ x: 1, y: 2 }).__count__ === 2;
 }">test(
@@ -416,7 +416,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="__parent__"><span><a class="anchor" href="#__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__parent__"><span><a class="anchor" href="#__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></span><script data-source="function () {
 return typeof ({}).__parent__ !== &apos;undefined&apos;;
   }">test(
 function () {
@@ -453,7 +453,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="__noSuchMethod__"><span><a class="anchor" href="#__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__noSuchMethod__"><span><a class="anchor" href="#__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></span><script data-source="function () {
 var o = { }, executed = false;
 o.__noSuchMethod__ = function () { executed = true; }
 try {
@@ -500,7 +500,7 @@ return executed;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="__defineGetter__"><span><a class="anchor" href="#__defineGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__defineGetter__"><span><a class="anchor" href="#__defineGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></span><script data-source="function () {
 return &apos;__defineGetter__&apos; in {};
   }">test(
 function () {
@@ -537,7 +537,7 @@ return '__defineGetter__' in {};
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="__defineSetter__"><span><a class="anchor" href="#__defineSetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__defineSetter__"><span><a class="anchor" href="#__defineSetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></span><script data-source="function () {
 return &apos;__defineSetter__&apos; in {};
   }">test(
 function () {
@@ -574,7 +574,7 @@ return '__defineSetter__' in {};
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="__lookupGetter__"><span><a class="anchor" href="#__lookupGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span><script data-source="
+<tr significance="1"><td id="test-__lookupGetter__"><span><a class="anchor" href="#__lookupGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span><script data-source="
 try {
   var obj = eval(&apos;{ get foo() { return &quot;bar&quot;; } }&apos;);
 }
@@ -618,7 +618,7 @@ return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Array_generics"><span><a class="anchor" href="#Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
+<tr significance="1"><td id="test-Array_generics"><span><a class="anchor" href="#Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
 return typeof Array.slice === &apos;function&apos; &amp;&amp; Array.slice(&apos;abc&apos;).length === 3;
   }">test(
 function () {
@@ -655,7 +655,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="String_generics"><span><a class="anchor" href="#String_generics">&#xA7;</a>String generics</span><script data-source="function () {
+<tr significance="1"><td id="test-String_generics"><span><a class="anchor" href="#String_generics">&#xA7;</a>String generics</span><script data-source="function () {
 return typeof String.slice === &apos;function&apos; &amp;&amp; String.slice(123, 1) === &quot;23&quot;;
   }">test(
 function () {
@@ -694,7 +694,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Array_comprehensions_(right-to-left)"><span><a class="anchor" href="#Array_comprehensions_(right-to-left)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (right-to-left)</a></span><script data-source="
+<tr significance="1"><td id="test-Array_comprehensions_(right-to-left)"><span><a class="anchor" href="#Array_comprehensions_(right-to-left)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (right-to-left)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var a = [i * 2 for (i in obj) if (i !== &quot;foo&quot;)];
 return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
@@ -731,7 +731,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Expression_closures"><span><a class="anchor" href="#Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
+<tr significance="1"><td id="test-Expression_closures"><span><a class="anchor" href="#Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
 return (function(x)x)(1) === 1;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -766,7 +766,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
+<tr significance="1"><td id="test-ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -801,7 +801,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="for_each..in_loops"><span><a class="anchor" href="#for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a></span><script data-source="
+<tr significance="1"><td id="test-for_each..in_loops"><span><a class="anchor" href="#for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a></span><script data-source="
 var str = &apos;&apos;;
 for each (var item in {a: &quot;foo&quot;, b: &quot;bar&quot;, c: &quot;baz&quot;}) {
   str += item;
@@ -840,7 +840,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
+<tr significance="1"><td id="test-Sharp_variables"><span><a class="anchor" href="#Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
 var arr = #1=[1, #1#, 3];
 return arr[1] === arr;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -878,7 +878,7 @@ return arr[1] === arr;
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Iterator"><span><a class="anchor" href="#Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
+<tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
 try {
   var it = Iterator({ foo: 1, bar: 2 });
   var keys = &quot;&quot;;
@@ -939,7 +939,7 @@ catch(e) {
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="__iterator__"><span><a class="anchor" href="#__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
+<tr significance="1"><td id="test-__iterator__"><span><a class="anchor" href="#__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
 try {
   var x = 5;
   var iter = {
@@ -1008,7 +1008,7 @@ catch(e) {
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Generators_(JS_1.8)"><span><a class="anchor" href="#Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="test(function () {
+<tr significance="1"><td id="test-Generators_(JS_1.8)"><span><a class="anchor" href="#Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="test(function () {
 try {
   var g = eval(&apos;(function() { var a = yield &quot;foo&quot;; yield a + &quot;baz&quot;;})&apos;)();
   var passed = g.next() === &quot;foo&quot;;
@@ -1082,7 +1082,7 @@ test(function () {
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Generator_comprehensions_(JS_1.8)"><span><a class="anchor" href="#Generator_comprehensions_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8)</a></span><script data-source="
+<tr significance="1"><td id="test-Generator_comprehensions_(JS_1.8)"><span><a class="anchor" href="#Generator_comprehensions_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var g = (i * 2 for (i in obj) if (i !== &quot;foo&quot;));
 return g.next() === 4 &amp;&amp; g.next() === 8;
@@ -1121,7 +1121,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
+<tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
   var re = RegExp(&apos;^ ( \\d+ ) \
                      ( \\w+ ) \
@@ -1172,7 +1172,7 @@ try {
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="RegExp_lastMatch"><span><a class="anchor" href="#RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot;</span><script data-source="function () {
+<tr significance="1"><td id="test-RegExp_lastMatch"><span><a class="anchor" href="#RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot;</span><script data-source="function () {
 var re = /\w/;
 re.exec(&apos;x&apos;);
 return RegExp.lastMatch === &apos;x&apos;;
@@ -1213,7 +1213,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="RegExp.$1-$9"><span><a class="anchor" href="#RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9</span><script data-source="function () {
+<tr significance="1"><td id="test-RegExp.$1-$9"><span><a class="anchor" href="#RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9</span><script data-source="function () {
 for (var i = 1; i &lt; 10; i++) {
   if (!((&apos;$&apos; + i) in RegExp)) return false;
 }
@@ -1256,7 +1256,7 @@ return true;
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
+<tr significance="1"><td id="test-Callable_RegExp"><span><a class="anchor" href="#Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -1291,7 +1291,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
+<tr significance="1"><td id="test-RegExp_named_groups"><span><a class="anchor" href="#RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
@@ -1328,7 +1328,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="String.prototype.trimLeft"><span><a class="anchor" href="#String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
+<tr significance="1"><td id="test-String.prototype.trimLeft"><span><a class="anchor" href="#String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimLeft === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1361,7 +1361,7 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="String.prototype.trimRight"><span><a class="anchor" href="#String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a></span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
+<tr significance="1"><td id="test-String.prototype.trimRight"><span><a class="anchor" href="#String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a></span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimRight === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1394,7 +1394,7 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="String.prototype.quote"><span><a class="anchor" href="#String.prototype.quote">&#xA7;</a>String.prototype.quote</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
+<tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#String.prototype.quote">&#xA7;</a>String.prototype.quote</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1427,7 +1427,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="String.prototype.replace_flags"><span><a class="anchor" href="#String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a></span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
+<tr significance="1"><td id="test-String.prototype.replace_flags"><span><a class="anchor" href="#String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a></span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1462,7 +1462,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Date.prototype.toLocaleFormat"><span><a class="anchor" href="#Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
+<tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1497,7 +1497,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="Object.prototype.watch"><span><a class="anchor" href="#Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
+<tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1530,7 +1530,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Object.prototype.unwatch"><span><a class="anchor" href="#Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a></span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
+<tr significance="1"><td id="test-Object.prototype.unwatch"><span><a class="anchor" href="#Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a></span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1563,7 +1563,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="Object.prototype.eval"><span><a class="anchor" href="#Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a></span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
+<tr significance="1"><td id="test-Object.prototype.eval"><span><a class="anchor" href="#Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a></span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -1598,7 +1598,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
-<tr significance="1"><td id="error_stack"><span><a class="anchor" href="#error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
 try {
   throw new Error;
 } catch (err) {
@@ -1643,7 +1643,7 @@ try {
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
 </tr>
-<tr significance="1"><td id="error_lineNumber"><span><a class="anchor" href="#error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="test-error_lineNumber"><span><a class="anchor" href="#error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a></span><script data-source="function () {
 return &apos;lineNumber&apos; in new Error;
   }">test(
 function () {
@@ -1680,7 +1680,7 @@ return 'lineNumber' in new Error;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="error_columnNumber"><span><a class="anchor" href="#error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="test-error_columnNumber"><span><a class="anchor" href="#error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a></span><script data-source="function () {
 return &apos;columnNumber&apos; in new Error;
   }">test(
 function () {
@@ -1717,7 +1717,7 @@ return 'columnNumber' in new Error;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="error_fileName"><span><a class="anchor" href="#error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="test-error_fileName"><span><a class="anchor" href="#error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a></span><script data-source="function () {
 return &apos;fileName&apos; in new Error;
   }">test(
 function () {
@@ -1754,7 +1754,7 @@ return 'fileName' in new Error;
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
 </tr>
-<tr significance="1"><td id="error_description"><span><a class="anchor" href="#error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
+<tr significance="1"><td id="test-error_description"><span><a class="anchor" href="#error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
 return &apos;description&apos; in new Error;
   }">test(
 function () {


### PR DESCRIPTION
I'm not sure how any of these Symbol tests are marked as "passed" for anyone, since clearly nobody verified them in the browser :-)

Fixes #477.
