### PR TITLE
Detach/attach subtests HTML Nodes and click event delegation

### DIFF
--- a/master.css
+++ b/master.css
@@ -155,6 +155,11 @@ table.one-selected td.selected {
     left: 1px;
     top: 1px;
 }
+.supertest.is-open .folddown {
+    -webkit-transform: rotate(90deg);
+    -ms-transform: rotate(90deg);
+    transform: rotate(90deg);
+}
 .subtest td:first-child {
   padding-left: 1.2em;
   font-style: italic;
@@ -162,6 +167,9 @@ table.one-selected td.selected {
 .subtest {
   font-size: 0.8em;
   display:none;
+}
+.js-applied .subtest {
+    display: table-row;
 }
 .subtest td.yes, .subtest td.no, .subtest td.strict {
   border-left: solid 5px #eee;
@@ -287,7 +295,7 @@ td[title] {
 }
 /* for IE compatibility, this must be a separate rule. */
 #show-obsolete[value='on'] ~ table .obsolete,
-#show-unstable[value='on'] ~ table .unstable, {
+#show-unstable[value='on'] ~ table .unstable {
     display: table-cell;
 }
 

--- a/master.js
+++ b/master.js
@@ -82,30 +82,34 @@ $(function() {
     if (subtests.length === 0) {
       return;
     }
+
+    // store and detach subtests
+    tr.data('subtests', subtests);
+    subtests.detach();
+
     // Attach dropdown indicator and onclick to those tests with subtests
     $('<span class="folddown">&#9658;</span>')
       .appendTo(tr.children()[0]);
 
-    tr.on('click', function(event) {
-      if (!$(event.target).is('a')) {
-
-        // toggle manually for perf. reasons
-        // it would be even better to toggle this via higher-level CSS (on a parent)
-        // but current optimization (getting rid of `toggle`)
-        // already brings time from ~500ms to ~15ms
-        // (mostly due to removal of recalc-heavy `css` for each element)
-        // so this is probably sufficient for now
-        subtests.each(function(i, el) {
-          el.style.display = el.style.display === 'table-row' ? 'none' : 'table-row';
-        });
-
-        var deg = subtests[0].style.display === 'table-row' ? '90deg' : '0deg';
-        tr.find(".folddown").css('transform', 'rotate(' + deg + ')');
-      }
-    });
-
     // Also, work out tallies for the current browser's tally features
     tr.each(__updateSupertest);
+  });
+
+  $(document).on('click', 'tr.supertest', function(event) {// click delegation
+    var tr = $(this);
+
+    if (!$(event.target).is('a')) {
+      var subtests = tr.data('subtests');
+
+      // detach/attach subtests
+      if (tr.hasClass('is-open')) {
+        subtests.detach();
+        tr.removeClass('is-open');
+      } else {
+        tr.after(subtests);
+        tr.addClass('is-open');
+      }
+    }
   });
 
 
@@ -419,4 +423,8 @@ $(function() {
     });
     table.insertBefore('#footnotes');
   });
+
+  // global class to reset specific CSS rules
+  // which are applied until JS is not invoked
+  $(document.documentElement).addClass('js-applied')
 });


### PR DESCRIPTION
Instead of CSS show/hide added detach/attach JS mechanism to subtests rows.
Also provided click delegation (instead of adding click even listener to each subtest row now it's one global click listener).

**Results**
Before:
![Alt Text](http://i.imgur.com/9Md65Ct.png)
![Alt Text](http://i.imgur.com/ptgoZFl.png)

After:
![Alt Text](http://i.imgur.com/bI7lo6W.png)
![Alt Text](http://i.imgur.com/7yyVwii.png)
