### PR TITLE
New test for super() invocation in arrow function

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -778,6 +778,29 @@ exports.tests = [
       },
     },
     {
+      name: 'lexical super-constructor binding',
+      exec: function(){/*
+        var received
+
+        class B {
+          constructor (arg) {
+            received = arg
+          }
+        }
+        class C extends B {
+          constructor () {
+            var callSuper = () => super('foo')
+            callSuper()
+          }
+        }
+
+	return new C instanceof C && received === 'foo'
+      */},
+      res: {
+      	/* TBD */
+      },
+    },
+    {
       name: 'lexical "new.target" binding',
       exec: function(){/*
         function C() {


### PR DESCRIPTION
There was already a test for `super.foo()` in arrow function, but not for `super()`.

Firefox Nightly currently supports the former, but not the latter. (In fact, arrow functions are disabled in derived constructors.)
