### PR TITLE
ES7: FF42 obsolete, added FF45

### DIFF
--- a/data-es7.js
+++ b/data-es7.js
@@ -106,6 +106,7 @@ exports.browsers = {
   firefox42: {
     full: 'Firefox',
     short: 'FF 42',
+    obsolete: true,
   },
   firefox43: {
     full: 'Firefox',
@@ -114,6 +115,11 @@ exports.browsers = {
   firefox44: {
     full: 'Firefox',
     short: 'FF 44',
+    unstable: true,
+  },
+  firefox45: {
+    full: 'Firefox',
+    short: 'FF 45',
     unstable: true,
   },
   chrome30: {
@@ -387,6 +393,7 @@ exports.tests = [
     babel:      true,
     es7shim:    true,
     typescript: typescript.corejs,
+    firefox45:  false, // limited to nightly builds atm
   }
 },
 {
@@ -408,6 +415,7 @@ exports.tests = [
     babel:      true,
     es7shim:    true,
     typescript: typescript.corejs,
+    firefox45:  false, // limited to nightly builds atm
   }
 },
 {
@@ -1442,7 +1450,7 @@ exports.tests = [
     },
     {
       name: 'Observable.prototype.forEach',
-      exec: function () {/*        
+      exec: function () {/*
         var o = new Observable(function() { });
         return 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;
       */},

--- a/es7/index.html
+++ b/es7/index.html
@@ -115,9 +115,10 @@
 <th class="platform firefox35 desktop obsolete" data-browser="firefox35"><a href="#firefox35" class="browser-name"><abbr title="Firefox">FF 35</abbr></a></th>
 <th class="platform firefox39 desktop obsolete" data-browser="firefox39"><a href="#firefox39" class="browser-name"><abbr title="Firefox">FF 39</abbr></a></th>
 <th class="platform firefox41 desktop obsolete" data-browser="firefox41"><a href="#firefox41" class="browser-name"><abbr title="Firefox">FF 41</abbr></a></th>
-<th class="platform firefox42 desktop" data-browser="firefox42"><a href="#firefox42" class="browser-name"><abbr title="Firefox">FF 42</abbr></a></th>
+<th class="platform firefox42 desktop obsolete" data-browser="firefox42"><a href="#firefox42" class="browser-name"><abbr title="Firefox">FF 42</abbr></a></th>
 <th class="platform firefox43 desktop" data-browser="firefox43"><a href="#firefox43" class="browser-name"><abbr title="Firefox">FF 43</abbr></a></th>
 <th class="platform firefox44 desktop unstable" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
+<th class="platform firefox45 desktop unstable" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45</abbr></a></th>
 <th class="platform chrome30 desktop obsolete" data-browser="chrome30"><a href="#chrome30" class="browser-name"><abbr title="Chrome">CH 30</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></a></th>
 <th class="platform chrome33 desktop obsolete" data-browser="chrome33"><a href="#chrome33" class="browser-name"><abbr title="Chrome">CH 33</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></a></th>
 <th class="platform chrome34 desktop obsolete" data-browser="chrome34"><a href="#chrome34" class="browser-name"><abbr title="Chrome">CH 34</abbr><a href="#experimental-flag-note"><sup>[1]</sup></a></a></th>
@@ -145,7 +146,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="41">Finished (stage 4)</td>
+      <tr class="category"><td colspan="42">Finished (stage 4)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#test-Array.prototype.includes">&#xA7;</a><a href="https://github.com/tc39/Array.prototype.includes">Array.prototype.includes</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -162,9 +163,10 @@
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox43" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/2</td>
@@ -210,9 +212,10 @@ return [1, 2, 3].includes(1)
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="yes" data-browser="firefox43">Yes</td>
 <td class="yes unstable" data-browser="firefox44">Yes</td>
+<td class="yes unstable" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -258,9 +261,10 @@ return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="yes" data-browser="firefox43">Yes</td>
 <td class="yes unstable" data-browser="firefox44">Yes</td>
+<td class="yes unstable" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -284,7 +288,7 @@ return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="category"><td colspan="41">Candidate (stage 3)</td>
+<tr class="category"><td colspan="42">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="https://github.com/rwaldron/exponentiation-operator">exponentiation (**) operator</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -301,9 +305,10 @@ return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/3</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/3</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/3</td>
@@ -345,9 +350,10 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -389,9 +395,10 @@ var a = 2; a **= 3; return a === 8;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -438,9 +445,10 @@ try {
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -485,9 +493,10 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -536,9 +545,10 @@ return Array.isArray(e)
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -577,9 +587,10 @@ return Array.isArray(e)
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/2</td>
@@ -621,9 +632,10 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -665,9 +677,10 @@ return Math.min(1,2,3,) === 1;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -706,9 +719,10 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/3</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/3</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/3</td>
@@ -752,9 +766,10 @@ return (async function(){
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -798,9 +813,10 @@ return (async function(){
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -842,9 +858,10 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -883,9 +900,10 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/50</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.02" style="background-color:hsl(2,85%,50%)">1/50</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0.02" style="background-color:hsl(2,85%,50%)">1/50</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/50</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/50</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/50</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/50</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/50</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/50</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/50</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/50</td>
@@ -927,9 +945,10 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
 <td class="yes obsolete" data-browser="firefox41">Yes</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -971,9 +990,10 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1015,9 +1035,10 @@ return typeof SIMD.Float64x2 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1059,9 +1080,10 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1103,9 +1125,10 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1147,9 +1170,10 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1191,9 +1215,10 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1235,9 +1260,10 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1279,9 +1305,10 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1323,9 +1350,10 @@ return typeof SIMD.Float32x4.abs === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1367,9 +1395,10 @@ return typeof SIMD.Float32x4.add === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1411,9 +1440,10 @@ return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1455,9 +1485,10 @@ return typeof SIMD.Bool16x8.and === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1499,9 +1530,10 @@ return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1543,9 +1575,10 @@ return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1587,9 +1620,10 @@ return typeof SIMD.Float32x4.check === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1631,9 +1665,10 @@ return typeof SIMD.Float32x4.equal === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1675,9 +1710,10 @@ return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1719,9 +1755,10 @@ return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1763,9 +1800,10 @@ return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1807,9 +1845,10 @@ return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1851,9 +1890,10 @@ return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1895,9 +1935,10 @@ return typeof SIMD.Float32x4.mul === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1939,9 +1980,10 @@ return typeof SIMD.Float32x4.div === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -1983,9 +2025,10 @@ return typeof SIMD.Float32x4.max === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2027,9 +2070,10 @@ return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2071,9 +2115,10 @@ return typeof SIMD.Float32x4.min === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2115,9 +2160,10 @@ return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2159,9 +2205,10 @@ return typeof SIMD.Float32x4.neg === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2203,9 +2250,10 @@ return typeof SIMD.Bool16x8.not === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2247,9 +2295,10 @@ return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2291,9 +2340,10 @@ return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2335,9 +2385,10 @@ return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2379,9 +2430,10 @@ return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2423,9 +2475,10 @@ return typeof SIMD.Float32x4.select === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2467,9 +2520,10 @@ return typeof SIMD.Int16x8.selectBits === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2511,9 +2565,10 @@ return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2555,9 +2610,10 @@ return typeof SIMD.Int32x4.shiftRightLogicalByScalar === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2599,9 +2655,10 @@ return typeof SIMD.Int32x4.shiftRightArithmeticByScalar === &apos;function&apos;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2643,9 +2700,10 @@ return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2687,9 +2745,10 @@ return typeof SIMD.Float32x4.splat === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2731,9 +2790,10 @@ return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2775,9 +2835,10 @@ return typeof SIMD.Float32x4.store === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2819,9 +2880,10 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2863,9 +2925,10 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2907,9 +2970,10 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2951,9 +3015,10 @@ return typeof SIMD.Float32x4.sub === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -2995,9 +3060,10 @@ return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3039,9 +3105,10 @@ return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3083,9 +3150,10 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3124,9 +3192,10 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/2</td>
@@ -3171,9 +3240,10 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3218,9 +3288,10 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3244,7 +3315,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="category"><td colspan="41">Draft (stage 2)</td>
+<tr class="category"><td colspan="42">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-function.sent"><span><a class="anchor" href="#test-function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
 var result;
@@ -3270,9 +3341,10 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3315,9 +3387,10 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3361,9 +3434,10 @@ return O.a + O.b + O.c === 6;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3387,7 +3461,7 @@ return O.a + O.b + O.c === 6;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="category"><td colspan="41">Proposal (stage 1)</td>
+<tr class="category"><td colspan="42">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-ArrayBuffer.transfer"><span><a class="anchor" href="#test-ArrayBuffer.transfer">&#xA7;</a><a href="https://gist.github.com/lukewagner/2735af7eea411e18cf20">ArrayBuffer.transfer</a></span><script data-source="
 return typeof ArrayBuffer.transfer === &apos;function&apos;;
@@ -3407,9 +3481,10 @@ return typeof ArrayBuffer.transfer === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3459,9 +3534,10 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3507,9 +3583,10 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3559,9 +3636,10 @@ return new C().x + C() === &apos;xy&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3600,9 +3678,10 @@ return new C().x + C() === &apos;xy&apos;;
 <td class="tally obsolete" data-browser="firefox35" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="firefox42" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="firefox43" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3644,9 +3723,10 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="firefox35">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
 <td class="yes obsolete" data-browser="firefox41">Yes</td>
-<td class="yes" data-browser="firefox42">Yes</td>
+<td class="yes obsolete" data-browser="firefox42">Yes</td>
 <td class="yes" data-browser="firefox43">Yes</td>
 <td class="yes unstable" data-browser="firefox44">Yes</td>
+<td class="yes unstable" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="chrome30">Yes</td>
 <td class="yes obsolete" data-browser="chrome33">Yes</td>
 <td class="yes obsolete" data-browser="chrome34">Yes</td>
@@ -3688,9 +3768,10 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="firefox35">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
 <td class="yes obsolete" data-browser="firefox41">Yes</td>
-<td class="yes" data-browser="firefox42">Yes</td>
+<td class="yes obsolete" data-browser="firefox42">Yes</td>
 <td class="yes" data-browser="firefox43">Yes</td>
 <td class="yes unstable" data-browser="firefox44">Yes</td>
+<td class="yes unstable" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="chrome30">Yes</td>
 <td class="yes obsolete" data-browser="chrome33">Yes</td>
 <td class="yes obsolete" data-browser="chrome34">Yes</td>
@@ -3732,9 +3813,10 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3776,9 +3858,10 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3821,9 +3904,10 @@ return System.global.__system_global_test__ === 42;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3862,9 +3946,10 @@ return System.global.__system_global_test__ === 42;
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/8</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/8</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/8</td>
@@ -3906,9 +3991,10 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3950,9 +4036,10 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -3994,9 +4081,10 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4046,9 +4134,10 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4072,10 +4161,10 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype.forEach"><td><span><a class="anchor" href="#test-Observable_Observable.prototype.forEach">&#xA7;</a>Observable.prototype.forEach</span><script data-source="        
- var o = new Observable(function() { });
- return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function(e){return true}) instanceof Promise;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","        \n var o = new Observable(function() { });\n return 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"        \n var o = new Observable(function() { });\n return 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+<tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype.forEach"><td><span><a class="anchor" href="#test-Observable_Observable.prototype.forEach">&#xA7;</a>Observable.prototype.forEach</span><script data-source="
+var o = new Observable(function() { });
+return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function(e){return true}) instanceof Promise;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn 'forEach' in Observable.prototype && o.forEach(function(e){return true}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="tr">No</td>
 <td class="no" data-browser="babel">No</td>
@@ -4091,9 +4180,10 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4136,9 +4226,10 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4180,9 +4271,10 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4224,9 +4316,10 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4250,7 +4343,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="category"><td colspan="41">Strawman (stage 0)</td>
+<tr class="category"><td colspan="42">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -4267,9 +4360,10 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/2</td>
@@ -4313,9 +4407,10 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4358,9 +4453,10 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4405,9 +4501,10 @@ return do {
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4457,9 +4554,10 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4504,9 +4602,10 @@ return JSON.stringify(map) === &apos;[[&quot;a&quot;,&quot;b&quot;],[&quot;c&quo
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4550,9 +4649,10 @@ return JSON.stringify(set) === &apos;[1,2,3]&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4594,9 +4694,10 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4638,9 +4739,10 @@ return Error.isError(new TypeError()) &amp;&amp; !Error.isError(Object.create(Ty
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4679,9 +4781,10 @@ return Error.isError(new TypeError()) &amp;&amp; !Error.isError(Object.create(Ty
 <td class="tally obsolete" data-browser="firefox35" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox41" data-tally="0">0/4</td>
-<td class="tally" data-browser="firefox42" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox43" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox44" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="firefox45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome33" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome34" data-tally="0">0/4</td>
@@ -4723,9 +4826,10 @@ return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4767,9 +4871,10 @@ return Math.isubh(0, 4, 1, 1) === 2;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4811,9 +4916,10 @@ return Math.imulh(0xffffffff, 7) === -1;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4855,9 +4961,10 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -4881,7 +4988,7 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 </tr>
-<tr class="category"><td colspan="41">Pre-strawman</td>
+<tr class="category"><td colspan="42">Pre-strawman</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-Reflect.Realm"><span><a class="anchor" href="#test-Reflect.Realm">&#xA7;</a><a href="https://gist.github.com/dherman/7568885">Reflect.Realm</a></span><script data-source="
 var i, names =
@@ -4914,9 +5021,10 @@ return true;
 <td class="no obsolete not-applicable" data-browser="firefox35" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="firefox42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox43" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="chrome30" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="chrome33" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="chrome34" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -4940,7 +5048,7 @@ return true;
 <td class="no not-applicable" data-browser="android50" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="android51" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="41">Errata</td>
+<tr class="category"><td colspan="42">Errata</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">generator functions can&apos;t be used with &quot;new&quot;</a></span><script data-source="
 function * generator() {
@@ -4967,9 +5075,10 @@ try {
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="yes" data-browser="firefox43">Yes</td>
 <td class="yes unstable" data-browser="firefox44">Yes</td>
+<td class="yes unstable" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -5016,9 +5125,10 @@ try {
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>
@@ -5061,9 +5171,10 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="firefox35">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
 <td class="no obsolete" data-browser="firefox41">No</td>
-<td class="no" data-browser="firefox42">No</td>
+<td class="no obsolete" data-browser="firefox42">No</td>
 <td class="no" data-browser="firefox43">No</td>
 <td class="no unstable" data-browser="firefox44">No</td>
+<td class="no unstable" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome33">No</td>
 <td class="no obsolete" data-browser="chrome34">No</td>


### PR DESCRIPTION
FF45 supports `Object.values` and `Object.entries`

As an aside, the calculated score is now 15%, but it shows 14% for "Current browser". Weird.
