### PR TITLE
Intl's resolvedOptions().timeZone results better defined.

### DIFF
--- a/data-esintl.js
+++ b/data-esintl.js
@@ -667,17 +667,17 @@ exports.tests = [
         chrome29: true,
         safari51: null,
         safari6: null,
-        safari7: null,
-        safari71_8: null,
+        safari7: false,
+        safari71_8: false,
         webkit: false,
         node12: true,
         node4: true,
         opera: null,
         android40: null,
-        ios7: null,
-        ios9: null
+        ios7: false,
+        ios9: false
       }
-    } 
+    }
   ],
 },
 {

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -1220,8 +1220,8 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes" data-browser="chrome29">Yes</td>
 <td class="unknown obsolete" data-browser="safari51">?</td>
 <td class="unknown obsolete" data-browser="safari6">?</td>
-<td class="unknown" data-browser="safari7">?</td>
-<td class="unknown" data-browser="safari71_8">?</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
 <td class="no" data-browser="webkit">No</td>
 <td class="unknown obsolete" data-browser="opera">?</td>
 <td class="no obsolete" data-browser="node10">No</td>
@@ -1232,8 +1232,8 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="unknown obsolete" data-browser="android40">?</td>
 <td class="unknown obsolete" data-browser="android41">?</td>
 <td class="yes" data-browser="android44">Yes</td>
-<td class="unknown" data-browser="ios7">?</td>
-<td class="unknown" data-browser="ios8">?</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a></span></td>
 <td class="tally" data-browser="ie9" data-tally="1">1/1</td>


### PR DESCRIPTION
Turned some `?`s into definitive `No`s.
