### PR TITLE
Update WebKit to r194678

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -388,7 +388,7 @@ exports.browsers = {
     short: 'SF 9',
   },
   webkit: {
-    full: 'WebKit r194284',
+    full: 'WebKit r194678',
     short: 'WK',
     unstable: true,
   },
@@ -866,6 +866,7 @@ exports.tests = [
         chrome45:    strict,
         node4:       strict,
         xs6:         true,
+        webkit:      true,
       },
     },
     {
@@ -12629,6 +12630,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        webkit:      true,
       },
     },
     {
@@ -12729,6 +12731,7 @@ exports.tests = [
         ejs:         true,
         chrome45:    strict,
         xs6:         true,
+        webkit:      true,
       }
     },
     {
@@ -12746,6 +12749,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         chrome45:    strict,
+        webkit:      true,
       }
     },
   ],
@@ -12792,6 +12796,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        webkit:      true,
       },
     },
     {
@@ -13085,7 +13090,7 @@ exports.tests = [
       res: {
         typescript:  typescript.fallthrough,
         safari9:     false,
-        webkit:      false,
+        webkit:      true,
         chrome43:    strict,
         node4:       strict,
         edge13:      true,
@@ -13106,7 +13111,7 @@ exports.tests = [
       res: {
         typescript:  typescript.fallthrough,
         safari9:     false,
-        webkit:      false,
+        webkit:      true,
         chrome43:    strict,
         node4:       strict,
         edge13:      true,
@@ -13152,7 +13157,7 @@ exports.tests = [
       res: {
         typescript:  typescript.fallthrough,
         safari9:     false,
-        webkit:      false,
+        webkit:      true,
         chrome43:    strict,
         node4:       strict,
         edge13:      true,
@@ -13176,7 +13181,7 @@ exports.tests = [
       res: {
         typescript:  typescript.fallthrough,
         safari9:     false,
-        webkit:      false,
+        webkit:      true,
         chrome43:    strict,
         node4:       strict,
         edge13:      true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -184,7 +184,7 @@
 <th class="platform safari7 desktop" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
 <th class="platform safari71_8 desktop" data-browser="safari71_8"><a href="#safari71_8" class="browser-name"><abbr title="Safari">SF 7.1,<br>SF 8</abbr></a></th>
 <th class="platform safari9 desktop" data-browser="safari9"><a href="#safari9" class="browser-name"><abbr title="Safari">SF 9</abbr></a></th>
-<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r194284">WK</abbr></a></th>
+<th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="WebKit r194678">WK</abbr></a></th>
 <th class="platform opera desktop obsolete" data-browser="opera"><a href="#opera" class="browser-name"><abbr title="Opera 12.16">OP 12</abbr></a></th>
 <th class="platform konq49 desktop" data-browser="konq49"><a href="#konq49" class="browser-name"><abbr title="Konqueror 4.14">KQ<br>4.14</abbr><a href="#khtml-note"><sup>[4]</sup></a></a></th>
 <th class="platform rhino17 engine obsolete" data-browser="rhino17"><a href="#rhino17" class="browser-name"><abbr title="Rhino 1.7">RH</abbr></a></th>
@@ -12702,7 +12702,7 @@ return f() === 1;
 <td class="tally" data-browser="safari7" data-tally="0">0/13</td>
 <td class="tally" data-browser="safari71_8" data-tally="0">0/13</td>
 <td class="tally" data-browser="safari9" data-tally="0">0/13</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)">11/13</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
 <td class="tally obsolete" data-browser="opera" data-tally="0">0/13</td>
 <td class="tally" data-browser="konq49" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="rhino17" data-tally="0">0/13</td>
@@ -13616,7 +13616,7 @@ return arrow() === &quot;quux&quot;;
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -39959,7 +39959,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="tally" data-browser="safari7" data-tally="0">0/11</td>
 <td class="tally" data-browser="safari71_8" data-tally="0">0/11</td>
 <td class="tally" data-browser="safari9" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">6/11</td>
 <td class="tally obsolete" data-browser="opera" data-tally="0">0/11</td>
 <td class="tally" data-browser="konq49" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="rhino17" data-tally="0">0/11</td>
@@ -40189,7 +40189,7 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -40714,7 +40714,7 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -40788,7 +40788,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -40858,7 +40858,7 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="safari7" data-tally="0">0/4</td>
 <td class="tally" data-browser="safari71_8" data-tally="0">0/4</td>
 <td class="tally" data-browser="safari9" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera" data-tally="0">0/4</td>
 <td class="tally" data-browser="konq49" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino17" data-tally="0">0/4</td>
@@ -41008,7 +41008,7 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -42165,7 +42165,7 @@ function check() {
 <td class="tally" data-browser="safari7" data-tally="0">0/5</td>
 <td class="tally" data-browser="safari71_8" data-tally="0">0/5</td>
 <td class="tally" data-browser="safari9" data-tally="0">0/5</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0">0/5</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="opera" data-tally="0">0/5</td>
 <td class="tally" data-browser="konq49" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="rhino17" data-tally="0">0/5</td>
@@ -42242,7 +42242,7 @@ return c instanceof Boolean
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -42319,7 +42319,7 @@ return c instanceof Number
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -42477,7 +42477,7 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>
@@ -42557,7 +42557,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="safari7">No</td>
 <td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="safari9">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera">No</td>
 <td class="no" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="rhino17">No</td>


### PR DESCRIPTION
- Support arrow function : lexical "super" binding in methods
- Support Array is subclassable : correct prototype chain
- Support Array is subclassable : Array.from
- Support Array is subclassable : Array.of
- Support RegExp is subclassable : correct prototype chain
- Support miscellaneous subclassables : Boolean is subclassable
- Support miscellaneous subclassables : Number is subclassable
- Support miscellaneous subclassables : Map is subclassable
- Support miscellaneous subclassables : Set is subclassable
