### PR TITLE
Update WebKit to r191276

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -363,7 +363,7 @@ exports.browsers = {
     short: 'SF 9',
   },
   webkit: {
-    full: 'WebKit r190846',
+    full: 'WebKit r191276',
     short: 'WK',
     unstable: true,
   },
@@ -8001,6 +8001,7 @@ exports.tests = [
         edge12:      true,
         chrome33:    true,
         node4:       true,
+        webkit:      true,
       },
     },
     {
@@ -11235,6 +11236,7 @@ exports.tests = [
         typescript:  typescript.fallthrough,
         chrome43:    strict,
         edge13:      true,
+        webkit:      true,
       },
     },
     {
@@ -11249,6 +11251,7 @@ exports.tests = [
         chrome43:    strict,
         node4:       strict,
         edge13:      true,
+        webkit:      true,
       },
     },
     {
@@ -11275,6 +11278,7 @@ exports.tests = [
         typescript:  typescript.fallthrough,
         chrome43:    strict,
         edge13:      true,
+        webkit:      true,
       },
     },
     {
@@ -11301,6 +11305,7 @@ exports.tests = [
         typescript:  typescript.fallthrough,
         chrome43:    strict,
         edge13:      true,
+        webkit:      true,
       },
     },
   ],

--- a/es6/index.html
+++ b/es6/index.html
@@ -174,7 +174,7 @@
 <th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
 <th class="platform safari71_8 desktop" data-browser="safari71_8"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></a></th>
 <th class="platform safari9 desktop" data-browser="safari9"><a href="#safari9" class="browser-name"><abbr title="Safari">SF 9</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r190846">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r191276">WK</abbr></a></th>
 <th class="platform opera desktop obsolete" data-browser="opera"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr><a href="#khtml-note"><sup>[5]</sup></a></a></th>
 <th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
@@ -25036,7 +25036,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td data-browser="safari7" class="tally" data-tally="0">0/7</td>
 <td data-browser="safari71_8" class="tally" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td data-browser="safari9" class="tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td data-browser="webkit" class="unstable tally" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/7</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/7</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/7</td>
@@ -25197,7 +25197,7 @@ try {
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -35982,7 +35982,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td data-browser="safari7" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari71_8" class="tally" data-tally="0">0/4</td>
 <td data-browser="safari9" class="tally" data-tally="0">0/4</td>
-<td data-browser="webkit" class="unstable tally" data-tally="0">0/4</td>
+<td data-browser="webkit" class="unstable tally" data-tally="1">4/4</td>
 <td data-browser="opera" class="obsolete tally" data-tally="0">0/4</td>
 <td data-browser="konq49" class="tally" data-tally="0">0/4</td>
 <td data-browser="rhino17" class="obsolete tally" data-tally="0">0/4</td>
@@ -36071,7 +36071,7 @@ function check() {
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -36140,7 +36140,7 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -36222,7 +36222,7 @@ function check() {
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -36304,7 +36304,7 @@ function check() {
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>


### PR DESCRIPTION
- Implement `String.prototype.normalize`
- Promise becomes subclassable
- Prohibit calling Promise constructor without "new"
