### PR TITLE
[ES6] Chrome 47 supports Symbol.toPrimitive

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -9736,6 +9736,7 @@ exports.tests = [
       res: {
         ejs:         true,
         typescript:  typescript.fallthrough,
+        chrome47:    true,
       },
     },
     {

--- a/es6/index.html
+++ b/es6/index.html
@@ -26067,7 +26067,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td data-browser="chrome44" class="obsolete tally" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
 <td data-browser="chrome45" class="tally" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
 <td data-browser="chrome46" class="unstable tally" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
-<td data-browser="chrome47" class="unstable tally" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
+<td data-browser="chrome47" class="unstable tally" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.2608695652173913">4/23</td>
 <td data-browser="safari51" class="obsolete tally" data-tally="0">0/23</td>
 <td data-browser="safari6" class="obsolete tally" data-tally="0">0/23</td>
 <td data-browser="safari7" class="tally" data-tally="0">0/23</td>
@@ -27480,7 +27480,7 @@ return passed === 3;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no" data-browser="chrome45">No</td>
 <td class="no unstable" data-browser="chrome46">No</td>
-<td class="no unstable" data-browser="chrome47">No</td>
+<td class="yes unstable" data-browser="chrome47">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no" data-browser="safari7">No</td>


### PR DESCRIPTION
Tested on Chrome 47.0.2522.0, the latest one on the dev channel as of
2015-10-06
