### PR TITLE
Chrome 48 moved to stable, Chrome 47 obsolete

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -349,12 +349,12 @@ exports.browsers = {
   chrome47: {
     full: 'Chrome, Opera',
     short: 'CH 47,<br>OP&nbsp;34',
+    obsolete: true,
     note_id: 'experimental-flag',
   },
   chrome48: {
     full: 'Chrome, Opera',
     short: 'CH 48,<br>OP&nbsp;35',
-    unstable: true,
     note_id: 'experimental-flag',
   },
   chrome49: {

--- a/es6/index.html
+++ b/es6/index.html
@@ -176,8 +176,8 @@
 <th class="platform chrome44 desktop obsolete" data-browser="chrome44"><a href="#chrome44" class="browser-name"><abbr title="Chrome, Opera">CH 44,<br>OP&#xA0;31</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform chrome45 desktop obsolete" data-browser="chrome45"><a href="#chrome45" class="browser-name"><abbr title="Chrome, Opera">CH 45,<br>OP&#xA0;32</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform chrome46 desktop obsolete" data-browser="chrome46"><a href="#chrome46" class="browser-name"><abbr title="Chrome, Opera">CH 46,<br>OP&#xA0;33</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
-<th class="platform chrome47 desktop" data-browser="chrome47"><a href="#chrome47" class="browser-name"><abbr title="Chrome, Opera">CH 47,<br>OP&#xA0;34</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
-<th class="platform chrome48 desktop unstable" data-browser="chrome48"><a href="#chrome48" class="browser-name"><abbr title="Chrome, Opera">CH 48,<br>OP&#xA0;35</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
+<th class="platform chrome47 desktop obsolete" data-browser="chrome47"><a href="#chrome47" class="browser-name"><abbr title="Chrome, Opera">CH 47,<br>OP&#xA0;34</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
+<th class="platform chrome48 desktop" data-browser="chrome48"><a href="#chrome48" class="browser-name"><abbr title="Chrome, Opera">CH 48,<br>OP&#xA0;35</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform chrome49 desktop unstable" data-browser="chrome49"><a href="#chrome49" class="browser-name"><abbr title="Chrome, Opera">CH 49,<br>OP&#xA0;36</abbr><a href="#experimental-flag-note"><sup>[0]</sup></a></a></th>
 <th class="platform safari51 desktop obsolete" data-browser="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></a></th>
 <th class="platform safari6 desktop obsolete" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
@@ -252,8 +252,8 @@
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/2</td>
@@ -331,8 +331,8 @@ return (function f(n){
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -417,8 +417,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -489,8 +489,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/7</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/7</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/7</td>
@@ -562,8 +562,8 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -635,8 +635,8 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -708,8 +708,8 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -788,8 +788,8 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -871,8 +871,8 @@ return (function(x = 1) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -949,8 +949,8 @@ return (function(a=function(){
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1024,8 +1024,8 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1094,8 +1094,8 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.8">0/5</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.8">0/5</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="0.8">0/5</td>
-<td class="tally" data-browser="chrome47" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome48" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
@@ -1169,8 +1169,8 @@ return (function (foo, ...args) {
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1242,8 +1242,8 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1323,8 +1323,8 @@ return (function (foo, ...args) {
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1402,8 +1402,8 @@ return (function (...args) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1477,8 +1477,8 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1547,8 +1547,8 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.5333333333333333">0/15</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.5333333333333333">0/15</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">15/15</td>
-<td class="tally" data-browser="chrome47" data-tally="1">15/15</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">15/15</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">15/15</td>
+<td class="tally" data-browser="chrome48" data-tally="1">15/15</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/15</td>
@@ -1620,8 +1620,8 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1693,8 +1693,8 @@ return [...[1, 2, 3]][2] === 3;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1767,8 +1767,8 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1841,8 +1841,8 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1914,8 +1914,8 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -1987,8 +1987,8 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2060,8 +2060,8 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2133,8 +2133,8 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2207,8 +2207,8 @@ return Math.max(...iterable) === 3;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2281,8 +2281,8 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2355,8 +2355,8 @@ return Math.max(...iterable) === 3;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2429,8 +2429,8 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2503,8 +2503,8 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2577,8 +2577,8 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2654,8 +2654,8 @@ try {
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2724,8 +2724,8 @@ try {
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome47" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome48" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
@@ -2798,8 +2798,8 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2872,8 +2872,8 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -2945,8 +2945,8 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3018,8 +3018,8 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3092,8 +3092,8 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3172,8 +3172,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3242,8 +3242,8 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally" data-browser="chrome47" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
+<td class="tally" data-browser="chrome48" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/9</td>
@@ -3317,8 +3317,8 @@ for (var item of arr)
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3394,8 +3394,8 @@ return count === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3470,8 +3470,8 @@ return str === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3546,8 +3546,8 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3624,8 +3624,8 @@ return result === &quot;123&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3702,8 +3702,8 @@ return result === &quot;123&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3780,8 +3780,8 @@ return result === &quot;123&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3858,8 +3858,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -3938,8 +3938,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4008,8 +4008,8 @@ return closed;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome47" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome48" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -4081,8 +4081,8 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4154,8 +4154,8 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4227,8 +4227,8 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4300,8 +4300,8 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4370,8 +4370,8 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome47" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome48" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
@@ -4445,8 +4445,8 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4522,8 +4522,8 @@ return `${a}` === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4606,8 +4606,8 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4681,8 +4681,8 @@ return (function(parts) {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4759,8 +4759,8 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4829,8 +4829,8 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -4904,8 +4904,8 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -4980,8 +4980,8 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5053,8 +5053,8 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5126,8 +5126,8 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5196,8 +5196,8 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/22</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/22</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/22</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/22</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/22</td>
@@ -5270,8 +5270,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5344,8 +5344,8 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5418,8 +5418,8 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5492,8 +5492,8 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5566,8 +5566,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5640,8 +5640,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5714,8 +5714,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5792,8 +5792,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5866,8 +5866,8 @@ return a === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -5940,8 +5940,8 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6016,8 +6016,8 @@ return toFixed === Number.prototype.toFixed
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6090,8 +6090,8 @@ return a === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6171,8 +6171,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6246,8 +6246,8 @@ return grault === &quot;garply&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6320,8 +6320,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6396,8 +6396,8 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6471,8 +6471,8 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6546,8 +6546,8 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6627,8 +6627,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6703,8 +6703,8 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6779,8 +6779,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6861,8 +6861,8 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -6931,8 +6931,8 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/24</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/24</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/24</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/24</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/24</td>
@@ -7006,8 +7006,8 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7081,8 +7081,8 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7156,8 +7156,8 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7231,8 +7231,8 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7306,8 +7306,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7381,8 +7381,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7456,8 +7456,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7535,8 +7535,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7609,8 +7609,8 @@ return ([a, b] = iterable) === iterable;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7684,8 +7684,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7759,8 +7759,8 @@ return a === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7834,8 +7834,8 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7911,8 +7911,8 @@ return toFixed === Number.prototype.toFixed
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -7986,8 +7986,8 @@ return a === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8060,8 +8060,8 @@ return ({a,b} = obj) === obj;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8140,8 +8140,8 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8215,8 +8215,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8297,8 +8297,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8372,8 +8372,8 @@ return grault === &quot;garply&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8449,8 +8449,8 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8526,8 +8526,8 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8601,8 +8601,8 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8676,8 +8676,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8753,8 +8753,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8823,8 +8823,8 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/23</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/23</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/23</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/23</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">22/23</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/23</td>
@@ -8898,8 +8898,8 @@ return function([a, , [b], c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -8973,8 +8973,8 @@ return function([a, , b]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9048,8 +9048,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9123,8 +9123,8 @@ return function([c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9198,8 +9198,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9273,8 +9273,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9348,8 +9348,8 @@ return function([a, b, c]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9426,8 +9426,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9501,8 +9501,8 @@ return function([a,]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9576,8 +9576,8 @@ return function({c, x:d, e}) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9652,8 +9652,8 @@ return function({toFixed}, {slice}) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9727,8 +9727,8 @@ return function({a,}) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9808,8 +9808,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9884,8 +9884,8 @@ return function({ [qux]: grault }) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -9960,8 +9960,8 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10036,8 +10036,8 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10112,8 +10112,8 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10185,8 +10185,8 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10261,8 +10261,8 @@ return function([a, ...b], [c, ...d]) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10336,8 +10336,8 @@ return function ([],{}){
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10413,8 +10413,8 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10491,8 +10491,8 @@ return (function({a=function(){
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10566,8 +10566,8 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10636,8 +10636,8 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome47" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome48" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/2</td>
@@ -10709,8 +10709,8 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10783,8 +10783,8 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -10853,8 +10853,8 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome47" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome48" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/2</td>
@@ -10933,8 +10933,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11015,8 +11015,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11087,8 +11087,8 @@ try {
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
-<td class="tally" data-browser="chrome47" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.625" style="background-color:hsl(75,58%,50%)" data-flagged-tally="1">5/8</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
+<td class="tally" data-browser="chrome48" data-tally="0.625" style="background-color:hsl(75,58%,50%)" data-flagged-tally="1">5/8</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
@@ -11161,8 +11161,8 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -11236,8 +11236,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11314,8 +11314,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11391,8 +11391,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11466,8 +11466,8 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11542,8 +11542,8 @@ return bar === 123;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11621,8 +11621,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11699,8 +11699,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11769,8 +11769,8 @@ return passed;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
-<td class="tally" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">5/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td class="tally" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">5/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
@@ -11843,8 +11843,8 @@ return (foo === 123);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11918,8 +11918,8 @@ return bar === 123;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -11993,8 +11993,8 @@ return baz === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12070,8 +12070,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12154,8 +12154,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12229,8 +12229,8 @@ return (foo === 123);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12305,8 +12305,8 @@ return bar === 123;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12381,8 +12381,8 @@ return baz === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12459,8 +12459,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12544,8 +12544,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12622,8 +12622,8 @@ return f() === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12694,8 +12694,8 @@ return f() === 1;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)" data-flagged-tally="0.8461538461538461">9/13</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.7692307692307693" style="background-color:hsl(92,52%,50%)" data-flagged-tally="0.9230769230769231">10/13</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)" data-flagged-tally="1">11/13</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)" data-flagged-tally="1">11/13</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)" data-flagged-tally="1">11/13</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)" data-flagged-tally="1">11/13</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/13</td>
@@ -12767,8 +12767,8 @@ return (() =&gt; 5)() === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12841,8 +12841,8 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12915,8 +12915,8 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -12990,8 +12990,8 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13065,8 +13065,8 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13140,8 +13140,8 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13214,8 +13214,8 @@ return f(6) === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13289,8 +13289,8 @@ return (() =&gt; {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13364,8 +13364,8 @@ return (() =&gt; {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13438,8 +13438,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13524,8 +13524,8 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13608,8 +13608,8 @@ return arrow() === &quot;quux&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13684,8 +13684,8 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13754,8 +13754,8 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.7391304347826086">0/23</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="1">0/23</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/23</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/23</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/23</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/23</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">23/23</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/23</td>
@@ -13828,8 +13828,8 @@ return typeof C === &quot;function&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13907,8 +13907,8 @@ return C === c1;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -13980,8 +13980,8 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14053,8 +14053,8 @@ return typeof class {} === &quot;function&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14130,8 +14130,8 @@ return C.prototype.constructor === C
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14207,8 +14207,8 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14284,8 +14284,8 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14362,8 +14362,8 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14439,8 +14439,8 @@ return typeof C.method === &quot;function&quot;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14517,8 +14517,8 @@ return typeof C.method === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14596,8 +14596,8 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14675,8 +14675,8 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14754,8 +14754,8 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14833,8 +14833,8 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14911,8 +14911,8 @@ return C === undefined &amp;&amp; M();
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -14990,8 +14990,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15067,8 +15067,8 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15143,8 +15143,8 @@ return (0,C.method)();
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15222,8 +15222,8 @@ catch(e) {
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15298,8 +15298,8 @@ return new C() instanceof B
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15374,8 +15374,8 @@ return new C() instanceof B
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15451,8 +15451,8 @@ return Function.prototype.isPrototypeOf(C)
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15536,8 +15536,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15606,8 +15606,8 @@ return passed;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.875">0/8</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.875">0/8</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="1">0/8</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/8</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/8</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/8</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/8</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/8</td>
@@ -15687,8 +15687,8 @@ return passed;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15766,8 +15766,8 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15846,8 +15846,8 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -15925,8 +15925,8 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16006,8 +16006,8 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16087,8 +16087,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16170,8 +16170,8 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16255,8 +16255,8 @@ return passed;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16325,8 +16325,8 @@ return passed;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.8">19/25</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
-<td class="tally" data-browser="chrome47" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
+<td class="tally" data-browser="chrome48" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.84" style="background-color:hsl(100,49%,50%)">21/25</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/25</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/25</td>
@@ -16408,8 +16408,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16491,8 +16491,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16574,8 +16574,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16655,8 +16655,8 @@ catch (e) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16736,8 +16736,8 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16818,8 +16818,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16901,8 +16901,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -16985,8 +16985,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17068,8 +17068,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17148,8 +17148,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17230,8 +17230,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17312,8 +17312,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17394,8 +17394,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17476,8 +17476,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17560,8 +17560,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17644,8 +17644,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17728,8 +17728,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17813,8 +17813,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17902,8 +17902,8 @@ return closed === &apos;ab&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -17990,8 +17990,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18075,8 +18075,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18160,8 +18160,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18246,8 +18246,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18331,8 +18331,8 @@ return passed;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18417,8 +18417,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -18489,8 +18489,8 @@ return passed;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">23/46</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
-<td class="tally" data-browser="chrome47" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
+<td class="tally" data-browser="chrome48" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">44/46</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.391304347826087" style="background-color:hsl(46,68%,50%)">18/46</td>
@@ -18564,8 +18564,8 @@ return view[0] === -0x80;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -18639,8 +18639,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -18714,8 +18714,8 @@ return view[0] === 0xFF;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -18789,8 +18789,8 @@ return view[0] === -0x8000;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -18864,8 +18864,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -18939,8 +18939,8 @@ return view[0] === -0x80000000;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19014,8 +19014,8 @@ return view[0] === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19089,8 +19089,8 @@ return view[0] === 0.10000000149011612;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19164,8 +19164,8 @@ return view[0] === 0.1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19240,8 +19240,8 @@ return view.getInt8(0) === -0x80;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19316,8 +19316,8 @@ return view.getUint8(0) === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19392,8 +19392,8 @@ return view.getInt16(0) === -0x8000;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19468,8 +19468,8 @@ return view.getUint16(0) === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19544,8 +19544,8 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19620,8 +19620,8 @@ return view.getUint32(0) === 0;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19696,8 +19696,8 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19772,8 +19772,8 @@ return view.getFloat64(0) === 0.1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -19845,8 +19845,8 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -19941,8 +19941,8 @@ return constructors.every(function (constructor) {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20029,8 +20029,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20125,8 +20125,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20206,8 +20206,8 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20287,8 +20287,8 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20368,8 +20368,8 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -20449,8 +20449,8 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20530,8 +20530,8 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20611,8 +20611,8 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20692,8 +20692,8 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20773,8 +20773,8 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20854,8 +20854,8 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -20935,8 +20935,8 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21016,8 +21016,8 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21097,8 +21097,8 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21178,8 +21178,8 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21259,8 +21259,8 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21340,8 +21340,8 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21421,8 +21421,8 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21502,8 +21502,8 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21583,8 +21583,8 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21664,8 +21664,8 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21745,8 +21745,8 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21826,8 +21826,8 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21907,8 +21907,8 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -21988,8 +21988,8 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22069,8 +22069,8 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22150,8 +22150,8 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22220,8 +22220,8 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">15/18</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/18</td>
@@ -22298,8 +22298,8 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22376,8 +22376,8 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22455,8 +22455,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22529,8 +22529,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22612,8 +22612,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22692,8 +22692,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22766,8 +22766,8 @@ return map.set(0, 0) === map;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22845,8 +22845,8 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22923,8 +22923,8 @@ return map.size === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -22996,8 +22996,8 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23069,8 +23069,8 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23142,8 +23142,8 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23215,8 +23215,8 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23288,8 +23288,8 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23361,8 +23361,8 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23434,8 +23434,8 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23517,8 +23517,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23591,8 +23591,8 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23661,8 +23661,8 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">15/18</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/18</td>
@@ -23740,8 +23740,8 @@ return set.has(123);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23817,8 +23817,8 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23896,8 +23896,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -23970,8 +23970,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24053,8 +24053,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24136,8 +24136,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24210,8 +24210,8 @@ return set.add(0) === set;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24289,8 +24289,8 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24369,8 +24369,8 @@ return set.size === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24442,8 +24442,8 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24515,8 +24515,8 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24588,8 +24588,8 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24661,8 +24661,8 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24734,8 +24734,8 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24807,8 +24807,8 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24880,8 +24880,8 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -24963,8 +24963,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25037,8 +25037,8 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25107,8 +25107,8 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
-<td class="tally" data-browser="chrome47" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally" data-browser="chrome48" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
@@ -25185,8 +25185,8 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25263,8 +25263,8 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25342,8 +25342,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25416,8 +25416,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25499,8 +25499,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25575,8 +25575,8 @@ return m.get(f) === 42;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25655,8 +25655,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25730,8 +25730,8 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25803,8 +25803,8 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25883,8 +25883,8 @@ return m.has(key);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -25953,8 +25953,8 @@ return m.has(key);
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/9</td>
@@ -26032,8 +26032,8 @@ return weakset.has(obj1);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26108,8 +26108,8 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26187,8 +26187,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26261,8 +26261,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26344,8 +26344,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26424,8 +26424,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26499,8 +26499,8 @@ return weakset.add(obj) === weakset;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26572,8 +26572,8 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26652,8 +26652,8 @@ return s.has(key);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26722,8 +26722,8 @@ return s.has(key);
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/21</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/21</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/21</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/21</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/21</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/21</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/21</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">21/21</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/21</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/21</td>
@@ -26801,8 +26801,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26880,8 +26880,8 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -26959,8 +26959,8 @@ return proxy.foo === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27040,8 +27040,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27121,8 +27121,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27201,8 +27201,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27281,8 +27281,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27361,8 +27361,8 @@ var proxied = {};
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27447,8 +27447,8 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27532,8 +27532,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27612,8 +27612,8 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27697,8 +27697,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27779,8 +27779,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27862,8 +27862,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -27947,8 +27947,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28029,8 +28029,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28112,8 +28112,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28193,8 +28193,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28274,8 +28274,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28347,8 +28347,8 @@ return Array.isArray(new Proxy([], {}));
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28420,8 +28420,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28490,8 +28490,8 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/17</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/17</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/17</td>
@@ -28563,8 +28563,8 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28638,8 +28638,8 @@ return obj.quux === 654;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28711,8 +28711,8 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28786,8 +28786,8 @@ return !(&quot;bar&quot; in obj);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28862,8 +28862,8 @@ return desc.value === 789 &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -28938,8 +28938,8 @@ return obj.foo === 123 &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29011,8 +29011,8 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29086,8 +29086,8 @@ return obj instanceof Array;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29160,8 +29160,8 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29235,8 +29235,8 @@ return !Object.isExtensible(obj);
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29320,8 +29320,8 @@ return passed === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29397,8 +29397,8 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29478,8 +29478,8 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29551,8 +29551,8 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29626,8 +29626,8 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29703,8 +29703,8 @@ return Reflect.construct(function(a, b, c) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29777,8 +29777,8 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -29847,8 +29847,8 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/7</td>
@@ -29941,8 +29941,8 @@ function check() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30020,8 +30020,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30107,8 +30107,8 @@ function check() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30194,8 +30194,8 @@ function check() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30281,8 +30281,8 @@ function check() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30368,8 +30368,8 @@ function check() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30442,8 +30442,8 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30512,8 +30512,8 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
-<td class="tally" data-browser="chrome47" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">10/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally" data-browser="chrome48" data-tally="1">10/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
@@ -30589,8 +30589,8 @@ return object[symbol] === value;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30662,8 +30662,8 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30747,8 +30747,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30829,8 +30829,8 @@ return passed;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30915,8 +30915,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -30988,8 +30988,8 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31066,8 +31066,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31146,8 +31146,8 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31222,8 +31222,8 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31297,8 +31297,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31367,8 +31367,8 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.13043478260869565" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.21739130434782608">3/23</td>
-<td class="tally" data-browser="chrome47" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.2608695652173913">4/23</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.30434782608695654" style="background-color:hsl(36,72%,50%)">7/23</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.17391304347826086" style="background-color:hsl(20,78%,50%)" data-flagged-tally="0.2608695652173913">4/23</td>
+<td class="tally" data-browser="chrome48" data-tally="0.30434782608695654" style="background-color:hsl(36,72%,50%)">7/23</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.30434782608695654" style="background-color:hsl(36,72%,50%)">7/23</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/23</td>
@@ -31447,8 +31447,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31523,8 +31523,8 @@ return a[0] === b;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31596,8 +31596,8 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31672,8 +31672,8 @@ return (function() {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31745,8 +31745,8 @@ return &quot;species&quot; in Symbol;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31823,8 +31823,8 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31901,8 +31901,8 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -31979,8 +31979,8 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32057,8 +32057,8 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32135,8 +32135,8 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32216,8 +32216,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32293,8 +32293,8 @@ return &apos;&apos;.replace(O) === 42;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32370,8 +32370,8 @@ return &apos;&apos;.search(O) === 42;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32447,8 +32447,8 @@ return &apos;&apos;.split(O) === 42;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32524,8 +32524,8 @@ return &apos;&apos;.match(O) === 42;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32601,8 +32601,8 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32680,8 +32680,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32759,8 +32759,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32838,8 +32838,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32920,8 +32920,8 @@ return passed === 3;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -32995,8 +32995,8 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="no flagged" data-browser="chrome47">Flag</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="no flagged obsolete" data-browser="chrome47">Flag</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33070,8 +33070,8 @@ return Math[s] === &quot;Math&quot;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome45">Flag</td>
 <td class="no flagged obsolete" data-browser="chrome46">Flag</td>
-<td class="no flagged" data-browser="chrome47">Flag</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="no flagged obsolete" data-browser="chrome47">Flag</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33147,8 +33147,8 @@ with (a) {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33219,8 +33219,8 @@ with (a) {
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome47" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome48" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -33293,8 +33293,8 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33368,8 +33368,8 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33449,8 +33449,8 @@ return result[0] === sym
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33522,8 +33522,8 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33592,8 +33592,8 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)" data-flagged-tally="0.5294117647058824">5/17</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)" data-flagged-tally="0.5882352941176471">6/17</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)" data-flagged-tally="0.5882352941176471">6/17</td>
-<td class="tally" data-browser="chrome47" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)" data-flagged-tally="0.5882352941176471">6/17</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)" data-flagged-tally="0.6470588235294118">7/17</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)" data-flagged-tally="0.5882352941176471">6/17</td>
+<td class="tally" data-browser="chrome48" data-tally="0.4117647058823529" style="background-color:hsl(49,67%,50%)" data-flagged-tally="0.6470588235294118">7/17</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.6470588235294118" style="background-color:hsl(77,57%,50%)">11/17</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
@@ -33667,8 +33667,8 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -33741,8 +33741,8 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -33814,8 +33814,8 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -33889,8 +33889,8 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -33964,8 +33964,8 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34041,8 +34041,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34117,8 +34117,8 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34191,8 +34191,8 @@ return o.foo.name === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34265,8 +34265,8 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34346,8 +34346,8 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34422,8 +34422,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34496,8 +34496,8 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34574,8 +34574,8 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34651,8 +34651,8 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34725,8 +34725,8 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34799,8 +34799,8 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34875,8 +34875,8 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -34945,8 +34945,8 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome47" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome48" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/2</td>
@@ -35018,8 +35018,8 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35091,8 +35091,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35161,8 +35161,8 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome47" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome48" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/8</td>
@@ -35234,8 +35234,8 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35309,8 +35309,8 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35383,8 +35383,8 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35457,8 +35457,8 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35531,8 +35531,8 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35605,8 +35605,8 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35678,8 +35678,8 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35761,8 +35761,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35831,8 +35831,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/6</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/6</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
@@ -35904,8 +35904,8 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -35977,8 +35977,8 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36050,8 +36050,8 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36123,8 +36123,8 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36196,8 +36196,8 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36270,8 +36270,8 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36340,8 +36340,8 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/11</td>
@@ -36413,8 +36413,8 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36487,8 +36487,8 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36561,8 +36561,8 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36635,8 +36635,8 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36710,8 +36710,8 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36786,8 +36786,8 @@ return Array.from(iterable, function(e, i) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36862,8 +36862,8 @@ return Array.from(iterable, function(e, i) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -36938,8 +36938,8 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37018,8 +37018,8 @@ return closed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37092,8 +37092,8 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37166,8 +37166,8 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37236,8 +37236,8 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.7">4/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
-<td class="tally" data-browser="chrome47" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td class="tally" data-browser="chrome48" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
@@ -37309,8 +37309,8 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37382,8 +37382,8 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37455,8 +37455,8 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37528,8 +37528,8 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="chrome44">Flag</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37601,8 +37601,8 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37674,8 +37674,8 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome44">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="chrome45">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="chrome46">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
-<td class="no" data-browser="chrome47">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
-<td class="no unstable" data-browser="chrome48">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="chrome47">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
+<td class="no" data-browser="chrome48">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
 <td class="no unstable" data-browser="chrome49">No<a href="#array-prototype-iterator-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37747,8 +37747,8 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37820,8 +37820,8 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37903,8 +37903,8 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -37984,8 +37984,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38054,8 +38054,8 @@ return true;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome47" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome48" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/7</td>
@@ -38127,8 +38127,8 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38200,8 +38200,8 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38273,8 +38273,8 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38346,8 +38346,8 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38419,8 +38419,8 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38492,8 +38492,8 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38565,8 +38565,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38635,8 +38635,8 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">17/17</td>
-<td class="tally" data-browser="chrome47" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">17/17</td>
+<td class="tally" data-browser="chrome48" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/17</td>
@@ -38708,8 +38708,8 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38781,8 +38781,8 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38854,8 +38854,8 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -38927,8 +38927,8 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39000,8 +39000,8 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39073,8 +39073,8 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39146,8 +39146,8 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39219,8 +39219,8 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39292,8 +39292,8 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39365,8 +39365,8 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39438,8 +39438,8 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39511,8 +39511,8 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39584,8 +39584,8 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39657,8 +39657,8 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39730,8 +39730,8 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39803,8 +39803,8 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39879,8 +39879,8 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -39951,8 +39951,8 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.36363636363636365">0/11</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="0.5454545454545454">0/11</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">6/11</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/11</td>
@@ -40029,8 +40029,8 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40106,8 +40106,8 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40181,8 +40181,8 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40255,8 +40255,8 @@ return Array.isArray(new C());
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40330,8 +40330,8 @@ return c.concat(1) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40405,8 +40405,8 @@ return c.filter(Boolean) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40480,8 +40480,8 @@ return c.map(Boolean) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40556,8 +40556,8 @@ return c.slice(1,2) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40632,8 +40632,8 @@ return c.splice(1,2) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40706,8 +40706,8 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40780,8 +40780,8 @@ return C.of(0) instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -40850,8 +40850,8 @@ return C.of(0) instanceof C;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -40925,8 +40925,8 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41000,8 +41000,8 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41075,8 +41075,8 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41150,8 +41150,8 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41220,8 +41220,8 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="0.8333333333333334">0/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="0.8333333333333334">0/6</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
@@ -41295,8 +41295,8 @@ return c() === &apos;foo&apos;;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41370,8 +41370,8 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41446,8 +41446,8 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41521,8 +41521,8 @@ return c.call({bar:1}, 2) === 3;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41596,8 +41596,8 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41671,8 +41671,8 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no flagged unstable" data-browser="chrome48">Flag</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no flagged" data-browser="chrome48">Flag</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41741,8 +41741,8 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -41836,8 +41836,8 @@ function check() {
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41911,8 +41911,8 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -41999,8 +41999,8 @@ function check() {
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42087,8 +42087,8 @@ function check() {
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42157,8 +42157,8 @@ function check() {
 <td class="tally obsolete" data-browser="chrome44" data-tally="0" data-flagged-tally="1">0/5</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0" data-flagged-tally="1">0/5</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0" data-flagged-tally="1">0/5</td>
-<td class="tally" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/5</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0" data-flagged-tally="1">0/5</td>
+<td class="tally" data-browser="chrome48" data-tally="0" data-flagged-tally="1">0/5</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
@@ -42234,8 +42234,8 @@ return c instanceof Boolean
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42311,8 +42311,8 @@ return c instanceof Number
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42390,8 +42390,8 @@ return c instanceof String
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42469,8 +42469,8 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42549,8 +42549,8 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome44">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome45">Strict</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42621,8 +42621,8 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
-<td class="tally" data-browser="chrome47" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
+<td class="tally" data-browser="chrome48" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
@@ -42707,8 +42707,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42793,8 +42793,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42879,8 +42879,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -42965,8 +42965,8 @@ return correctProtoBound(Function.prototype)
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43049,8 +43049,8 @@ return correctProtoBound(function(){})
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome46">Strict</td>
-<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
-<td class="no strict unstable" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
+<td class="no strict obsolete" title="Support for this feature incorrectly requires strict mode." data-browser="chrome47">Strict</td>
+<td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="chrome48">Strict</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43119,8 +43119,8 @@ return correctProtoBound(function(){})
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/35</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/35</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.6" style="background-color:hsl(72,59%,50%)">21/35</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/35</td>
@@ -43196,8 +43196,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43273,8 +43273,8 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43351,8 +43351,8 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43431,8 +43431,8 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43508,8 +43508,8 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43585,8 +43585,8 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43673,8 +43673,8 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43758,8 +43758,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43835,8 +43835,8 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43912,8 +43912,8 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -43989,8 +43989,8 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44066,8 +44066,8 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44144,8 +44144,8 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44223,8 +44223,8 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44300,8 +44300,8 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44377,8 +44377,8 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44456,8 +44456,8 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44535,8 +44535,8 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44612,8 +44612,8 @@ return get + &apos;&apos; === &quot;lastIndex,exec&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44691,8 +44691,8 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44768,8 +44768,8 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44852,8 +44852,8 @@ return get[0] === &quot;constructor&quot;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -44942,8 +44942,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45019,8 +45019,8 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45096,8 +45096,8 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45173,8 +45173,8 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45251,8 +45251,8 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45328,8 +45328,8 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45405,8 +45405,8 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45482,8 +45482,8 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45561,8 +45561,8 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45640,8 +45640,8 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45719,8 +45719,8 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45798,8 +45798,8 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45876,8 +45876,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -45946,8 +45946,8 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/11</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/11</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/11</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/11</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/11</td>
@@ -46023,8 +46023,8 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46100,8 +46100,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46177,8 +46177,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46254,8 +46254,8 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46331,8 +46331,8 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46408,8 +46408,8 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46485,8 +46485,8 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46562,8 +46562,8 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46639,8 +46639,8 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46716,8 +46716,8 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46793,8 +46793,8 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -46863,8 +46863,8 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/2</td>
@@ -46940,8 +46940,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47017,8 +47017,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47087,8 +47087,8 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/6</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/6</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/6</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
@@ -47164,8 +47164,8 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47241,8 +47241,8 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47318,8 +47318,8 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47395,8 +47395,8 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47472,8 +47472,8 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47549,8 +47549,8 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47619,8 +47619,8 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
@@ -47697,8 +47697,8 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47775,8 +47775,8 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47853,8 +47853,8 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -47931,8 +47931,8 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48001,8 +48001,8 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/3</td>
-<td class="tally" data-browser="chrome47" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/3</td>
+<td class="tally" data-browser="chrome48" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/3</td>
@@ -48078,8 +48078,8 @@ return ownKeysCalled === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48155,8 +48155,8 @@ return ownKeysCalled === 1;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48232,8 +48232,8 @@ return ownKeysCalled === 2;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48302,8 +48302,8 @@ return ownKeysCalled === 2;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">10/10</td>
-<td class="tally" data-browser="chrome47" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">10/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">10/10</td>
+<td class="tally" data-browser="chrome48" data-tally="1">10/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
@@ -48375,8 +48375,8 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48448,8 +48448,8 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48523,8 +48523,8 @@ return s.length === 2 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48596,8 +48596,8 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48669,8 +48669,8 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48742,8 +48742,8 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48815,8 +48815,8 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48888,8 +48888,8 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -48961,8 +48961,8 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49035,8 +49035,8 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49105,8 +49105,8 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td class="tally" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
+<td class="tally" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
@@ -49211,8 +49211,8 @@ return result === &quot;012349 DB-1AEFGHIJKLMNOPQRSTUVWXYZC&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49304,8 +49304,8 @@ return Object.keys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNOPQRS
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49397,8 +49397,8 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49495,8 +49495,8 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49589,8 +49589,8 @@ return JSON.stringify(obj) ===
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49670,8 +49670,8 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -49763,8 +49763,8 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49851,8 +49851,8 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -49921,8 +49921,8 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
-<td class="tally" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
+<td class="tally" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9">8/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
@@ -49999,8 +49999,8 @@ try {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50073,8 +50073,8 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50146,8 +50146,8 @@ do {} while (false) return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -50224,8 +50224,8 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no flagged unstable" data-browser="chrome49">Flag</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50301,8 +50301,8 @@ try {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50374,8 +50374,8 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -50447,8 +50447,8 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50533,8 +50533,8 @@ return true;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50614,8 +50614,8 @@ return false;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50687,8 +50687,8 @@ return &quot;&#x10418;&quot;.toLowerCase() === &quot;&#x10440;&quot; &amp;&amp; 
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="no unstable" data-browser="chrome49">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50759,8 +50759,8 @@ return &quot;&#x10418;&quot;.toLowerCase() === &quot;&#x10440;&quot; &amp;&amp; 
 <td class="tally obsolete" data-browser="chrome44" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="chrome47" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="chrome48" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -50846,8 +50846,8 @@ return passed;
 <td class="no obsolete" data-browser="chrome44">No</td>
 <td class="no obsolete" data-browser="chrome45">No</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
-<td class="no" data-browser="chrome47">No</td>
-<td class="no unstable" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no" data-browser="chrome48">No</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -50923,8 +50923,8 @@ return foo() === 2;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51003,8 +51003,8 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51073,8 +51073,8 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome47" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome48" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
@@ -51147,8 +51147,8 @@ return { __proto__ : [] } instanceof Array
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51225,8 +51225,8 @@ catch(e) {
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -51302,8 +51302,8 @@ return !({ [a] : [] } instanceof Array);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -51379,8 +51379,8 @@ return !({ __proto__ } instanceof Array);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -51455,8 +51455,8 @@ return !({ __proto__(){} } instanceof Function);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
@@ -51525,8 +51525,8 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome47" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome48" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="1">6/6</td>
@@ -51599,8 +51599,8 @@ return (new A()).__proto__ === A.prototype;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51674,8 +51674,8 @@ return o instanceof Array;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51749,8 +51749,8 @@ return Object.getPrototypeOf(o) !== p;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51822,8 +51822,8 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51902,8 +51902,8 @@ return (desc
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -51975,8 +51975,8 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52045,8 +52045,8 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome47" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome48" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="1">3/3</td>
@@ -52125,8 +52125,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52205,8 +52205,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52284,8 +52284,8 @@ return true;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52357,8 +52357,8 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52427,8 +52427,8 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome44" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome47" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="chrome48" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome48" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome49" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="1">8/8</td>
@@ -52500,8 +52500,8 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52574,8 +52574,8 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52647,8 +52647,8 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52721,8 +52721,8 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52795,8 +52795,8 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52869,8 +52869,8 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -52943,8 +52943,8 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -53017,8 +53017,8 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>
@@ -53093,8 +53093,8 @@ return a === 3;
 <td class="yes obsolete" data-browser="chrome44">Yes</td>
 <td class="yes obsolete" data-browser="chrome45">Yes</td>
 <td class="yes obsolete" data-browser="chrome46">Yes</td>
-<td class="yes" data-browser="chrome47">Yes</td>
-<td class="yes unstable" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes" data-browser="chrome48">Yes</td>
 <td class="yes unstable" data-browser="chrome49">Yes</td>
 <td class="yes obsolete" data-browser="safari51">Yes</td>
 <td class="yes obsolete" data-browser="safari6">Yes</td>


### PR DESCRIPTION
Chrome 48 has been promoted to stable, making Chrome 47 obsolete.
