### PR TITLE
removed Object.observe

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -365,30 +365,6 @@ exports.tests = [
   }
 },
 {
-  name: 'Object.observe',
-  link: 'https://arv.github.io/ecmascript-object-observe/',
-  category: 'draft',
-  significance: 'large',
-  exec: function () {/*
-    var obj = {x: 1};
-    Object.observe(obj, function(changes){
-      var data = changes[0];
-      if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){
-        asyncTestPassed();
-      }
-    });
-    obj.x = 2;
-  */},
-  res: {
-    chrome33:        true,
-    chrome34:        true,
-    chrome35:        true,
-    chrome37:        true,
-    node:            true,
-    iojs:            true,
-  }
-},
-{
   name: 'Array.prototype.includes',
   link: 'https://github.com/tc39/Array.prototype.includes',
   category: 'finished',

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1474,9 +1474,8 @@ exports.tests = [
 {
   name: 'Object.observe',
   link: 'https://arv.github.io/ecmascript-object-observe/',
-  category: 'draft',
   significance: 'large',
-  exec: function () {
+	exec: function () {/*
     var obj = {x: 1};
     Object.observe(obj, function(changes){
       var data = changes[0];
@@ -1485,7 +1484,7 @@ exports.tests = [
       }
     });
     obj.x = 2;
-  },
+  */},
   res: {
     android50: true,
     android51: true,

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1438,6 +1438,30 @@ exports.tests = [
   separator: 'after'
 },
 {
+  name: 'Object.observe',
+  link: 'https://arv.github.io/ecmascript-object-observe/',
+  category: 'draft',
+  significance: 'large',
+  exec: function () {/*
+    var obj = {x: 1};
+    Object.observe(obj, function(changes){
+      var data = changes[0];
+      if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){
+        asyncTestPassed();
+      }
+    });
+    obj.x = 2;
+  */},
+  res: {
+    chrome33:        true,
+    chrome34:        true,
+    chrome35:        true,
+    chrome37:        true,
+    node:            true,
+    iojs:            true,
+  }
+},
+{
   name: 'Object.prototype.watch',
   link: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch',
   exec: function () { return typeof Object.prototype.watch == 'function' },

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -20,6 +20,20 @@ exports.browsers = {
     short: 'io.js',
     platformtype: 'engine',
   },
+	node4:  {
+		full: 'Node.js',
+		family: 'Node.js',
+		short: 'Node<br>4.0',
+		platformtype: 'engine',
+		note_id: 'harmony-flag',
+	},
+	node5:  {
+		full: 'Node.js',
+		family: 'Node.js',
+		short: 'Node<br>5.0',
+		platformtype: 'engine',
+		note_id: 'harmony-flag',
+	},
   firefox3: {
     full: 'Firefox 3',
     short: 'FF 3',
@@ -110,6 +124,12 @@ exports.browsers = {
     short: 'CH 11+,<br>OP 15+',
     obsolete: false
   },
+	chrome33: {
+		full: 'Chrome, Opera',
+		short: 'CH&nbsp;32-33,<br>OP&nbsp;19-20',
+		obsolete: true,
+		note_id: 'experimental-flag',
+	},
   opera10_10: {
     full: 'Opera 10.10',
     short: 'OP 10.10',
@@ -160,6 +180,20 @@ exports.browsers = {
     short: 'Android 4.1+',
     platformtype: 'mobile',
   },
+	android50: {
+		full: 'Android Browser',
+		short: 'AN 5.0',
+		platformtype: 'mobile',
+		equals: 'chrome37',
+		ignore_flagged: true,
+	},
+	android51: {
+		full: 'Android Browser',
+		short: 'AN 5.1',
+		platformtype: 'mobile',
+		equals: 'chrome39',
+		ignore_flagged: true,
+	}
 };
 
 exports.tests = [
@@ -1442,7 +1476,7 @@ exports.tests = [
   link: 'https://arv.github.io/ecmascript-object-observe/',
   category: 'draft',
   significance: 'large',
-  exec: function () {/*
+  exec: function () {
     var obj = {x: 1};
     Object.observe(obj, function(changes){
       var data = changes[0];
@@ -1451,14 +1485,18 @@ exports.tests = [
       }
     });
     obj.x = 2;
-  */},
+  },
   res: {
-    chrome33:        true,
-    chrome34:        true,
-    chrome35:        true,
-    chrome37:        true,
-    node:            true,
-    iojs:            true,
+    android50: true,
+    android51: true,
+    chrome33: true,
+    chrome34: true,
+    chrome35: true,
+    chrome37: true,
+    node: true,
+    node4: true,
+		node5: true,
+    iojs: true,
   }
 },
 {

--- a/es7/index.html
+++ b/es7/index.html
@@ -2950,54 +2950,6 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
-var obj = {x: 1};
-Object.observe(obj, function(changes){
-  var data = changes[0];
-  if(data.name === &apos;x&apos; &amp;&amp; data.type === &apos;update&apos; &amp;&amp; data.oldValue === 1 &amp;&amp; data.object.x === 2){
-    asyncTestPassed();
-  }
-});
-obj.x = 2;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="no" data-browser="tr">No</td>
-<td class="no" data-browser="babel">No</td>
-<td class="no" data-browser="jsx">No</td>
-<td class="no" data-browser="es7shim">No</td>
-<td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
-<td class="no" data-browser="edge13">No</td>
-<td class="no obsolete" data-browser="firefox31">No</td>
-<td class="no obsolete" data-browser="firefox32">No</td>
-<td class="no obsolete" data-browser="firefox34">No</td>
-<td class="no obsolete" data-browser="firefox35">No</td>
-<td class="no obsolete" data-browser="firefox39">No</td>
-<td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
-<td class="no unstable" data-browser="firefox44">No</td>
-<td class="no obsolete" data-browser="chrome30">No</td>
-<td class="yes obsolete" data-browser="chrome33">Yes</td>
-<td class="yes obsolete" data-browser="chrome34">Yes</td>
-<td class="yes obsolete" data-browser="chrome35">Yes</td>
-<td class="yes obsolete" data-browser="chrome37">Yes</td>
-<td class="yes obsolete" data-browser="chrome38">Yes</td>
-<td class="yes obsolete" data-browser="chrome39">Yes</td>
-<td class="yes obsolete" data-browser="chrome40">Yes</td>
-<td class="yes obsolete" data-browser="chrome41">Yes</td>
-<td class="yes obsolete" data-browser="chrome42">Yes</td>
-<td class="yes obsolete" data-browser="chrome43">Yes</td>
-<td class="yes" data-browser="chrome46">Yes</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="yes" data-browser="node">Yes</td>
-<td class="yes obsolete" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="node4">Yes</td>
-<td class="no obsolete" data-browser="android40">No</td>
-<td class="no obsolete" data-browser="android41">No</td>
-<td class="no" data-browser="android44">No</td>
-<td class="yes" data-browser="android50">Yes</td>
-<td class="yes" data-browser="android51">Yes</td>
-</tr>
 <tr significance="0.25"><td id="test-object_rest_properties"><span><a class="anchor" href="#test-object_rest_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object rest properties</a></span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
 return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp; rest.c === 3;

--- a/es7/index.html
+++ b/es7/index.html
@@ -2953,7 +2953,7 @@ return result === &apos;tromple&apos;;
 <tr significance="0.25"><td id="test-object_rest_properties"><span><a class="anchor" href="#test-object_rest_properties">&#xA7;</a><a href="https://github.com/sebmarkbage/ecmascript-rest-spread">object rest properties</a></span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
 return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp; rest.c === 3;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === undefined && rest.b === 2 && rest.c === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -2996,7 +2996,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 var spread = {b: 2, c: 3};
 var O = {a: 1, ...spread};
 return O.a + O.b + O.c === 6;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O.a + O.b + O.c === 6;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O.a + O.b + O.c === 6;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O.a + O.b + O.c === 6;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O.a + O.b + O.c === 6;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3039,7 +3039,7 @@ return O.a + O.b + O.c === 6;
 </tr>
 <tr significance="0.25"><td id="test-ArrayBuffer.transfer"><span><a class="anchor" href="#test-ArrayBuffer.transfer">&#xA7;</a><a href="https://gist.github.com/lukewagner/2735af7eea411e18cf20">ArrayBuffer.transfer</a></span><script data-source="
 return typeof ArrayBuffer.transfer === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof ArrayBuffer.transfer === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -3088,7 +3088,7 @@ function nonconf(target, name, descriptor) {
   return descriptor;
 }
 return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable === false;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3133,7 +3133,7 @@ class C {
   static y = &apos;y&apos;;
 }
 return new C().x + C.y === &apos;xy&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  x = 'x';\n  static y = 'y';\n}\nreturn new C().x + C.y === 'xy';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3182,7 +3182,7 @@ class C {
   }
 }
 return new C().x + C() === &apos;xy&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nclass C {\n  constructor(){\n    this.x = 'x';\n  }\n  call constructor(){\n    return 'y';\n  }\n}\nreturn new C().x + C() === 'xy';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  constructor(){\n    this.x = 'x';\n  }\n  call constructor(){\n    return 'y';\n  }\n}\nreturn new C().x + C() === 'xy';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nclass C {\n  constructor(){\n    this.x = 'x';\n  }\n  call constructor(){\n    return 'y';\n  }\n}\nreturn new C().x + C() === 'xy';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  constructor(){\n    this.x = 'x';\n  }\n  call constructor(){\n    return 'y';\n  }\n}\nreturn new C().x + C() === 'xy';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -3261,7 +3261,7 @@ return new C().x + C() === &apos;xy&apos;;
 </tr>
 <tr class="subtest" data-parent="String_trimming" id="test-String_trimming_String.prototype.trimLeft"><td><span><a class="anchor" href="#test-String_trimming_String.prototype.trimLeft">&#xA7;</a>String.prototype.trimLeft</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3302,7 +3302,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 </tr>
 <tr class="subtest" data-parent="String_trimming" id="test-String_trimming_String.prototype.trimRight"><td><span><a class="anchor" href="#test-String_trimming_String.prototype.trimRight">&#xA7;</a>String.prototype.trimRight</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3385,7 +3385,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 function foo() { this.garply += &quot;foo&quot;; return this; }
 var obj = { garply: &quot;bar&quot; };
 return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply === &quot;barfoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3427,7 +3427,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <tr class="subtest" data-parent="bind_(::)_operator" id="test-bind_(::)_operator_unary_form"><td><span><a class="anchor" href="#test-bind_(::)_operator_unary_form">&#xA7;</a>unary form</span><script data-source="
 var obj = { garply: &quot;bar&quot;, foo: function() { this.garply += &quot;foo&quot;; return this; } };
 return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply === &quot;barfoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3471,7 +3471,7 @@ return do {
   let x = 23;
   x + 19;
 } === 42;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3520,7 +3520,7 @@ var D = Object.getOwnPropertyDescriptors(O);
 return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configurable === true &amp;&amp; D.a.writable === true
   &amp;&amp; D[B].value === 2 &amp;&amp; D[B].enumerable === true &amp;&amp; D[B].configurable === true &amp;&amp; D[B].writable === true
   &amp;&amp; D.c.value === 3 &amp;&amp; D.c.enumerable === false &amp;&amp; D.c.configurable === false &amp;&amp; D.c.writable === false;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n  && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n  && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3564,7 +3564,7 @@ var map = new Map();
 map.set(&apos;a&apos;, &apos;b&apos;);
 map.set(&apos;c&apos;, &apos;d&apos;);
 return JSON.stringify(map) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quot;,&quot;d&quot;]]&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nvar map = new Map();\nmap.set('a', 'b');\nmap.set('c', 'd');\nreturn JSON.stringify(map) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map();\nmap.set('a', 'b');\nmap.set('c', 'd');\nreturn JSON.stringify(map) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nvar map = new Map();\nmap.set('a', 'b');\nmap.set('c', 'd');\nreturn JSON.stringify(map) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map();\nmap.set('a', 'b');\nmap.set('c', 'd');\nreturn JSON.stringify(map) === '[[\"a\",\"b\"],[\"c\",\"d\"]]';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3607,7 +3607,7 @@ return JSON.stringify(map) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quo
 var set = new Set();
 [1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });
 return JSON.stringify(set) === &apos;[1,2,3]&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nvar set = new Set();\n[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });\nreturn JSON.stringify(set) === '[1,2,3]';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set();\n[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });\nreturn JSON.stringify(set) === '[1,2,3]';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nvar set = new Set();\n[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });\nreturn JSON.stringify(set) === '[1,2,3]';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set();\n[1, 2, 3, 2, 1].forEach(function (i) { set.add(i); });\nreturn JSON.stringify(set) === '[1,2,3]';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3648,7 +3648,7 @@ return JSON.stringify(set) === &apos;[1,2,3]&apos;;
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.at"><span><a class="anchor" href="#test-String.prototype.at">&#xA7;</a><a href="https://github.com/mathiasbynens/String.prototype.at">String.prototype.at</a></span><script data-source="
 return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -3691,7 +3691,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 </tr>
 <tr significance="0.5" class="optional-feature"><td id="test-array_comprehensions"><span><a class="anchor" href="#test-array_comprehensions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">array comprehensions</a></span><script data-source="
 return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -3739,7 +3739,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -3780,7 +3780,7 @@ return passed;
 </tr>
 <tr significance="0.5" class="optional-feature"><td id="test-destructuring_in_comprehensions"><span><a class="anchor" href="#test-destructuring_in_comprehensions">&#xA7;</a><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=980828">destructuring in comprehensions</a></span><script data-source="
 return [for([a, b] of [[&apos;a&apos;, &apos;b&apos;]])a + b][0] === &apos;ab&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nreturn [for([a, b] of [['a', 'b']])a + b][0] === 'ab';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -3834,7 +3834,7 @@ for (i = 0; i &lt; names.length; i++) {
   }
 }
 return true;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nvar i, names =\n  [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\",\n  \"indirectEval\", \"initGlobal\", \"nonEval\"];\n\nif (typeof Reflect !== \"object\" || typeof Reflect.Realm !== \"function\"\n    || typeof Reflect.Realm.prototype !== \"object\") {\n  return false;\n}\nfor (i = 0; i < names.length; i++) {\n  if (!(names[i] in Reflect.Realm.prototype)) {\n    return false;\n  }\n}\nreturn true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -3875,7 +3875,7 @@ return true;
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-RegExp.escape"><span><a class="anchor" href="#test-RegExp.escape">&#xA7;</a><a href="https://github.com/benjamingr/RexExp.escape">RegExp.escape</a></span><script data-source="
 return RegExp.escape(&apos;Hello, \\^$*+?.()|[]{}!&apos;) === &apos;Hello, \\\\\\^\\$\\*\\+\\?\\.\\(\\)\\|\\[\\]\\{\\}!&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nreturn RegExp.escape('Hello, \\\\^$*+?.()|[]{}!') === 'Hello, \\\\\\\\\\\\^\\\\$\\\\*\\\\+\\\\?\\\\.\\\\(\\\\)\\\\|\\\\[\\\\]\\\\{\\\\}!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -3925,7 +3925,7 @@ try {
 } catch(e) {
   return true;
 }
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nfunction * generator() {\n  yield 3;\n}\ntry {\n  new generator();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\n  yield 3;\n}\ntry {\n  new generator();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nfunction * generator() {\n  yield 3;\n}\ntry {\n  new generator();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\n  yield 3;\n}\ntry {\n  new generator();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -3971,7 +3971,7 @@ try {
 } catch(e) {
   return true;
 }
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nfunction foo(...a){}\ntry {\n  Function(\"function bar(...a){'use strict';}\")();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(...a){}\ntry {\n  Function(\"function bar(...a){'use strict';}\")();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nfunction foo(...a){}\ntry {\n  Function(\"function bar(...a){'use strict';}\")();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(...a){}\ntry {\n  Function(\"function bar(...a){'use strict';}\")();\n} catch(e) {\n  return true;\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -4013,7 +4013,7 @@ try {
 <tr significance="0.125"><td id="test-nested_rest_destructuring"><span><a class="anchor" href="#test-nested_rest_destructuring">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">nested rest destructuring</a></span><script data-source="
 var [x, ...[y, ...z]] = [1,2,3,4];
 return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="yes" data-browser="babel">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -1497,6 +1497,50 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 </tr>
 <tr><th colspan="33" class="separator"></th>
 </tr>
+<tr class="category"><td colspan="32">Draft</td>
+</tr>
+<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
+var obj = {x: 1};
+Object.observe(obj, function(changes){
+  var data = changes[0];
+  if(data.name === &apos;x&apos; &amp;&amp; data.type === &apos;update&apos; &amp;&amp; data.oldValue === 1 &amp;&amp; data.object.x === 2){
+    asyncTestPassed();
+  }
+});
+obj.x = 2;
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="ie7">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="iojs">Yes</td>
+<td class="no obsolete" data-browser="firefox3">No</td>
+<td class="no obsolete" data-browser="firefox3_5">No</td>
+<td class="no obsolete" data-browser="firefox4">No</td>
+<td class="no obsolete" data-browser="firefox5">No</td>
+<td class="no obsolete" data-browser="firefox7">No</td>
+<td class="no obsolete" data-browser="firefox12">No</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox17">No</td>
+<td class="no obsolete" data-browser="firefox20">No</td>
+<td class="no" data-browser="firefox28">No</td>
+<td class="no obsolete" data-browser="safari3">No</td>
+<td class="no obsolete" data-browser="safari4">No</td>
+<td class="no obsolete" data-browser="safari5">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="no" data-browser="webkit">No</td>
+<td class="no obsolete" data-browser="chrome7">No</td>
+<td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="opera10_10">No</td>
+<td class="no obsolete" data-browser="opera10_50">No</td>
+<td class="no obsolete" data-browser="konq44">No</td>
+<td class="no" data-browser="konq49">No</td>
+<td class="no" data-browser="besen">No</td>
+<td class="no" data-browser="rhino">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no" data-browser="android41">No</td>
+</tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -93,6 +93,8 @@
           <th class="platform ie7 desktop" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7-10">IE 7-10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
 <th class="platform iojs engine" data-browser="iojs"><a href="#iojs" class="browser-name"><abbr title="io.js 1.0.0">io.js</abbr></a></th>
+<th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node<br>4.0</abbr><a href="#harmony-flag-note"><sup>[0]</sup></a></a></th>
+<th class="platform node5 engine" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node<br>5.0</abbr><a href="#harmony-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform firefox3 desktop obsolete" data-browser="firefox3"><a href="#firefox3" class="browser-name"><abbr title="Firefox 3">FF 3</abbr></a></th>
 <th class="platform firefox3_5 desktop obsolete" data-browser="firefox3_5"><a href="#firefox3_5" class="browser-name"><abbr title="Firefox 3.5, Firefox 3.6">FF 3.5, 3.6</abbr></a></th>
 <th class="platform firefox4 desktop obsolete" data-browser="firefox4"><a href="#firefox4" class="browser-name"><abbr title="Firefox 4.0b12pre">FF 4</abbr></a></th>
@@ -111,6 +113,7 @@
 <th class="platform webkit desktop" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit r72487 (Nov 24, 2010)">WebKit</abbr></a></th>
 <th class="platform chrome7 desktop obsolete" data-browser="chrome7"><a href="#chrome7" class="browser-name"><abbr title="Chrome 7 (7.0.517.5), Chrome 8, Chrome 9 (9.0.587.0 dev)">CH 7-10</abbr></a></th>
 <th class="platform chrome11 desktop" data-browser="chrome11"><a href="#chrome11" class="browser-name"><abbr title="Chrome 11+, Opera 15+">CH 11+,<br>OP 15+</abbr></a></th>
+<th class="platform chrome33 desktop obsolete" data-browser="chrome33"><a href="#chrome33" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;32-33,<br>OP&#xA0;19-20</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform opera10_10 desktop obsolete" data-browser="opera10_10"><a href="#opera10_10" class="browser-name"><abbr title="Opera 10.10">OP 10.10</abbr></a></th>
 <th class="platform opera10_50 desktop obsolete" data-browser="opera10_50"><a href="#opera10_50" class="browser-name"><abbr title="Opera 10.50, Opera 10.62 (build 8437), Opera 10.70 (build 9044), Opera 11 (build 1156)">OP 10.50-11.10</abbr></a></th>
 <th class="platform konq44 desktop obsolete" data-browser="konq44"><a href="#konq44" class="browser-name"><abbr title="Konqueror 4.4">Konq 4.4</abbr></a></th>
@@ -120,6 +123,8 @@
 <th class="platform phantom engine" data-browser="phantom"><a href="#phantom" class="browser-name"><abbr title="PhantomJS 1.9.7 AppleWebKit/534.34">Phantom</abbr></a></th>
 <th class="platform android40 mobile obsolete" data-browser="android40"><a href="#android40" class="browser-name"><abbr title="Android Browser">Android 4.0</abbr></a></th>
 <th class="platform android41 mobile" data-browser="android41"><a href="#android41" class="browser-name"><abbr title="Android Browser">Android 4.1+</abbr></a></th>
+<th class="platform android50 mobile" data-browser="android50"><a href="#android50" class="browser-name"><abbr title="Android Browser">AN 5.0</abbr></a></th>
+<th class="platform android51 mobile" data-browser="android51"><a href="#android51" class="browser-name"><abbr title="Android Browser">AN 5.1</abbr></a></th>
 </tr>
 
         </thead>
@@ -134,6 +139,8 @@ return typeof uneval == 'function';
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -152,6 +159,7 @@ return typeof uneval == 'function';
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -161,6 +169,8 @@ return typeof uneval == 'function';
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-toSource_method"><span><a class="anchor" href="#test-toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
 return &apos;toSource&apos; in Object.prototype
@@ -187,6 +197,8 @@ return 'toSource' in Object.prototype
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -205,6 +217,7 @@ return 'toSource' in Object.prototype
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -214,8 +227,10 @@ return 'toSource' in Object.prototype
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
 return &apos;caller&apos; in (function(){});
@@ -226,6 +241,8 @@ return 'caller' in (function(){});
 <td class="yes" data-browser="ie7">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -244,6 +261,7 @@ return 'caller' in (function(){});
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -253,6 +271,8 @@ return 'caller' in (function(){});
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arity_property"><span><a class="anchor" href="#test-function_arity_property">&#xA7;</a>function &quot;arity&quot; property</span><script data-source="function () {
 return (function (){}).arity === 0 &amp;&amp;
@@ -267,6 +287,8 @@ return (function (){}).arity === 0 &&
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -285,6 +307,7 @@ return (function (){}).arity === 0 &&
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -294,6 +317,8 @@ return (function (){}).arity === 0 &&
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arguments_property"><span><a class="anchor" href="#test-function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property</span><script data-source="function () {
 function f(a, b) {
@@ -310,6 +335,8 @@ return f(1, 'boo');
 <td class="yes" data-browser="ie7">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -328,6 +355,7 @@ return f(1, 'boo');
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -337,6 +365,8 @@ return f(1, 'boo');
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Function.prototype.isGenerator"><span><a class="anchor" href="#test-Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a></span><script data-source="function () {
 return typeof Function.prototype.isGenerator == &apos;function&apos;;
@@ -347,6 +377,8 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -365,6 +397,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -374,8 +407,10 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-__count__"><span><a class="anchor" href="#test-__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a></span><script data-source="function () {
 return typeof ({}).__count__ === &apos;number&apos; &amp;&amp;
@@ -388,6 +423,8 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -406,6 +443,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -415,6 +453,8 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__parent__"><span><a class="anchor" href="#test-__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a></span><script data-source="function () {
 return typeof ({}).__parent__ !== &apos;undefined&apos;;
@@ -425,6 +465,8 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -443,6 +485,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -452,6 +495,8 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__noSuchMethod__"><span><a class="anchor" href="#test-__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a></span><script data-source="function () {
 var o = { }, executed = false;
@@ -472,6 +517,8 @@ return executed;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -490,6 +537,7 @@ return executed;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -499,6 +547,8 @@ return executed;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__defineGetter__"><span><a class="anchor" href="#test-__defineGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineGetter">__defineGetter__</a></span><script data-source="function () {
 return &apos;__defineGetter__&apos; in {};
@@ -509,6 +559,8 @@ return '__defineGetter__' in {};
 <td class="no" data-browser="ie7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -527,6 +579,7 @@ return '__defineGetter__' in {};
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -536,6 +589,8 @@ return '__defineGetter__' in {};
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__defineSetter__"><span><a class="anchor" href="#test-__defineSetter__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineSetter">__defineSetter__</a></span><script data-source="function () {
 return &apos;__defineSetter__&apos; in {};
@@ -546,6 +601,8 @@ return '__defineSetter__' in {};
 <td class="no" data-browser="ie7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -564,6 +621,7 @@ return '__defineSetter__' in {};
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -573,6 +631,8 @@ return '__defineSetter__' in {};
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__lookupGetter__"><span><a class="anchor" href="#test-__lookupGetter__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__">__lookupGetter__</a></span><script data-source="
 try {
@@ -588,6 +648,8 @@ return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot
 <td class="no" data-browser="ie7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -606,6 +668,7 @@ return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -615,8 +678,10 @@ return typeof func === &quot;function&quot; &amp;&amp; func() === &quot;bar&quot
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_generics"><span><a class="anchor" href="#test-Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
 return typeof Array.slice === &apos;function&apos; &amp;&amp; Array.slice(&apos;abc&apos;).length === 3;
@@ -627,6 +692,8 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -645,6 +712,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -654,6 +722,8 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-String_generics"><span><a class="anchor" href="#test-String_generics">&#xA7;</a>String generics</span><script data-source="function () {
 return typeof String.slice === &apos;function&apos; &amp;&amp; String.slice(123, 1) === &quot;23&quot;;
@@ -664,6 +734,8 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -682,6 +754,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -691,8 +764,10 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(right-to-left)"><span><a class="anchor" href="#test-Array_comprehensions_(right-to-left)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (right-to-left)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -703,6 +778,8 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -721,6 +798,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -730,6 +808,8 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Expression_closures"><span><a class="anchor" href="#test-Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
 return (function(x)x)(1) === 1;
@@ -738,6 +818,8 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -756,6 +838,7 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -765,6 +848,8 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#test-ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
@@ -773,6 +858,8 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -791,6 +878,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -800,6 +888,8 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-for_each..in_loops"><span><a class="anchor" href="#test-for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a></span><script data-source="
 var str = &apos;&apos;;
@@ -812,6 +902,8 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -830,6 +922,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -839,6 +932,8 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Sharp_variables"><span><a class="anchor" href="#test-Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
 var arr = #1=[1, #1#, 3];
@@ -848,6 +943,8 @@ return arr[1] === arr;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -866,6 +963,7 @@ return arr[1] === arr;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td data-browser="opera10_10" class="obsolete"></td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td data-browser="konq44" class="obsolete"></td>
@@ -875,8 +973,10 @@ return arr[1] === arr;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
 try {
@@ -911,6 +1011,8 @@ catch(e) {
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -929,6 +1031,7 @@ catch(e) {
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -938,6 +1041,8 @@ catch(e) {
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-__iterator__"><span><a class="anchor" href="#test-__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
 try {
@@ -980,6 +1085,8 @@ catch(e) {
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -998,6 +1105,7 @@ catch(e) {
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1007,6 +1115,8 @@ catch(e) {
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Generators_(JS_1.8)"><span><a class="anchor" href="#test-Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="test(function () {
 try {
@@ -1054,6 +1164,8 @@ test(function () {
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1072,6 +1184,7 @@ test(function () {
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1081,6 +1194,8 @@ test(function () {
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Generator_comprehensions_(JS_1.8)"><span><a class="anchor" href="#test-Generator_comprehensions_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1091,6 +1206,8 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1109,6 +1226,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1118,8 +1236,10 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -1144,6 +1264,8 @@ try {
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1162,6 +1284,7 @@ try {
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1171,6 +1294,8 @@ try {
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp_lastMatch"><span><a class="anchor" href="#test-RegExp_lastMatch">&#xA7;</a>RegExp &quot;lastMatch&quot;</span><script data-source="function () {
 var re = /\w/;
@@ -1185,6 +1310,8 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="ie7">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1203,6 +1330,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -1212,6 +1340,8 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp.$1-$9"><span><a class="anchor" href="#test-RegExp.$1-$9">&#xA7;</a>RegExp.$1-$9</span><script data-source="function () {
 for (var i = 1; i &lt; 10; i++) {
@@ -1228,6 +1358,8 @@ return true;
 <td class="yes" data-browser="ie7">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1246,6 +1378,7 @@ return true;
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="yes obsolete" data-browser="konq44">Yes</td>
@@ -1255,6 +1388,8 @@ return true;
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Callable_RegExp"><span><a class="anchor" href="#test-Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
@@ -1263,6 +1398,8 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1281,6 +1418,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="webkit">No</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="yes obsolete" data-browser="opera10_10">Yes</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1290,6 +1428,8 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp_named_groups"><span><a class="anchor" href="#test-RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
@@ -1298,6 +1438,8 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1316,6 +1458,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td data-browser="opera10_10" class="obsolete"></td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td data-browser="konq44" class="obsolete"></td>
@@ -1325,14 +1468,18 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.trimLeft"><span><a class="anchor" href="#test-String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimLeft === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1351,6 +1498,7 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1360,12 +1508,16 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.trimRight"><span><a class="anchor" href="#test-String.prototype.trimRight">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight">String.prototype.trimRight</a></span><script data-source="function () { return typeof String.prototype.trimRight === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimRight === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1384,6 +1536,7 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1393,12 +1546,16 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="yes" data-browser="phantom">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1417,6 +1574,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1426,12 +1584,16 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.replace_flags"><span><a class="anchor" href="#test-String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a></span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1450,6 +1612,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1459,14 +1622,18 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1485,6 +1652,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1494,12 +1662,14 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
-<tr class="category"><td colspan="32">Draft</td>
+<tr class="category"><td colspan="37">Draft</td>
 </tr>
-<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
+<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="function () {
 var obj = {x: 1};
 Object.observe(obj, function(changes){
   var data = changes[0];
@@ -1508,11 +1678,22 @@ Object.observe(obj, function(changes){
   }
 });
 obj.x = 2;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
+  }">test(
+function () {
+var obj = {x: 1};
+Object.observe(obj, function(changes){
+  var data = changes[0];
+  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){
+    asyncTestPassed();
+  }
+});
+obj.x = 2;
+  }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="yes" data-browser="node4">Yes</td>
+<td class="yes" data-browser="node5">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1531,6 +1712,7 @@ obj.x = 2;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="yes obsolete" data-browser="chrome33">Yes</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1540,12 +1722,16 @@ obj.x = 2;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="yes" data-browser="android50">Yes</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1564,6 +1750,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1573,12 +1760,16 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.unwatch"><span><a class="anchor" href="#test-Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a></span><script data-source="function () { return typeof Object.prototype.unwatch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.unwatch == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1597,6 +1788,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1606,12 +1798,16 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.eval"><span><a class="anchor" href="#test-Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a></span><script data-source="function () { return typeof Object.prototype.eval == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.eval == 'function' }())</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1630,6 +1826,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1639,8 +1836,10 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
 try {
@@ -1659,6 +1858,8 @@ try {
 <td class="no" data-browser="ie7">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="iojs">Yes</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1677,6 +1878,7 @@ try {
 <td class="yes" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="chrome7">Yes</td>
 <td class="yes" data-browser="chrome11">Yes</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="yes obsolete" data-browser="opera10_50">Yes</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1686,6 +1888,8 @@ try {
 <td class="no" data-browser="phantom">No</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes" data-browser="android41">Yes</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-error_lineNumber"><span><a class="anchor" href="#test-error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a></span><script data-source="function () {
 return &apos;lineNumber&apos; in new Error;
@@ -1696,6 +1900,8 @@ return 'lineNumber' in new Error;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1714,6 +1920,7 @@ return 'lineNumber' in new Error;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1723,6 +1930,8 @@ return 'lineNumber' in new Error;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-error_columnNumber"><span><a class="anchor" href="#test-error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a></span><script data-source="function () {
 return &apos;columnNumber&apos; in new Error;
@@ -1733,6 +1942,8 @@ return 'columnNumber' in new Error;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1751,6 +1962,7 @@ return 'columnNumber' in new Error;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1760,6 +1972,8 @@ return 'columnNumber' in new Error;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-error_fileName"><span><a class="anchor" href="#test-error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a></span><script data-source="function () {
 return &apos;fileName&apos; in new Error;
@@ -1770,6 +1984,8 @@ return 'fileName' in new Error;
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
@@ -1788,6 +2004,7 @@ return 'fileName' in new Error;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1797,6 +2014,8 @@ return 'fileName' in new Error;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
 <tr significance="1"><td id="test-error_description"><span><a class="anchor" href="#test-error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
 return &apos;description&apos; in new Error;
@@ -1807,6 +2026,8 @@ return 'description' in new Error;
 <td class="yes" data-browser="ie7">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="no" data-browser="iojs">No</td>
+<td class="no" data-browser="node4">No</td>
+<td class="no" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
@@ -1825,6 +2046,7 @@ return 'description' in new Error;
 <td class="no" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="chrome7">No</td>
 <td class="no" data-browser="chrome11">No</td>
+<td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="opera10_10">No</td>
 <td class="no obsolete" data-browser="opera10_50">No</td>
 <td class="no obsolete" data-browser="konq44">No</td>
@@ -1834,8 +2056,10 @@ return 'description' in new Error;
 <td class="no" data-browser="phantom">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no" data-browser="android41">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
 </tr>
-<tr><th colspan="33" class="separator"></th>
+<tr><th colspan="38" class="separator"></th>
 </tr>
 </tbody>
       </table>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -1667,9 +1667,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 </tr>
 <tr><th colspan="38" class="separator"></th>
 </tr>
-<tr class="category"><td colspan="37">Draft</td>
-</tr>
-<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="function () {
+<tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
 var obj = {x: 1};
 Object.observe(obj, function(changes){
   var data = changes[0];
@@ -1678,17 +1676,8 @@ Object.observe(obj, function(changes){
   }
 });
 obj.x = 2;
-  }">test(
-function () {
-var obj = {x: 1};
-Object.observe(obj, function(changes){
-  var data = changes[0];
-  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){
-    asyncTestPassed();
-  }
-});
-obj.x = 2;
-  }())</script></td>
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {x: 1};\nObject.observe(obj, function(changes){\n  var data = changes[0];\n  if(data.name === 'x' && data.type === 'update' && data.oldValue === 1 && data.object.x === 2){\n    asyncTestPassed();\n  }\n});\nobj.x = 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
 <td class="no" data-browser="ie7">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="iojs">Yes</td>


### PR DESCRIPTION
The `Object.observe()` proposal has been withdrawn by its original author, Adam Klein (https://mail.mozilla.org/pipermail/es-discuss/2015-November/044684.html). Therefore I removed it all references from the ES7 table. #680 
