### PR TITLE
Make JSX obsolete

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -55,7 +55,7 @@ exports.browsers = {
   jsx: {
     full: 'JSX',
     short: 'JSX',
-    obsolete: false,
+    obsolete: true,
     platformtype: 'compiler',
     note_id: 'jsx-flag',
     note_html: 'Have to be enabled via <code>harmony</code> option'

--- a/es6/index.html
+++ b/es6/index.html
@@ -141,7 +141,7 @@
 <th class="platform babel compiler" data-browser="babel"><a href="#babel" class="browser-name"><abbr title="Babel 5.8 + core-js 2.0">Babel +<br><nobr>core-js</nobr></abbr><a href="#babel-optional-note"><sup>[1]</sup></a></a></th>
 <th class="platform es6tr compiler obsolete" data-browser="es6tr"><a href="#es6tr" class="browser-name"><abbr title="ES6 Transpiler">ES6<br>Trans-<br>piler</abbr></a></th>
 <th class="platform closure compiler" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20160201">Closure</abbr></a></th>
-<th class="platform jsx compiler" data-browser="jsx"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[2]</sup></a></a></th>
+<th class="platform jsx compiler obsolete" data-browser="jsx"><a href="#jsx" class="browser-name"><abbr title="JSX">JSX</abbr><a href="#jsx-flag-note"><sup>[2]</sup></a></a></th>
 <th class="platform typescript compiler" data-browser="typescript"><a href="#typescript" class="browser-name"><abbr title="TypeScript 1.6.2 + core-js 2.0">Type-<br>Script +<br><nobr>core-js</nobr></abbr></a></th>
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-<br>shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
@@ -218,7 +218,7 @@
 <td class="tally" data-browser="babel" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
@@ -298,7 +298,7 @@ return (function f(n){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -385,7 +385,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -458,7 +458,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="babel" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="closure" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
@@ -532,7 +532,7 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -606,7 +606,7 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -680,7 +680,7 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -761,7 +761,7 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -845,7 +845,7 @@ return (function(x = 1) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -924,7 +924,7 @@ return (function(a=function(){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1000,7 +1000,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1071,7 +1071,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="babel" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally" data-browser="closure" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
-<td class="tally" data-browser="jsx" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
@@ -1147,7 +1147,7 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1221,7 +1221,7 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1303,7 +1303,7 @@ return (function (foo, ...args) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1383,7 +1383,7 @@ return (function (...args) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1459,7 +1459,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1530,7 +1530,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="babel" data-tally="0.8666666666666667" style="background-color:hsl(104,47%,50%)">13/15</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally" data-browser="closure" data-tally="0.8" style="background-color:hsl(96,50%,50%)">12/15</td>
-<td class="tally" data-browser="jsx" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.13333333333333333" style="background-color:hsl(16,80%,50%)">2/15</td>
 <td class="tally" data-browser="typescript" data-tally="0.26666666666666666" style="background-color:hsl(32,74%,50%)">4/15</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
@@ -1604,7 +1604,7 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1678,7 +1678,7 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1753,7 +1753,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1828,7 +1828,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1902,7 +1902,7 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1976,7 +1976,7 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2050,7 +2050,7 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2124,7 +2124,7 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2199,7 +2199,7 @@ return Math.max(...iterable) === 3;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2274,7 +2274,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2349,7 +2349,7 @@ return Math.max(...iterable) === 3;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2424,7 +2424,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2499,7 +2499,7 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2574,7 +2574,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2652,7 +2652,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2723,7 +2723,7 @@ try {
 <td class="tally" data-browser="babel" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="1">6/6</td>
 <td class="tally" data-browser="closure" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally" data-browser="jsx" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
@@ -2798,7 +2798,7 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2873,7 +2873,7 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2947,7 +2947,7 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3021,7 +3021,7 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3096,7 +3096,7 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3177,7 +3177,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3248,7 +3248,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="babel" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">4/9</td>
 <td class="tally" data-browser="closure" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">6/9</td>
-<td class="tally" data-browser="jsx" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.2222222222222222" style="background-color:hsl(26,76%,50%)">2/9</td>
 <td class="tally" data-browser="typescript" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">3/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
@@ -3324,7 +3324,7 @@ for (var item of arr)
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3402,7 +3402,7 @@ return count === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3479,7 +3479,7 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3556,7 +3556,7 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3635,7 +3635,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3714,7 +3714,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3793,7 +3793,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes<a href="#compiler-iterable-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3872,7 +3872,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -3953,7 +3953,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4024,7 +4024,7 @@ return closed;
 <td class="tally" data-browser="babel" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="closure" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="1">4/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -4098,7 +4098,7 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4172,7 +4172,7 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4246,7 +4246,7 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4320,7 +4320,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4391,7 +4391,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="babel" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="closure" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally" data-browser="jsx" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
@@ -4467,7 +4467,7 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4545,7 +4545,7 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4630,7 +4630,7 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4706,7 +4706,7 @@ return (function(parts) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4785,7 +4785,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -4856,7 +4856,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="babel" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -4932,7 +4932,7 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5009,7 +5009,7 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5083,7 +5083,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5157,7 +5157,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5228,7 +5228,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="tally" data-browser="babel" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)" data-flagged-tally="1">21/22</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">14/22</td>
 <td class="tally" data-browser="closure" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">18/22</td>
-<td class="tally" data-browser="jsx" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">12/22</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">12/22</td>
 <td class="tally" data-browser="typescript" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">14/22</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
@@ -5303,7 +5303,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5378,7 +5378,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5453,7 +5453,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5528,7 +5528,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5603,7 +5603,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5678,7 +5678,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5753,7 +5753,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5832,7 +5832,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5907,7 +5907,7 @@ return a === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -5982,7 +5982,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6059,7 +6059,7 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6134,7 +6134,7 @@ return a === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6216,7 +6216,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6292,7 +6292,7 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6367,7 +6367,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6444,7 +6444,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6520,7 +6520,7 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6596,7 +6596,7 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6678,7 +6678,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6755,7 +6755,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6832,7 +6832,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6915,7 +6915,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -6986,7 +6986,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="babel" data-tally="1">24/24</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.7083333333333334" style="background-color:hsl(85,54%,50%)">17/24</td>
 <td class="tally" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">15/24</td>
-<td class="tally" data-browser="jsx" data-tally="0.4583333333333333" style="background-color:hsl(55,65%,50%)">11/24</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.4583333333333333" style="background-color:hsl(55,65%,50%)">11/24</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">18/24</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
@@ -7062,7 +7062,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7138,7 +7138,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7214,7 +7214,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7290,7 +7290,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7366,7 +7366,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7442,7 +7442,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7518,7 +7518,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7598,7 +7598,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7673,7 +7673,7 @@ return ([a, b] = iterable) === iterable;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7749,7 +7749,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7825,7 +7825,7 @@ return a === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7901,7 +7901,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -7979,7 +7979,7 @@ return toFixed === Number.prototype.toFixed
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8055,7 +8055,7 @@ return a === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8130,7 +8130,7 @@ return ({a,b} = obj) === obj;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8211,7 +8211,7 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8287,7 +8287,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8370,7 +8370,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8446,7 +8446,7 @@ return grault === &quot;garply&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8524,7 +8524,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8602,7 +8602,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8678,7 +8678,7 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8754,7 +8754,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8832,7 +8832,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -8903,7 +8903,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="babel" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">21/23</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="closure" data-tally="0.7391304347826086" style="background-color:hsl(88,53%,50%)">17/23</td>
-<td class="tally" data-browser="jsx" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
 <td class="tally" data-browser="typescript" data-tally="0.6086956521739131" style="background-color:hsl(73,59%,50%)">14/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
@@ -8979,7 +8979,7 @@ return function([a, , [b], c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9055,7 +9055,7 @@ return function([a, , b]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9131,7 +9131,7 @@ return function([a, b, c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9207,7 +9207,7 @@ return function([c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9283,7 +9283,7 @@ return function([a, b, c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9359,7 +9359,7 @@ return function([a, b, c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9435,7 +9435,7 @@ return function([a, b, c]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9514,7 +9514,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9590,7 +9590,7 @@ return function([a,]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9666,7 +9666,7 @@ return function({c, x:d, e}) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9743,7 +9743,7 @@ return function({toFixed}, {slice}) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9819,7 +9819,7 @@ return function({a,}) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9901,7 +9901,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -9978,7 +9978,7 @@ return function({ [qux]: grault }) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10055,7 +10055,7 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10132,7 +10132,7 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10209,7 +10209,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10283,7 +10283,7 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10360,7 +10360,7 @@ return function([a, ...b], [c, ...d]) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10436,7 +10436,7 @@ return function ([],{}){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10514,7 +10514,7 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10593,7 +10593,7 @@ return (function({a=function(){
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10669,7 +10669,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10740,7 +10740,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="babel" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="closure" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
@@ -10814,7 +10814,7 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10889,7 +10889,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -10960,7 +10960,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="babel" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
@@ -11041,7 +11041,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11124,7 +11124,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11197,7 +11197,7 @@ try {
 <td class="tally" data-browser="babel" data-tally="0.75" style="background-color:hsl(90,53%,50%)" data-flagged-tally="1">6/8</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td class="tally" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
@@ -11272,7 +11272,7 @@ return (foo === 123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11348,7 +11348,7 @@ return bar === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11427,7 +11427,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11505,7 +11505,7 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11581,7 +11581,7 @@ return (foo === 123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11658,7 +11658,7 @@ return bar === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11738,7 +11738,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11817,7 +11817,7 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -11888,7 +11888,7 @@ return passed;
 <td class="tally" data-browser="babel" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="1">8/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="closure" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/10</td>
 <td class="tally" data-browser="typescript" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
@@ -11963,7 +11963,7 @@ return (foo === 123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12039,7 +12039,7 @@ return bar === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12115,7 +12115,7 @@ return baz === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12193,7 +12193,7 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12278,7 +12278,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12354,7 +12354,7 @@ return (foo === 123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12431,7 +12431,7 @@ return bar === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12508,7 +12508,7 @@ return baz === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12587,7 +12587,7 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12673,7 +12673,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12752,7 +12752,7 @@ return f() === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12825,7 +12825,7 @@ return f() === 1;
 <td class="tally" data-browser="babel" data-tally="0.7692307692307693" style="background-color:hsl(92,52%,50%)">10/13</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
 <td class="tally" data-browser="closure" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)">11/13</td>
-<td class="tally" data-browser="jsx" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
 <td class="tally" data-browser="typescript" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
@@ -12899,7 +12899,7 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -12974,7 +12974,7 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13049,7 +13049,7 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13125,7 +13125,7 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13201,7 +13201,7 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13277,7 +13277,7 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13352,7 +13352,7 @@ return f(6) === 5;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13428,7 +13428,7 @@ return (() =&gt; {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13504,7 +13504,7 @@ return (() =&gt; {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13579,7 +13579,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13666,7 +13666,7 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13751,7 +13751,7 @@ return arrow() === &quot;quux&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13828,7 +13828,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -13899,7 +13899,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="babel" data-tally="0.8260869565217391" style="background-color:hsl(99,49%,50%)">19/23</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.6956521739130435" style="background-color:hsl(83,55%,50%)">16/23</td>
 <td class="tally" data-browser="closure" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">8/23</td>
-<td class="tally" data-browser="jsx" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.6521739130434783" style="background-color:hsl(78,57%,50%)">15/23</td>
 <td class="tally" data-browser="typescript" data-tally="0.6956521739130435" style="background-color:hsl(83,55%,50%)">16/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
@@ -13974,7 +13974,7 @@ return typeof C === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14054,7 +14054,7 @@ return C === c1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14128,7 +14128,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14202,7 +14202,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14280,7 +14280,7 @@ return C.prototype.constructor === C
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14358,7 +14358,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14436,7 +14436,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14515,7 +14515,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14593,7 +14593,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14672,7 +14672,7 @@ return typeof C.method === &quot;function&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14752,7 +14752,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14832,7 +14832,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14912,7 +14912,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -14992,7 +14992,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15071,7 +15071,7 @@ return C === undefined &amp;&amp; M();
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15151,7 +15151,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15229,7 +15229,7 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15306,7 +15306,7 @@ return (0,C.method)();
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15386,7 +15386,7 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15463,7 +15463,7 @@ return new C() instanceof B
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="closure">No<a href="#compiled-extends-note"><sup>[14]</sup></a></td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15540,7 +15540,7 @@ return new C() instanceof B
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[14]</sup></a></td>
+<td class="no obsolete" data-browser="jsx">No<a href="#compiled-extends-note"><sup>[14]</sup></a></td>
 <td class="no" data-browser="typescript">No<a href="#typescript-extends-note"><sup>[15]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15618,7 +15618,7 @@ return Function.prototype.isPrototypeOf(C)
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15704,7 +15704,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15775,7 +15775,7 @@ return passed;
 <td class="tally" data-browser="babel" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="closure" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
-<td class="tally" data-browser="jsx" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
@@ -15857,7 +15857,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -15937,7 +15937,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16018,7 +16018,7 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16098,7 +16098,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16180,7 +16180,7 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16262,7 +16262,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16346,7 +16346,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16432,7 +16432,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="no" data-browser="closure">No</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16503,7 +16503,7 @@ return passed;
 <td class="tally" data-browser="babel" data-tally="0.92" style="background-color:hsl(110,45%,50%)">23/25</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/25</td>
 <td class="tally" data-browser="closure" data-tally="0.64" style="background-color:hsl(76,57%,50%)">16/25</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/25</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/25</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/25</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/25</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/25</td>
@@ -16587,7 +16587,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16671,7 +16671,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16755,7 +16755,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16837,7 +16837,7 @@ catch (e) {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -16919,7 +16919,7 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17002,7 +17002,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17086,7 +17086,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17171,7 +17171,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17255,7 +17255,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17336,7 +17336,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17419,7 +17419,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17502,7 +17502,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17585,7 +17585,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17668,7 +17668,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17753,7 +17753,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17838,7 +17838,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -17923,7 +17923,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18009,7 +18009,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18099,7 +18099,7 @@ return closed === &apos;ab&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18188,7 +18188,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18274,7 +18274,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18360,7 +18360,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18447,7 +18447,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18533,7 +18533,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18620,7 +18620,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18693,7 +18693,7 @@ return passed;
 <td class="tally" data-browser="babel" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/46</td>
 <td class="tally" data-browser="closure" data-tally="0">0/46</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/46</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/46</td>
 <td class="tally" data-browser="typescript" data-tally="0.9782608695652174" style="background-color:hsl(117,42%,50%)">45/46</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
@@ -18769,7 +18769,7 @@ return view[0] === -0x80;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -18845,7 +18845,7 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -18921,7 +18921,7 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -18997,7 +18997,7 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19073,7 +19073,7 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19149,7 +19149,7 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19225,7 +19225,7 @@ return view[0] === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19301,7 +19301,7 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19377,7 +19377,7 @@ return view[0] === 0.1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19454,7 +19454,7 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19531,7 +19531,7 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19608,7 +19608,7 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19685,7 +19685,7 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19762,7 +19762,7 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19839,7 +19839,7 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19916,7 +19916,7 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -19993,7 +19993,7 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -20067,7 +20067,7 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20164,7 +20164,7 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20253,7 +20253,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20350,7 +20350,7 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20432,7 +20432,7 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20514,7 +20514,7 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20596,7 +20596,7 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20678,7 +20678,7 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20760,7 +20760,7 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20842,7 +20842,7 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -20924,7 +20924,7 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21006,7 +21006,7 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21088,7 +21088,7 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21170,7 +21170,7 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21252,7 +21252,7 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21334,7 +21334,7 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21416,7 +21416,7 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21498,7 +21498,7 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21580,7 +21580,7 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21662,7 +21662,7 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21744,7 +21744,7 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21826,7 +21826,7 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21908,7 +21908,7 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -21990,7 +21990,7 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22072,7 +22072,7 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22154,7 +22154,7 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22236,7 +22236,7 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22318,7 +22318,7 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22400,7 +22400,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22471,7 +22471,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="babel" data-tally="1">18/18</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/18</td>
 <td class="tally" data-browser="closure" data-tally="0">0/18</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/18</td>
 <td class="tally" data-browser="typescript" data-tally="1">18/18</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">14/18</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/18</td>
@@ -22550,7 +22550,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22629,7 +22629,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22709,7 +22709,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22784,7 +22784,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22868,7 +22868,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -22949,7 +22949,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23024,7 +23024,7 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23104,7 +23104,7 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23183,7 +23183,7 @@ return map.size === 1;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23257,7 +23257,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23331,7 +23331,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23405,7 +23405,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23479,7 +23479,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23553,7 +23553,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23627,7 +23627,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23701,7 +23701,7 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23785,7 +23785,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23860,7 +23860,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -23931,7 +23931,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="babel" data-tally="1">18/18</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/18</td>
 <td class="tally" data-browser="closure" data-tally="0">0/18</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/18</td>
 <td class="tally" data-browser="typescript" data-tally="1">18/18</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">14/18</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/18</td>
@@ -24011,7 +24011,7 @@ return set.has(123);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24089,7 +24089,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24169,7 +24169,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24244,7 +24244,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24328,7 +24328,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24412,7 +24412,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24487,7 +24487,7 @@ return set.add(0) === set;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24567,7 +24567,7 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24648,7 +24648,7 @@ return set.size === 2;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24722,7 +24722,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24796,7 +24796,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24870,7 +24870,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -24944,7 +24944,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25018,7 +25018,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25092,7 +25092,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25166,7 +25166,7 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25250,7 +25250,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25325,7 +25325,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25396,7 +25396,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="babel" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/10</td>
 <td class="tally" data-browser="closure" data-tally="0">0/10</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/10</td>
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
@@ -25475,7 +25475,7 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25554,7 +25554,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25634,7 +25634,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25709,7 +25709,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25793,7 +25793,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25870,7 +25870,7 @@ return m.get(f) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -25951,7 +25951,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26027,7 +26027,7 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26101,7 +26101,7 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26182,7 +26182,7 @@ return m.has(key);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26253,7 +26253,7 @@ return m.has(key);
 <td class="tally" data-browser="babel" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/9</td>
 <td class="tally" data-browser="closure" data-tally="0">0/9</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/9</td>
 <td class="tally" data-browser="typescript" data-tally="1">9/9</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
@@ -26333,7 +26333,7 @@ return weakset.has(obj1);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26410,7 +26410,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26490,7 +26490,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26565,7 +26565,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26649,7 +26649,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26730,7 +26730,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26806,7 +26806,7 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26880,7 +26880,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -26961,7 +26961,7 @@ return s.has(key);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27032,7 +27032,7 @@ return s.has(key);
 <td class="tally" data-browser="babel" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/20</td>
 <td class="tally" data-browser="closure" data-tally="0">0/20</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/20</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/20</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/20</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
@@ -27112,7 +27112,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27192,7 +27192,7 @@ return proxy.foo === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27272,7 +27272,7 @@ return proxy.foo === 5;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27354,7 +27354,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27436,7 +27436,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27517,7 +27517,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27598,7 +27598,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27679,7 +27679,7 @@ var proxied = {};
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27766,7 +27766,7 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27852,7 +27852,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -27933,7 +27933,7 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28019,7 +28019,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28102,7 +28102,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28186,7 +28186,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28269,7 +28269,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28353,7 +28353,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28435,7 +28435,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28517,7 +28517,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28591,7 +28591,7 @@ return Array.isArray(new Proxy([], {}));
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28665,7 +28665,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28736,7 +28736,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="babel" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/16</td>
 <td class="tally" data-browser="closure" data-tally="0">0/16</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/16</td>
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
@@ -28810,7 +28810,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28886,7 +28886,7 @@ return obj.quux === 654;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -28960,7 +28960,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29036,7 +29036,7 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29113,7 +29113,7 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29190,7 +29190,7 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29264,7 +29264,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29340,7 +29340,7 @@ return obj instanceof Array;
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29415,7 +29415,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29491,7 +29491,7 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29569,7 +29569,7 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29651,7 +29651,7 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29725,7 +29725,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29801,7 +29801,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29879,7 +29879,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -29954,7 +29954,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30025,7 +30025,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="tally" data-browser="babel" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
@@ -30120,7 +30120,7 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30200,7 +30200,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30288,7 +30288,7 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30376,7 +30376,7 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30464,7 +30464,7 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30552,7 +30552,7 @@ function check() {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30627,7 +30627,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30698,7 +30698,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="babel" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="0.7">6/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/10</td>
 <td class="tally" data-browser="closure" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/10</td>
 <td class="tally" data-browser="typescript" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
@@ -30776,7 +30776,7 @@ return object[symbol] === value;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30850,7 +30850,7 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -30936,7 +30936,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31019,7 +31019,7 @@ return passed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31106,7 +31106,7 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31180,7 +31180,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31259,7 +31259,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31340,7 +31340,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31417,7 +31417,7 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31493,7 +31493,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31564,7 +31564,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="babel" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)" data-flagged-tally="0.5652173913043478">12/23</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/23</td>
 <td class="tally" data-browser="closure" data-tally="0.043478260869565216" style="background-color:hsl(5,84%,50%)">1/23</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/23</td>
 <td class="tally" data-browser="typescript" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
@@ -31645,7 +31645,7 @@ return passed;
 <td class="no flagged" data-browser="babel">Flag</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31722,7 +31722,7 @@ return a[0] === b;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31796,7 +31796,7 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31873,7 +31873,7 @@ return (function() {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -31947,7 +31947,7 @@ return &quot;species&quot; in Symbol;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32026,7 +32026,7 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32105,7 +32105,7 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32184,7 +32184,7 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32263,7 +32263,7 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32342,7 +32342,7 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32424,7 +32424,7 @@ return passed;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32502,7 +32502,7 @@ return &apos;&apos;.replace(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32580,7 +32580,7 @@ return &apos;&apos;.search(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32658,7 +32658,7 @@ return &apos;&apos;.split(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32736,7 +32736,7 @@ return &apos;&apos;.match(O) === 42;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32814,7 +32814,7 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32894,7 +32894,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -32974,7 +32974,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33054,7 +33054,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33137,7 +33137,7 @@ return passed === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33213,7 +33213,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33289,7 +33289,7 @@ return Math[s] === &quot;Math&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33367,7 +33367,7 @@ with (a) {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33440,7 +33440,7 @@ with (a) {
 <td class="tally" data-browser="babel" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -33515,7 +33515,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33591,7 +33591,7 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33673,7 +33673,7 @@ return result[0] === sym
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33747,7 +33747,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33818,7 +33818,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="babel" data-tally="0.5294117647058824" style="background-color:hsl(63,62%,50%)">9/17</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/17</td>
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
@@ -33894,7 +33894,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -33969,7 +33969,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34043,7 +34043,7 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34119,7 +34119,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34195,7 +34195,7 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34273,7 +34273,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34350,7 +34350,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34425,7 +34425,7 @@ return o.foo.name === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34500,7 +34500,7 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34582,7 +34582,7 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34659,7 +34659,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34734,7 +34734,7 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34813,7 +34813,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="babel">No<a href="#name-configurable-note"><sup>[19]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34891,7 +34891,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -34966,7 +34966,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35041,7 +35041,7 @@ return C.foo.name === &quot;foo&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35118,7 +35118,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35189,7 +35189,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="1">2/2</td>
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
@@ -35263,7 +35263,7 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35337,7 +35337,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35408,7 +35408,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="babel" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
@@ -35482,7 +35482,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35558,7 +35558,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35633,7 +35633,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35708,7 +35708,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35783,7 +35783,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35858,7 +35858,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -35932,7 +35932,7 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36016,7 +36016,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36087,7 +36087,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="babel" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/6</td>
 <td class="tally" data-browser="closure" data-tally="0">0/6</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/6</td>
 <td class="tally" data-browser="typescript" data-tally="1">6/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
@@ -36161,7 +36161,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36235,7 +36235,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36309,7 +36309,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36383,7 +36383,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36457,7 +36457,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36532,7 +36532,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36603,7 +36603,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="babel" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
 <td class="tally" data-browser="closure" data-tally="0">0/11</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/11</td>
 <td class="tally" data-browser="typescript" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
@@ -36677,7 +36677,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36752,7 +36752,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36827,7 +36827,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36902,7 +36902,7 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -36978,7 +36978,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37055,7 +37055,7 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37132,7 +37132,7 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37209,7 +37209,7 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37290,7 +37290,7 @@ return closed;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37365,7 +37365,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37440,7 +37440,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37511,7 +37511,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="babel" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/10</td>
 <td class="tally" data-browser="closure" data-tally="0">0/10</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/10</td>
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
@@ -37585,7 +37585,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37659,7 +37659,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37733,7 +37733,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37807,7 +37807,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37881,7 +37881,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -37955,7 +37955,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38029,7 +38029,7 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38103,7 +38103,7 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38187,7 +38187,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38269,7 +38269,7 @@ return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38340,7 +38340,7 @@ return true;
 <td class="tally" data-browser="babel" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/7</td>
 <td class="tally" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/7</td>
 <td class="tally" data-browser="typescript" data-tally="1">7/7</td>
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
@@ -38414,7 +38414,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38488,7 +38488,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38562,7 +38562,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38636,7 +38636,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38710,7 +38710,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38784,7 +38784,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38858,7 +38858,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -38929,7 +38929,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="babel" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/17</td>
 <td class="tally" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/17</td>
 <td class="tally" data-browser="typescript" data-tally="1">17/17</td>
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
@@ -39003,7 +39003,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39077,7 +39077,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39151,7 +39151,7 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39225,7 +39225,7 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39299,7 +39299,7 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39373,7 +39373,7 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39447,7 +39447,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39521,7 +39521,7 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39595,7 +39595,7 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39669,7 +39669,7 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39743,7 +39743,7 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39817,7 +39817,7 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39891,7 +39891,7 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -39965,7 +39965,7 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40039,7 +40039,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40113,7 +40113,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40190,7 +40190,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40263,7 +40263,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="tally" data-browser="babel" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
 <td class="tally" data-browser="closure" data-tally="0">0/11</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/11</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
@@ -40342,7 +40342,7 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40420,7 +40420,7 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40496,7 +40496,7 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40571,7 +40571,7 @@ return Array.isArray(new C());
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40647,7 +40647,7 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40723,7 +40723,7 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40799,7 +40799,7 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40876,7 +40876,7 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -40953,7 +40953,7 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41028,7 +41028,7 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41103,7 +41103,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41174,7 +41174,7 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="babel" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -41250,7 +41250,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41326,7 +41326,7 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41402,7 +41402,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41478,7 +41478,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41549,7 +41549,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="babel" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/6</td>
 <td class="tally" data-browser="closure" data-tally="0">0/6</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/6</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
@@ -41625,7 +41625,7 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41701,7 +41701,7 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="babel">No<a href="#compiler-proto-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41778,7 +41778,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41854,7 +41854,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -41930,7 +41930,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42006,7 +42006,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42077,7 +42077,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="babel" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -42173,7 +42173,7 @@ function check() {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42249,7 +42249,7 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42338,7 +42338,7 @@ function check() {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42427,7 +42427,7 @@ function check() {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42498,7 +42498,7 @@ function check() {
 <td class="tally" data-browser="babel" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
 <td class="tally" data-browser="closure" data-tally="0">0/5</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/5</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
@@ -42576,7 +42576,7 @@ return c instanceof Boolean
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42654,7 +42654,7 @@ return c instanceof Number
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42734,7 +42734,7 @@ return c instanceof String
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42814,7 +42814,7 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42895,7 +42895,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -42968,7 +42968,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="babel" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/5</td>
 <td class="tally" data-browser="closure" data-tally="0">0/5</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/5</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/5</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
@@ -43055,7 +43055,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43142,7 +43142,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43229,7 +43229,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43316,7 +43316,7 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43401,7 +43401,7 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43472,7 +43472,7 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="babel" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/35</td>
 <td class="tally" data-browser="closure" data-tally="0">0/35</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/35</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/35</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/35</td>
@@ -43550,7 +43550,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43628,7 +43628,7 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43707,7 +43707,7 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43788,7 +43788,7 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43866,7 +43866,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -43944,7 +43944,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44033,7 +44033,7 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44119,7 +44119,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44197,7 +44197,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44275,7 +44275,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44353,7 +44353,7 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44431,7 +44431,7 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44510,7 +44510,7 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44590,7 +44590,7 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44668,7 +44668,7 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44746,7 +44746,7 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44826,7 +44826,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44906,7 +44906,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -44984,7 +44984,7 @@ return get + &apos;&apos; === &quot;lastIndex,exec&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45064,7 +45064,7 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45142,7 +45142,7 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45227,7 +45227,7 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45318,7 +45318,7 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45396,7 +45396,7 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45474,7 +45474,7 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45552,7 +45552,7 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45631,7 +45631,7 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45709,7 +45709,7 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45787,7 +45787,7 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45865,7 +45865,7 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -45945,7 +45945,7 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46025,7 +46025,7 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46105,7 +46105,7 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46185,7 +46185,7 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46264,7 +46264,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46335,7 +46335,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="babel" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/11</td>
 <td class="tally" data-browser="closure" data-tally="0">0/11</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/11</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/11</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/11</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
@@ -46413,7 +46413,7 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46491,7 +46491,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46569,7 +46569,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46647,7 +46647,7 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46725,7 +46725,7 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46803,7 +46803,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46881,7 +46881,7 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -46959,7 +46959,7 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47037,7 +47037,7 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47115,7 +47115,7 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47193,7 +47193,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47264,7 +47264,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="babel" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/2</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
@@ -47342,7 +47342,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47420,7 +47420,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47491,7 +47491,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="babel" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/6</td>
 <td class="tally" data-browser="closure" data-tally="0">0/6</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/6</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/6</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
@@ -47569,7 +47569,7 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47647,7 +47647,7 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47725,7 +47725,7 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47803,7 +47803,7 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47881,7 +47881,7 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -47959,7 +47959,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48030,7 +48030,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="babel" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/4</td>
 <td class="tally" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/4</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
@@ -48109,7 +48109,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48188,7 +48188,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48267,7 +48267,7 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48346,7 +48346,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48417,7 +48417,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="babel" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/3</td>
 <td class="tally" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/3</td>
 <td class="tally" data-browser="typescript" data-tally="0">0/3</td>
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
@@ -48495,7 +48495,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48573,7 +48573,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48651,7 +48651,7 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48722,7 +48722,7 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="babel" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/10</td>
 <td class="tally" data-browser="closure" data-tally="0">0/10</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/10</td>
 <td class="tally" data-browser="typescript" data-tally="1">10/10</td>
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
@@ -48796,7 +48796,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48870,7 +48870,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -48946,7 +48946,7 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49020,7 +49020,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49094,7 +49094,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49168,7 +49168,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49242,7 +49242,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49316,7 +49316,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49390,7 +49390,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49465,7 +49465,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -49536,7 +49536,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="babel" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0">0/8</td>
 <td class="tally" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally" data-browser="jsx" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0">0/8</td>
 <td class="tally" data-browser="typescript" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td class="tally" data-browser="es6shim" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.625" style="background-color:hsl(75,58%,50%)">5/8</td>
@@ -49643,7 +49643,7 @@ return result === &quot;012349 DB-1AEFGHIJKLMNOPQRSTUVWXYZC&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -49737,7 +49737,7 @@ return Object.keys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNOPQRS
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -49831,7 +49831,7 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -49930,7 +49930,7 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50025,7 +50025,7 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
@@ -50107,7 +50107,7 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[23]</sup></a></td>
@@ -50201,7 +50201,7 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="babel">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
 <td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50290,7 +50290,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50361,7 +50361,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="babel" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="es6tr" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td class="tally" data-browser="closure" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
-<td class="tally" data-browser="jsx" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
+<td class="tally obsolete" data-browser="jsx" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td class="tally" data-browser="typescript" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
@@ -50440,7 +50440,7 @@ try {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="yes obsolete" data-browser="es6tr">Yes</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="yes" data-browser="jsx">Yes</td>
+<td class="yes obsolete" data-browser="jsx">Yes</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -50515,7 +50515,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50589,7 +50589,7 @@ do {} while (false) return true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -50668,7 +50668,7 @@ catch(e) {
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="yes" data-browser="closure">Yes</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50746,7 +50746,7 @@ try {
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50820,7 +50820,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -50894,7 +50894,7 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="babel">Yes</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="yes" data-browser="typescript">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -50981,7 +50981,7 @@ return true;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51063,7 +51063,7 @@ return false;
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51137,7 +51137,7 @@ return &quot;&#x10418;&quot;.toLowerCase() === &quot;&#x10440;&quot; &amp;&amp; 
 <td class="no" data-browser="babel">No</td>
 <td class="no obsolete" data-browser="es6tr">No</td>
 <td class="no" data-browser="closure">No</td>
-<td class="no" data-browser="jsx">No</td>
+<td class="no obsolete" data-browser="jsx">No</td>
 <td class="no" data-browser="typescript">No</td>
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51210,7 +51210,7 @@ return &quot;&#x10418;&quot;.toLowerCase() === &quot;&#x10440;&quot; &amp;&amp; 
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -51298,7 +51298,7 @@ return passed;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51376,7 +51376,7 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -51457,7 +51457,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -51528,7 +51528,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
-<td class="tally not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
@@ -51603,7 +51603,7 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51682,7 +51682,7 @@ catch(e) {
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51760,7 +51760,7 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51838,7 +51838,7 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51915,7 +51915,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -51986,7 +51986,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
-<td class="tally not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
@@ -52061,7 +52061,7 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52137,7 +52137,7 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52213,7 +52213,7 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52287,7 +52287,7 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52368,7 +52368,7 @@ return (desc
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52442,7 +52442,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52513,7 +52513,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -52594,7 +52594,7 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -52675,7 +52675,7 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52755,7 +52755,7 @@ return true;
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[10]</sup></a></td>
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -52829,7 +52829,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -52900,7 +52900,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
@@ -52974,7 +52974,7 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53049,7 +53049,7 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53123,7 +53123,7 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53198,7 +53198,7 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53273,7 +53273,7 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53348,7 +53348,7 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53423,7 +53423,7 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53498,7 +53498,7 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -53575,7 +53575,7 @@ return a === 3;
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>


### PR DESCRIPTION
react-tools and JSTransform was deprecated and switched to Babel last year.
- [Deprecating JSTransform and react-tools | React](https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html)

So please make it obsolete and hide.
