### PR TITLE
Ensure links to specific subtests positioned immediately after a supertest work.

### DIFF
--- a/master.js
+++ b/master.js
@@ -233,8 +233,16 @@ $(function() {
 
     elem.addClass('selected');
 
+    // Trigger `click` event on supertest to open dropdown.
     if (!elem.is('.parent') && elem.is('.subtest:hidden')) {
-      elem.prevUntil('.supertest').prev().click();
+      var supertest = elem.prevUntil('.supertest').prev();
+      // If there are no other subtests before this, `prevUntil`
+      // will return an empty jQuery object. To select the supertest,
+      // we can just select the previous element.
+      if (!supertest.length) {
+        supertest = elem.prev();
+      }
+      supertest.click();
     }
 
     table.addClass('one-selected').insertBefore('#footnotes');


### PR DESCRIPTION
For example try to open the [direct recursion subtest](https://kangax.github.io/compat-table/es6/#test-proper_tail_calls_%28tail_call_optimisation%29_direct_recursion) (the first subtest after the [proper tail calls (tail call optimisation)](https://kangax.github.io/compat-table/es6/#test-proper_tail_calls_%28tail_call_optimisation%29) supertest).
