### PR TITLE
[ES6] Added JavaScript Automation for OS X

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -471,6 +471,11 @@ exports.browsers = {
     short: 'XS6',
     platformtype: 'engine'
   },
+  jxa: {
+    full: 'JavaScript Automation for OS X',
+    short: 'JXA',
+    platformtype: 'engine'
+  },
   android40: {
     full: 'Android Browser',
     short: 'AN 4.0',
@@ -933,6 +938,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -955,6 +961,7 @@ exports.tests = [
         chrome49:    true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -980,6 +987,7 @@ exports.tests = [
         chrome49:    true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1004,6 +1012,7 @@ exports.tests = [
         chrome49:    true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1023,6 +1032,7 @@ exports.tests = [
         chrome49:    true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1048,6 +1058,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1073,6 +1084,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1101,6 +1113,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1128,6 +1141,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -1150,6 +1164,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ]
@@ -1772,6 +1787,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1794,6 +1810,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1819,6 +1836,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1837,6 +1855,7 @@ exports.tests = [
         node5:       true,
         edge13:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1876,6 +1895,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1913,6 +1933,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -1981,6 +2002,7 @@ exports.tests = [
         node5:       true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -2003,6 +2025,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2025,6 +2048,7 @@ exports.tests = [
         node5:       true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -2047,6 +2071,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2072,6 +2097,7 @@ exports.tests = [
         node4:       flag,
         node5:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ]
@@ -2105,6 +2131,7 @@ exports.tests = [
         chrome49:    true,
         typescript:  true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2132,6 +2159,7 @@ exports.tests = [
         node4:       strict,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2155,6 +2183,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2178,6 +2207,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2206,6 +2236,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2234,6 +2265,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2261,6 +2293,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2317,6 +2350,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2375,6 +2409,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2431,6 +2466,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2484,6 +2520,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2530,6 +2567,7 @@ exports.tests = [
         edge13:      true,
         firefox45:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2556,6 +2594,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2580,6 +2619,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -2618,6 +2658,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -2647,6 +2688,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2673,6 +2715,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2740,6 +2783,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2769,6 +2813,7 @@ exports.tests = [
         chrome49:    true,
         node4:       strict,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2799,6 +2844,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2829,6 +2875,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2861,6 +2908,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2918,6 +2966,7 @@ exports.tests = [
         chrome41:    strict,
         chrome49:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -2950,6 +2999,7 @@ exports.tests = [
         typescript:  true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -2981,6 +3031,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3005,6 +3056,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3028,6 +3080,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -3040,6 +3093,7 @@ exports.tests = [
         ejs:         true,
         firefox34:   true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -3063,6 +3117,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -3124,6 +3179,7 @@ exports.tests = [
         firefox11:   true,
         rhino17:     true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -3147,6 +3203,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3173,6 +3230,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -3204,6 +3262,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3224,6 +3283,7 @@ exports.tests = [
         chrome42:     true,
         node4:        true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3243,6 +3303,7 @@ exports.tests = [
         chrome44:     true,
         node4:        true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3262,6 +3323,7 @@ exports.tests = [
         node4:        true,
         edge13:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3280,6 +3342,7 @@ exports.tests = [
         node4:        true,
         edge13:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -3312,6 +3375,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -3346,6 +3410,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3368,6 +3433,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3421,6 +3487,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3448,6 +3515,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -3468,6 +3536,7 @@ exports.tests = [
         webkit:      true,
         xs6:         true,
         chrome51:    true,
+        jxa:         true,
       },
     },
     {
@@ -3490,6 +3559,7 @@ exports.tests = [
         webkit:      true,
         xs6:         true,
         chrome51:    true,
+        jxa:         true,
       },
     },
   ],
@@ -4240,6 +4310,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -4325,6 +4396,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -4351,6 +4423,7 @@ exports.tests = [
         node5:       strict,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
   ],
@@ -4382,6 +4455,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4405,6 +4479,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4425,6 +4500,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4445,6 +4521,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -4476,6 +4553,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4496,6 +4574,7 @@ exports.tests = [
         node4:       true,
         edge13:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4529,6 +4608,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4551,6 +4631,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4578,6 +4659,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -4686,6 +4768,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -4715,6 +4798,7 @@ exports.tests = [
         opera:       true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -4796,6 +4880,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -4881,6 +4966,7 @@ exports.tests = [
         ejs:         true,
         webkit:      true,
         chrome51:    true,
+        jxa:         true,
       },
     },
     {
@@ -4948,6 +5034,7 @@ exports.tests = [
         node4:       true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -4983,6 +5070,7 @@ exports.tests = [
         edge12:      true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ].concat([		//@@ jph
@@ -4995,6 +5083,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.of', res: {
       babel:       true,
@@ -5006,6 +5095,7 @@ exports.tests = [
       webkit:      true,
       xs6:         true,
       ejs:         true,
+      jxa:         true,
     }},
     { name: '.prototype.subarray', res: {
       babel:       true,
@@ -5019,6 +5109,7 @@ exports.tests = [
       opera:       true,
       node012:     true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.join', res: {
       babel:       true,
@@ -5030,6 +5121,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.indexOf', res: {
       babel:       true,
@@ -5041,6 +5133,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.lastIndexOf', res: {
       babel:       true,
@@ -5052,6 +5145,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.slice', res: {
       babel:       true,
@@ -5062,6 +5156,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6: true,
+      jxa:         true,
     }},
     { name: '.prototype.every', res: {
       babel:       true,
@@ -5073,6 +5168,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.filter', res: {
       babel:       true,
@@ -5083,6 +5179,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.forEach', res: {
       babel:       true,
@@ -5094,6 +5191,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.map', res: {
       babel:       true,
@@ -5104,6 +5202,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.reduce', res: {
       babel:       true,
@@ -5115,6 +5214,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.reduceRight', res: {
       babel:       true,
@@ -5126,6 +5226,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.reverse', res: {
       babel:       true,
@@ -5137,6 +5238,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.some', res: {
       babel:       true,
@@ -5148,6 +5250,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.sort', res: {
       babel:       true,
@@ -5157,6 +5260,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.copyWithin', res: {
       babel:       true,
@@ -5168,6 +5272,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.find', res: {
       babel:       true,
@@ -5179,6 +5284,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.findIndex', res: {
       babel:       true,
@@ -5190,6 +5296,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.fill', res: {
       babel:       true,
@@ -5201,6 +5308,7 @@ exports.tests = [
       node4:       true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.keys', res: {
       babel:       true,
@@ -5212,6 +5320,7 @@ exports.tests = [
       ejs:         true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype.values', res: {
       babel:       true,
@@ -5223,6 +5332,7 @@ exports.tests = [
       ejs:         true,
       webkit:      true,
       xs6: true,
+      jxa:         true,
     }},
     { name: '.prototype.entries', res: {
       babel:       true,
@@ -5233,6 +5343,7 @@ exports.tests = [
       firefox37:   true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '.prototype[Symbol.iterator]', res: {
       babel:       true,
@@ -5244,6 +5355,7 @@ exports.tests = [
       ejs:         true,
       webkit:      true,
       xs6:         true,
+      jxa:         true,
     }},
     { name: '[Symbol.species]', res: {
       babel:       true,
@@ -5253,6 +5365,7 @@ exports.tests = [
       ejs:         true,
       chrome51:    true,
       webkit:      true,
+      jxa:         true,
     }},
     ].map(function(m) {
       var eqFn = ' === "function"';
@@ -5304,6 +5417,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -5329,6 +5443,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5354,6 +5469,7 @@ exports.tests = [
         node4:       true,
         firefox42:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5391,6 +5507,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5412,6 +5529,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5434,6 +5552,7 @@ exports.tests = [
         node012:     true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5459,6 +5578,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5485,6 +5605,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5506,6 +5627,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5527,6 +5649,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5548,6 +5671,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5569,6 +5693,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5590,6 +5715,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5611,6 +5737,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5631,6 +5758,7 @@ exports.tests = [
         edge12:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5660,6 +5788,7 @@ exports.tests = [
         edge13:      true,
         firefox45:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5712,6 +5841,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -5736,6 +5866,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5761,6 +5892,7 @@ exports.tests = [
         node4:       true,
         firefox42:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5798,6 +5930,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5822,6 +5955,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5843,6 +5977,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5869,6 +6004,7 @@ exports.tests = [
         node4:       true,
         ejs:         true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5897,6 +6033,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5918,6 +6055,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5939,6 +6077,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5960,6 +6099,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -5980,6 +6120,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6001,6 +6142,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6022,6 +6164,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6043,6 +6186,7 @@ exports.tests = [
         edge12:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6072,6 +6216,7 @@ exports.tests = [
         edge13:      true,
         firefox45:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6122,6 +6267,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -6145,6 +6291,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6169,6 +6316,7 @@ exports.tests = [
         node4:       true,
         firefox42:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6205,6 +6353,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6227,6 +6376,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6248,6 +6398,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6269,6 +6420,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6289,6 +6441,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6313,6 +6466,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -6347,6 +6501,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -6368,6 +6523,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6392,6 +6548,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6428,6 +6585,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6449,6 +6607,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6470,6 +6629,7 @@ exports.tests = [
         firefox34:   true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6490,6 +6650,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -6514,6 +6675,7 @@ exports.tests = [
         edge12:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -8484,6 +8646,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       }),
     },
     {
@@ -8506,6 +8669,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8528,6 +8692,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8547,6 +8712,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8586,6 +8752,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -8606,6 +8773,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -8625,6 +8793,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -8639,6 +8808,7 @@ exports.tests = [
         tr:           false,
         closure:      false,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -8656,6 +8826,7 @@ exports.tests = [
         ejs:          false,
         firefox16:    true,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -8668,6 +8839,7 @@ exports.tests = [
       */},
       res: Object.assign({}, temp.destructuringResults, {
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -8680,6 +8852,7 @@ exports.tests = [
         safari71_8:   false,
         safari9:      true,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -8697,6 +8870,7 @@ exports.tests = [
       */},
       res: Object.assign({}, temp.destructuringResults, {
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -8739,6 +8913,7 @@ exports.tests = [
         edge13:       flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8752,6 +8927,7 @@ exports.tests = [
       res: Object.assign({}, temp.destructuringResults, {
         ejs:          false,
         chrome49:    true,
+        jxa:         true,
       }),
     },
     {
@@ -8771,6 +8947,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8792,6 +8969,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8838,6 +9016,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8859,6 +9038,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8883,6 +9063,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
   ],
@@ -8932,6 +9113,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8952,6 +9134,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -8993,6 +9176,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9014,6 +9198,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9033,6 +9218,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -9053,6 +9239,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9074,6 +9261,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9089,6 +9277,7 @@ exports.tests = [
         tr:           true,
         closure:      false,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -9107,6 +9296,7 @@ exports.tests = [
         ejs:          false,
         firefox16:    true,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -9131,6 +9321,7 @@ exports.tests = [
         safari71_8:   false,
         safari9:      true,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -9150,6 +9341,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9175,6 +9367,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9195,6 +9388,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9214,6 +9408,7 @@ exports.tests = [
       res: Object.assign({}, temp.destructuringResults, {
         closure:      false,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -9248,6 +9443,7 @@ exports.tests = [
       res: Object.assign({}, temp.destructuringResults, {
         ejs:          false,
         chrome49:     true,
+        jxa:          true,
       }),
     },
     {
@@ -9272,6 +9468,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9303,6 +9500,7 @@ exports.tests = [
         safari71_8:  false,
         safari9:     true,
         chrome49:    true,
+        jxa:         true,
       }),
     },
     {
@@ -9325,6 +9523,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
   ],
@@ -9374,6 +9573,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9394,6 +9594,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9440,6 +9641,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9461,6 +9663,7 @@ exports.tests = [
         edge13:       flag,
         xs6:          true,
         chrome49:     true,
+        jxa:          true,
       },
     },
     {
@@ -9479,6 +9682,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -9608,6 +9812,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9625,6 +9830,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },{
       name: 'in parameters, function \'length\' property',
@@ -9644,6 +9850,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9667,6 +9874,7 @@ exports.tests = [
         edge13:      flag,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -9985,6 +10193,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10009,6 +10218,7 @@ exports.tests = [
         node012:     true,
         android41:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10037,6 +10247,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10056,6 +10267,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -10083,6 +10295,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10102,6 +10315,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10124,6 +10338,7 @@ exports.tests = [
         webkit:      true,
         chrome44:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10143,6 +10358,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10162,6 +10378,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10181,6 +10398,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10200,6 +10418,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:		 true,
+        jxa:         true,
       },
     },
     {
@@ -10219,6 +10438,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:		 true,
+        jxa:         true,
       },
     },
     {
@@ -10238,6 +10458,7 @@ exports.tests = [
         chrome44:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10258,6 +10479,7 @@ exports.tests = [
         node4:       true,
         chrome44:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -10287,6 +10509,7 @@ exports.tests = [
         android40:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }),
     },
     {
@@ -10318,6 +10541,7 @@ exports.tests = [
         node012:     true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }),
     },
     {
@@ -10398,6 +10622,7 @@ exports.tests = [
         android40:   true,
         edge13:      false,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -10425,6 +10650,7 @@ exports.tests = [
         chrome48:    true,
         xs6:         true,
         ejs:         { val: false, note_id: 'ejs-no-function-ctor' },
+        jxa:         true,
       },
     },
     {
@@ -10441,6 +10667,7 @@ exports.tests = [
         node4:       true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -10455,6 +10682,7 @@ exports.tests = [
         chrome51:    flag,
         babel:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10472,6 +10700,7 @@ exports.tests = [
         edge13:      true,
         chrome51:    flag,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10486,6 +10715,7 @@ exports.tests = [
         edge12:      true,
         chrome51:    flag,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10505,6 +10735,7 @@ exports.tests = [
         webkit:       true,
         node4:        true,
         xs6:          true,
+        jxa:          true,
       },
     },
     {
@@ -10523,6 +10754,7 @@ exports.tests = [
         node4:       true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -10542,6 +10774,7 @@ exports.tests = [
         edge12:      true,
         chrome51:    flag,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10619,6 +10852,7 @@ exports.tests = [
         edge13:       true,
         chrome51:     flag,
         xs6:          true,
+        jxa:          true,
       },
     },
     {
@@ -10638,6 +10872,7 @@ exports.tests = [
         chrome49:     true,
         node4:        strict,
         xs6:         true,
+        jxa:          true,
       },
     },
     {
@@ -10658,6 +10893,7 @@ exports.tests = [
         chrome49:     true,
         node4:        strict,
         xs6:          true,
+        jxa:          true,
       },
     },
     {
@@ -10675,6 +10911,7 @@ exports.tests = [
         node4:        true,
         xs6:          true,
         webkit:       true,
+        jxa:          true,
       },
     },
   ],
@@ -10703,6 +10940,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10725,6 +10963,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -10755,6 +10994,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10772,6 +11012,7 @@ exports.tests = [
         node4:       true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -10795,6 +11036,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10818,6 +11060,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10841,6 +11084,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10869,6 +11113,7 @@ exports.tests = [
         node4:       true,
         edge12:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10889,6 +11134,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -10917,6 +11163,7 @@ exports.tests = [
         edge13:      true,
         firefox45:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -10954,6 +11201,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         false,
+        jxa:         true,
       },
     },
     {
@@ -10983,6 +11231,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         false,
+        jxa:         true,
       },
     },
     {
@@ -11010,6 +11259,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         false,
+        jxa:         true,
       },
     },
   ],
@@ -11039,6 +11289,7 @@ exports.tests = [
         firefox40:   true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11055,6 +11306,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
   ]
@@ -11141,6 +11393,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11161,6 +11414,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11191,6 +11445,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11221,6 +11476,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11250,6 +11506,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11266,6 +11523,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11290,6 +11548,7 @@ exports.tests = [
         chrome38:   true,
         node012:    true,
         xs6:        true,
+        jxa:        true,
       },
     },
     {
@@ -11314,6 +11573,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11335,6 +11595,7 @@ exports.tests = [
         webkit:      true,
         edge13:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11355,6 +11616,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -11389,6 +11651,7 @@ exports.tests = [
         ejs:         true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -11404,6 +11667,7 @@ exports.tests = [
         ejs:        true,
         chrome48:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11425,6 +11689,7 @@ exports.tests = [
         ejs:         true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11447,6 +11712,7 @@ exports.tests = [
         edge12: true,
         xs6: true,
         ejs: true,
+        jxa: true,
       },
     },
     {
@@ -11463,6 +11729,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -11481,6 +11748,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -11498,6 +11766,7 @@ exports.tests = [
         edge13:      true,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11515,6 +11784,7 @@ exports.tests = [
         edge13:      true,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11533,6 +11803,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -11551,6 +11822,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -11569,6 +11841,7 @@ exports.tests = [
       res: {
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }
     },
     {
@@ -11605,6 +11878,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11623,6 +11897,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -11640,6 +11915,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11657,6 +11933,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11675,6 +11952,7 @@ exports.tests = [
         firefox40:   true,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -11754,6 +12032,7 @@ exports.tests = [
         firefox44:   true,
         chrome47:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11772,6 +12051,7 @@ exports.tests = [
         node4:       flag,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -11790,6 +12070,7 @@ exports.tests = [
         node4:       flag,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -11814,6 +12095,7 @@ exports.tests = [
         typescript:  typescript.fallthrough,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -11840,6 +12122,7 @@ exports.tests = [
         xs6:         true,
         chrome48:    flag,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -11853,6 +12136,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11866,6 +12150,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11879,6 +12164,7 @@ exports.tests = [
         typescript:  typescript.corejs,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -11893,6 +12179,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -11963,6 +12250,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       }),
     },
     {
@@ -12046,6 +12334,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12088,6 +12377,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12108,6 +12398,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12129,6 +12420,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12173,6 +12465,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12194,6 +12487,7 @@ exports.tests = [
         chrome45:     true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       }
     },
     {
@@ -12216,6 +12510,7 @@ exports.tests = [
         safari9:     true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12239,6 +12534,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12282,6 +12578,7 @@ exports.tests = [
         chrome45:    true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12304,6 +12601,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12326,6 +12624,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12348,6 +12647,7 @@ exports.tests = [
         node012:     flag,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12369,6 +12669,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12405,6 +12706,7 @@ exports.tests = [
         node012:     true,
         node4:       false,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12426,6 +12728,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12454,6 +12757,7 @@ exports.tests = [
         chrome38:    true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12481,6 +12785,7 @@ exports.tests = [
         firefox45:   true,
         chrome51:    true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12505,6 +12810,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -12535,6 +12841,7 @@ exports.tests = [
         node012:     true,
         android41:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12556,6 +12863,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12577,6 +12885,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12599,6 +12908,7 @@ exports.tests = [
         node012:     true,
         android41:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12619,6 +12929,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12640,6 +12951,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -12661,6 +12973,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       },
     },
   ],
@@ -12686,6 +12999,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'imul': {
         ejs:         true,
@@ -12706,6 +13020,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'sign': {
         ejs:         true,
@@ -12722,6 +13037,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'log10': {
         ejs:         true,
@@ -12738,6 +13054,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'log2': {
         ejs:         true,
@@ -12754,6 +13071,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'log1p': {
         ejs:         true,
@@ -12770,6 +13088,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'expm1': {
         ejs:         true,
@@ -12785,6 +13104,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'cosh': {
         ejs:         true,
@@ -12801,6 +13121,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'sinh': {
         ejs:         true,
@@ -12817,6 +13138,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'tanh': {
         ejs:         true,
@@ -12833,6 +13155,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'acosh': {
         ejs:         true,
@@ -12849,6 +13172,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'asinh': {
         ejs:         true,
@@ -12864,6 +13188,7 @@ exports.tests = [
         webkit:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'atanh': {
         ejs:         true,
@@ -12880,6 +13205,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'trunc': {
         ejs:         true,
@@ -12896,6 +13222,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'fround': {
         ejs:         true,
@@ -12917,6 +13244,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
       'cbrt': {
         ejs:         true,
@@ -12933,6 +13261,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:    	 true,
+        jxa:         true,
       },
     };
     var eqFn = ' === "function"';
@@ -12966,6 +13295,7 @@ exports.tests = [
         konq49:      true,
         node012:     true,
         xs6:         true,
+        jxa:         true,
       }
     });
   }()),
@@ -13015,6 +13345,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13036,6 +13367,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13056,6 +13388,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -13073,6 +13406,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }
     },
     {
@@ -13088,6 +13422,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -13102,6 +13437,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }
     },
     {
@@ -13116,6 +13452,7 @@ exports.tests = [
         chrome51:    true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       }
     },
     {
@@ -13132,6 +13469,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -13148,6 +13486,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -13167,6 +13506,7 @@ exports.tests = [
         chrome49:    true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       }
     },
     {
@@ -13186,6 +13526,7 @@ exports.tests = [
         chrome45:    strict,
         chrome49:    true,
         webkit:      true,
+        jxa:         true,
       }
     },
   ],
@@ -13214,6 +13555,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13235,6 +13577,7 @@ exports.tests = [
         xs6:         true,
         ejs:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
     {
@@ -13255,6 +13598,7 @@ exports.tests = [
         node5:       strict,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13275,6 +13619,7 @@ exports.tests = [
         node5:       strict,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
   ],
@@ -13552,6 +13897,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13574,6 +13920,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13598,6 +13945,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13622,6 +13970,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
     {
@@ -13647,6 +13996,7 @@ exports.tests = [
         firefox45:   true,
         xs6:         true,
         ejs:         true,
+        jxa:         true,
       },
     },
   ],
@@ -13691,7 +14041,7 @@ exports.tests = [
 
         var forInOrder = '';
         for(var key in obj)forInOrder += key;
-        
+
         return Object.keys(obj).join('') === forInOrder;
       */},
       res: {
@@ -13708,6 +14058,7 @@ exports.tests = [
         ejs:           false,
         konq49:        null,
         rhino17:       null,
+        jxa:           true,
       },
     },
     {
@@ -13743,6 +14094,7 @@ exports.tests = [
         webkit:        true,
         xs6:           true,
         chrome49:      true,
+        jxa:           true,
       },
     },
     {
@@ -13782,6 +14134,7 @@ exports.tests = [
         webkit:      true,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -13821,6 +14174,7 @@ exports.tests = [
         webkit:        true,
         android40:     true,
         xs6:           true,
+        jxa:           true,
       },
     },
     {
@@ -13850,6 +14204,7 @@ exports.tests = [
         webkit:        true,
         android40:     true,
         xs6:           true,
+        jxa:           true,
       },
     },
     {
@@ -13953,6 +14308,7 @@ exports.tests = [
         opera:       true,
         xs6:         true,
         chrome49:    true,
+        jxa:         true,
       },
     },
     {
@@ -13970,6 +14326,7 @@ exports.tests = [
         webkit:      true,
         node4:       true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -13992,6 +14349,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -14010,6 +14368,7 @@ exports.tests = [
         closure:     true,
         typescript:  true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -14028,6 +14387,7 @@ exports.tests = [
         firefox41:   true,
         webkit:      true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -14051,6 +14411,7 @@ exports.tests = [
         node012:     true,
         android40:   true,
         xs6:         true,
+        jxa:         true,
       },
     },
     {
@@ -14081,6 +14442,7 @@ exports.tests = [
         chrome51:    true,
         ejs:         null,
         xs6:         null,
+        jxa:         true,
       },
     },
     {
@@ -14103,6 +14465,7 @@ exports.tests = [
       */},
       res: {
         xs6:         false,
+        jxa:         true,
       },
     },
     {
@@ -14125,6 +14488,7 @@ exports.tests = [
         node4:       true,
         xs6:         true,
         webkit:      true,
+        jxa:         true,
       },
     },
   ],

--- a/es6/index.html
+++ b/es6/index.html
@@ -199,6 +199,7 @@
 <th class="platform node5 engine" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node<br>5.0</abbr><a href="#harmony-flag-note"><sup>[5]</sup></a></a></th>
 <th class="platform ejs engine unstable" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>
 <th class="platform xs6 engine" data-browser="xs6"><a href="#xs6" class="browser-name"><abbr title="Kinoma XS6">XS6</abbr></a></th>
+<th class="platform jxa engine" data-browser="jxa"><a href="#jxa" class="browser-name"><abbr title="JavaScript Automation for OS X">JXA</abbr></a></th>
 <th class="platform android40 mobile obsolete" data-browser="android40"><a href="#android40" class="browser-name"><abbr title="Android Browser">AN 4.0</abbr></a></th>
 <th class="platform android41 mobile obsolete" data-browser="android41"><a href="#android41" class="browser-name"><abbr title="Android Browser">AN 4.1</abbr></a></th>
 <th class="platform android42 mobile obsolete" data-browser="android42"><a href="#android42" class="browser-name"><abbr title="Android Browser">AN 4.2</abbr></a></th>
@@ -214,7 +215,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">Optimisation</td>
+      <tr class="category"><td colspan="73">Optimisation</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-proper_tail_calls_(tail_call_optimisation)"><span><a class="anchor" href="#test-proper_tail_calls_(tail_call_optimisation)">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls">proper tail calls (tail call optimisation)</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0" data-flagged-tally="1">0/2</td>
@@ -277,6 +278,7 @@
 <td class="tally" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0">0/2</td>
 <td class="tally" data-browser="xs6" data-tally="1">2/2</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -358,6 +360,7 @@ return (function f(n){
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -446,6 +449,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -457,7 +461,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Syntax</td>
+<tr class="category"><td colspan="73">Syntax</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-default_function_parameters"><span><a class="anchor" href="#test-default_function_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">default function parameters</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -520,6 +524,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="node5" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="xs6" data-tally="1">7/7</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/7</td>
@@ -595,6 +600,7 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -670,6 +676,7 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -745,6 +752,7 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -827,6 +835,7 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -912,6 +921,7 @@ return (function(x = 1) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -992,6 +1002,7 @@ return (function(a=function(){
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1069,6 +1080,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-function-ctor-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1141,6 +1153,7 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="xs6" data-tally="1">5/5</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
@@ -1218,6 +1231,7 @@ return (function (foo, ...args) {
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1293,6 +1307,7 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1376,6 +1391,7 @@ return (function (foo, ...args) {
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1457,6 +1473,7 @@ return (function (...args) {
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1534,6 +1551,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-function-ctor-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1606,6 +1624,7 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="node5" data-tally="1">15/15</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">10/15</td>
 <td class="tally" data-browser="xs6" data-tally="1">15/15</td>
+<td class="tally" data-browser="jxa" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/15</td>
@@ -1681,6 +1700,7 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1756,6 +1776,7 @@ return [...[1, 2, 3]][2] === 3;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1832,6 +1853,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1908,6 +1930,7 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1983,6 +2006,7 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2058,6 +2082,7 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2133,6 +2158,7 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2208,6 +2234,7 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2284,6 +2311,7 @@ return Math.max(...iterable) === 3;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2360,6 +2388,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2436,6 +2465,7 @@ return Math.max(...iterable) === 3;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2512,6 +2542,7 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2588,6 +2619,7 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2664,6 +2696,7 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2743,6 +2776,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2815,6 +2849,7 @@ try {
 <td class="tally" data-browser="node5" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="xs6" data-tally="1">6/6</td>
+<td class="tally" data-browser="jxa" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
@@ -2891,6 +2926,7 @@ return ({ [x]: 1 }).y === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2967,6 +3003,7 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3042,6 +3079,7 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3117,6 +3155,7 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3193,6 +3232,7 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3275,6 +3315,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3347,6 +3388,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="node5" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally" data-browser="xs6" data-tally="1">9/9</td>
+<td class="tally" data-browser="jxa" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/9</td>
@@ -3424,6 +3466,7 @@ for (var item of arr)
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3503,6 +3546,7 @@ return count === 2;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3581,6 +3625,7 @@ return str === &quot;foo&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3659,6 +3704,7 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3739,6 +3785,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3819,6 +3866,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3899,6 +3947,7 @@ return result === &quot;123&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3979,6 +4028,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4061,6 +4111,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4133,6 +4184,7 @@ return closed;
 <td class="tally" data-browser="node5" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="xs6" data-tally="1">4/4</td>
+<td class="tally" data-browser="jxa" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -4208,6 +4260,7 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4283,6 +4336,7 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4358,6 +4412,7 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4433,6 +4488,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4505,6 +4561,7 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="node5" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="xs6" data-tally="1">5/5</td>
+<td class="tally" data-browser="jxa" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
@@ -4582,6 +4639,7 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4661,6 +4719,7 @@ return `${a}` === &quot;foo&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4747,6 +4806,7 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4824,6 +4884,7 @@ return (function(parts) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4904,6 +4965,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4976,6 +5038,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="node5" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="xs6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -5053,6 +5116,7 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5131,6 +5195,7 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5206,6 +5271,7 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="xs6">No</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5281,6 +5347,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="xs6">No</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5353,6 +5420,7 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="tally" data-browser="node5" data-tally="0">0/22</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">12/22</td>
 <td class="tally" data-browser="xs6" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
+<td class="tally" data-browser="jxa" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/22</td>
@@ -5429,6 +5497,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5505,6 +5574,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5581,6 +5651,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5657,6 +5728,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5733,6 +5805,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5809,6 +5882,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5885,6 +5959,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5965,6 +6040,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6041,6 +6117,7 @@ return a === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6117,6 +6194,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6195,6 +6273,7 @@ return toFixed === Number.prototype.toFixed
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6271,6 +6350,7 @@ return a === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6354,6 +6434,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6431,6 +6512,7 @@ return grault === &quot;garply&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6507,6 +6589,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6585,6 +6668,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6662,6 +6746,7 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6739,6 +6824,7 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6822,6 +6908,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="xs6">No</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6900,6 +6987,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6978,6 +7066,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7062,6 +7151,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7134,6 +7224,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="node5" data-tally="0">0/24</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
 <td class="tally" data-browser="xs6" data-tally="1">24/24</td>
+<td class="tally" data-browser="jxa" data-tally="0.875" style="background-color:hsl(105,47%,50%)">21/24</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/24</td>
@@ -7211,6 +7302,7 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7288,6 +7380,7 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7365,6 +7458,7 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7442,6 +7536,7 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7519,6 +7614,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7596,6 +7692,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7673,6 +7770,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7754,6 +7852,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7830,6 +7929,7 @@ return ([a, b] = iterable) === iterable;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7907,6 +8007,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7984,6 +8085,7 @@ return a === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8061,6 +8163,7 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8140,6 +8243,7 @@ return toFixed === Number.prototype.toFixed
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8217,6 +8321,7 @@ return a === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8293,6 +8398,7 @@ return ({a,b} = obj) === obj;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8375,6 +8481,7 @@ catch(e) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8452,6 +8559,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8536,6 +8644,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8613,6 +8722,7 @@ return grault === &quot;garply&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8692,6 +8802,7 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8771,6 +8882,7 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8848,6 +8960,7 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -8925,6 +9038,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9004,6 +9118,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9076,6 +9191,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="node5" data-tally="0">0/23</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
 <td class="tally" data-browser="xs6" data-tally="1">23/23</td>
+<td class="tally" data-browser="jxa" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/23</td>
@@ -9153,6 +9269,7 @@ return function([a, , [b], c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9230,6 +9347,7 @@ return function([a, , b]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9307,6 +9425,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9384,6 +9503,7 @@ return function([c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9461,6 +9581,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9538,6 +9659,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9615,6 +9737,7 @@ return function([a, b, c]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9695,6 +9818,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9772,6 +9896,7 @@ return function([a,]) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9849,6 +9974,7 @@ return function({c, x:d, e}) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -9927,6 +10053,7 @@ return function({toFixed}, {slice}) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10004,6 +10131,7 @@ return function({a,}) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10087,6 +10215,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10165,6 +10294,7 @@ return function({ [qux]: grault }) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10243,6 +10373,7 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10321,6 +10452,7 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10399,6 +10531,7 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10474,6 +10607,7 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10552,6 +10686,7 @@ return function([a, ...b], [c, ...d]) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10629,6 +10764,7 @@ return function ([],{}){
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10708,6 +10844,7 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10788,6 +10925,7 @@ return (function({a=function(){
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10865,6 +11003,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-function-ctor-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -10937,6 +11076,7 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="node5" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">2/2</td>
 <td class="tally" data-browser="xs6" data-tally="1">2/2</td>
+<td class="tally" data-browser="jxa" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -11012,6 +11152,7 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11088,6 +11229,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11160,6 +11302,7 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="node5" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">2/2</td>
 <td class="tally" data-browser="xs6" data-tally="1">2/2</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -11242,6 +11385,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11326,6 +11470,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11337,7 +11482,7 @@ try {
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Bindings</td>
+<tr class="category"><td colspan="73">Bindings</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-const"><span><a class="anchor" href="#test-const">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations">const</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
@@ -11400,6 +11545,7 @@ try {
 <td class="tally" data-browser="node5" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
 <td class="tally" data-browser="xs6" data-tally="1">10/10</td>
+<td class="tally" data-browser="jxa" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.1" style="background-color:hsl(12,81%,50%)">1/10</td>
@@ -11476,6 +11622,7 @@ return (foo === 123);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -11553,6 +11700,7 @@ return bar === 123;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11633,6 +11781,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11713,6 +11862,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11792,6 +11942,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11869,6 +12020,7 @@ return (foo === 123);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -11947,6 +12099,7 @@ return bar === 123;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12028,6 +12181,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12109,6 +12263,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12189,6 +12344,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12261,6 +12417,7 @@ return passed;
 <td class="tally" data-browser="node5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally" data-browser="xs6" data-tally="1">12/12</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/12</td>
@@ -12337,6 +12494,7 @@ return (foo === 123);
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12414,6 +12572,7 @@ return bar === 123;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12494,6 +12653,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12571,6 +12731,7 @@ return baz === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12650,6 +12811,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12736,6 +12898,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12813,6 +12976,7 @@ return (foo === 123);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12891,6 +13055,7 @@ return bar === 123;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -12972,6 +13137,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13050,6 +13216,7 @@ return baz === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13130,6 +13297,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13217,6 +13385,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13297,6 +13466,7 @@ return f() === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13308,7 +13478,7 @@ return f() === 1;
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Functions</td>
+<tr class="category"><td colspan="73">Functions</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-arrow_functions"><span><a class="anchor" href="#test-arrow_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions">arrow functions</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.8461538461538461" style="background-color:hsl(101,48%,50%)">11/13</td>
@@ -13371,6 +13541,7 @@ return f() === 1;
 <td class="tally" data-browser="node5" data-tally="0.7692307692307693" style="background-color:hsl(92,52%,50%)" data-flagged-tally="0.9230769230769231">10/13</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5384615384615384" style="background-color:hsl(64,62%,50%)">7/13</td>
 <td class="tally" data-browser="xs6" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/13</td>
@@ -13446,6 +13617,7 @@ return (() =&gt; 5)() === 5;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13522,6 +13694,7 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13598,6 +13771,7 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13675,6 +13849,7 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13752,6 +13927,7 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13829,6 +14005,7 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13905,6 +14082,7 @@ return f(6) === 5;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -13982,6 +14160,7 @@ return (() =&gt; {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14059,6 +14238,7 @@ return (() =&gt; {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="xs6">No</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14135,6 +14315,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14223,6 +14404,7 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14309,6 +14491,7 @@ return arrow() === &quot;quux&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14387,6 +14570,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14459,6 +14643,7 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/23</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">21/23</td>
 <td class="tally" data-browser="xs6" data-tally="1">23/23</td>
+<td class="tally" data-browser="jxa" data-tally="0.7391304347826086" style="background-color:hsl(88,53%,50%)">17/23</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/23</td>
@@ -14535,6 +14720,7 @@ return typeof C === &quot;function&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14616,6 +14802,7 @@ return C === c1;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14691,6 +14878,7 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14766,6 +14954,7 @@ return typeof class {} === &quot;function&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14845,6 +15034,7 @@ return C.prototype.constructor === C
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -14924,6 +15114,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15003,6 +15194,7 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15083,6 +15275,7 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15162,6 +15355,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15242,6 +15436,7 @@ return typeof C.method === &quot;function&quot;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15323,6 +15518,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15404,6 +15600,7 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15485,6 +15682,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15566,6 +15764,7 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15646,6 +15845,7 @@ return C === undefined &amp;&amp; M();
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15727,6 +15927,7 @@ try {
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15806,6 +16007,7 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15884,6 +16086,7 @@ return (0,C.method)();
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -15965,6 +16168,7 @@ catch(e) {
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16043,6 +16247,7 @@ return new C() instanceof B
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16121,6 +16326,7 @@ return new C() instanceof B
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16200,6 +16406,7 @@ return Function.prototype.isPrototypeOf(C)
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16287,6 +16494,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16359,6 +16567,7 @@ return passed;
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/8</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td class="tally" data-browser="xs6" data-tally="1">8/8</td>
+<td class="tally" data-browser="jxa" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/8</td>
@@ -16442,6 +16651,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16523,6 +16733,7 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16605,6 +16816,7 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16686,6 +16898,7 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16769,6 +16982,7 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16852,6 +17066,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -16937,6 +17152,7 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17024,6 +17240,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17096,6 +17313,7 @@ return passed;
 <td class="tally" data-browser="node5" data-tally="0.76" style="background-color:hsl(91,52%,50%)" data-flagged-tally="0.84">19/25</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.64" style="background-color:hsl(76,57%,50%)">16/25</td>
 <td class="tally" data-browser="xs6" data-tally="1">25/25</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/25</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/25</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/25</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/25</td>
@@ -17181,6 +17399,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17266,6 +17485,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17351,6 +17571,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17434,6 +17655,7 @@ catch (e) {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17517,6 +17739,7 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17601,6 +17824,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17686,6 +17910,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17772,6 +17997,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17857,6 +18083,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -17939,6 +18166,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18023,6 +18251,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18107,6 +18336,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18191,6 +18421,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18275,6 +18506,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18361,6 +18593,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18447,6 +18680,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18533,6 +18767,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18620,6 +18855,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18711,6 +18947,7 @@ return closed === &apos;ab&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18801,6 +19038,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18888,6 +19126,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -18975,6 +19214,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -19063,6 +19303,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -19150,6 +19391,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -19238,6 +19480,7 @@ return passed;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -19249,7 +19492,7 @@ return passed;
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Built-ins</td>
+<tr class="category"><td colspan="73">Built-ins</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-typed_arrays"><span><a class="anchor" href="#test-typed_arrays">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects">typed arrays</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/46</td>
@@ -19312,6 +19555,7 @@ return passed;
 <td class="tally" data-browser="node5" data-tally="0.9347826086956522" style="background-color:hsl(112,44%,50%)">43/46</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8043478260869565" style="background-color:hsl(96,50%,50%)">37/46</td>
 <td class="tally" data-browser="xs6" data-tally="1">46/46</td>
+<td class="tally" data-browser="jxa" data-tally="1">46/46</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.32608695652173914" style="background-color:hsl(39,71%,50%)">15/46</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
@@ -19389,6 +19633,7 @@ return view[0] === -0x80;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19466,6 +19711,7 @@ return view[0] === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19543,6 +19789,7 @@ return view[0] === 0xFF;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -19620,6 +19867,7 @@ return view[0] === -0x8000;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19697,6 +19945,7 @@ return view[0] === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19774,6 +20023,7 @@ return view[0] === -0x80000000;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19851,6 +20101,7 @@ return view[0] === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -19928,6 +20179,7 @@ return view[0] === 0.10000000149011612;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20005,6 +20257,7 @@ return view[0] === 0.1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20083,6 +20336,7 @@ return view.getInt8(0) === -0x80;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20161,6 +20415,7 @@ return view.getUint8(0) === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20239,6 +20494,7 @@ return view.getInt16(0) === -0x8000;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20317,6 +20573,7 @@ return view.getUint16(0) === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20395,6 +20652,7 @@ return view.getInt32(0) === -0x80000000;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20473,6 +20731,7 @@ return view.getUint32(0) === 0;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20551,6 +20810,7 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20629,6 +20889,7 @@ return view.getFloat64(0) === 0.1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -20704,6 +20965,7 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -20802,6 +21064,7 @@ return constructors.every(function (constructor) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -20892,6 +21155,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -20990,6 +21254,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21073,6 +21338,7 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21156,6 +21422,7 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21239,6 +21506,7 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21322,6 +21590,7 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21405,6 +21674,7 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21488,6 +21758,7 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21571,6 +21842,7 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21654,6 +21926,7 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21737,6 +22010,7 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21820,6 +22094,7 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21903,6 +22178,7 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -21986,6 +22262,7 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22069,6 +22346,7 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22152,6 +22430,7 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22235,6 +22514,7 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22318,6 +22598,7 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22401,6 +22682,7 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22484,6 +22766,7 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22567,6 +22850,7 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22650,6 +22934,7 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22733,6 +23018,7 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22816,6 +23102,7 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22899,6 +23186,7 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -22982,6 +23270,7 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23065,6 +23354,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23137,6 +23427,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="node5" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally" data-browser="xs6" data-tally="1">18/18</td>
+<td class="tally" data-browser="jxa" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/18</td>
@@ -23217,6 +23508,7 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23297,6 +23589,7 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23378,6 +23671,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23454,6 +23748,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23539,6 +23834,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23621,6 +23917,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23697,6 +23994,7 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23778,6 +24076,7 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23858,6 +24157,7 @@ return map.size === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -23933,6 +24233,7 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24008,6 +24309,7 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24083,6 +24385,7 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24158,6 +24461,7 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24233,6 +24537,7 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24308,6 +24613,7 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24383,6 +24689,7 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24468,6 +24775,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24544,6 +24852,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24616,6 +24925,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="node5" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">16/18</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
 <td class="tally" data-browser="xs6" data-tally="1">18/18</td>
+<td class="tally" data-browser="jxa" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/18</td>
@@ -24697,6 +25007,7 @@ return set.has(123);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24776,6 +25087,7 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24857,6 +25169,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -24933,6 +25246,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25018,6 +25332,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25103,6 +25418,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25179,6 +25495,7 @@ return set.add(0) === set;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25260,6 +25577,7 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25342,6 +25660,7 @@ return set.size === 2;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25417,6 +25736,7 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25492,6 +25812,7 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25567,6 +25888,7 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25642,6 +25964,7 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25717,6 +26040,7 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25792,6 +26116,7 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25867,6 +26192,7 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -25952,6 +26278,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26028,6 +26355,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26100,6 +26428,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="node5" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally" data-browser="xs6" data-tally="1">10/10</td>
+<td class="tally" data-browser="jxa" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/10</td>
@@ -26180,6 +26509,7 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26260,6 +26590,7 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26341,6 +26672,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26417,6 +26749,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26502,6 +26835,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26580,6 +26914,7 @@ return m.get(f) === 42;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26662,6 +26997,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26739,6 +27075,7 @@ return weakmap.set(key, 0) === weakmap;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26814,6 +27151,7 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26896,6 +27234,7 @@ return m.has(key);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -26968,6 +27307,7 @@ return m.has(key);
 <td class="tally" data-browser="node5" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8888888888888888" style="background-color:hsl(106,46%,50%)">8/9</td>
 <td class="tally" data-browser="xs6" data-tally="1">9/9</td>
+<td class="tally" data-browser="jxa" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/9</td>
@@ -27049,6 +27389,7 @@ return weakset.has(obj1);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27127,6 +27468,7 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27208,6 +27550,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27284,6 +27627,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27369,6 +27713,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27451,6 +27796,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27528,6 +27874,7 @@ return weakset.add(obj) === weakset;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27603,6 +27950,7 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27685,6 +28033,7 @@ return s.has(key);
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27757,6 +28106,7 @@ return s.has(key);
 <td class="tally" data-browser="node5" data-tally="0">0/20</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8" style="background-color:hsl(96,50%,50%)">16/20</td>
 <td class="tally" data-browser="xs6" data-tally="1">20/20</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/20</td>
@@ -27838,6 +28188,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -27919,6 +28270,7 @@ return proxy.foo === 5;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28000,6 +28352,7 @@ return proxy.foo === 5;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28083,6 +28436,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28166,6 +28520,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28248,6 +28603,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28330,6 +28686,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28412,6 +28769,7 @@ var proxied = {};
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28500,6 +28858,7 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28587,6 +28946,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28669,6 +29029,7 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28756,6 +29117,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28840,6 +29202,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -28925,6 +29288,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29009,6 +29373,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29094,6 +29459,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29177,6 +29543,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29260,6 +29627,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29335,6 +29703,7 @@ return Array.isArray(new Proxy([], {}));
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29410,6 +29779,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29482,6 +29852,7 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="node5" data-tally="0">0/16</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="xs6" data-tally="1">16/16</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/16</td>
@@ -29557,6 +29928,7 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29634,6 +30006,7 @@ return obj.quux === 654;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29709,6 +30082,7 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29786,6 +30160,7 @@ return !(&quot;bar&quot; in obj);
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29864,6 +30239,7 @@ return desc.value === 789 &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -29942,6 +30318,7 @@ return obj.foo === 123 &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30017,6 +30394,7 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30094,6 +30472,7 @@ return obj instanceof Array;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30170,6 +30549,7 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30247,6 +30627,7 @@ return !Object.isExtensible(obj);
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30326,6 +30707,7 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30409,6 +30791,7 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30484,6 +30867,7 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30561,6 +30945,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30640,6 +31025,7 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30716,6 +31102,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30788,6 +31175,7 @@ return Reflect.construct(function(){}, [], F) instanceof F;
 <td class="tally" data-browser="node5" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally" data-browser="xs6" data-tally="1">7/7</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/7</td>
@@ -30884,6 +31272,7 @@ function check() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -30965,6 +31354,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31054,6 +31444,7 @@ function check() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31143,6 +31534,7 @@ function check() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31232,6 +31624,7 @@ function check() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31321,6 +31714,7 @@ function check() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31397,6 +31791,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31469,6 +31864,7 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="node5" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="xs6" data-tally="1">10/10</td>
+<td class="tally" data-browser="jxa" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/10</td>
@@ -31548,6 +31944,7 @@ return object[symbol] === value;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31623,6 +32020,7 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31710,6 +32108,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31794,6 +32193,7 @@ return passed;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31882,6 +32282,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -31957,6 +32358,7 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32037,6 +32439,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32119,6 +32522,7 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32197,6 +32601,7 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32274,6 +32679,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32346,6 +32752,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="node5" data-tally="0.125" style="background-color:hsl(15,80%,50%)" data-flagged-tally="0.20833333333333334">3/24</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">22/24</td>
 <td class="tally" data-browser="xs6" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
+<td class="tally" data-browser="jxa" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">20/24</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/24</td>
@@ -32428,6 +32835,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32506,6 +32914,7 @@ return a[0] === b;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32581,6 +32990,7 @@ return &quot;iterator&quot; in Symbol;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32659,6 +33069,7 @@ return (function() {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32734,6 +33145,7 @@ return &quot;species&quot; in Symbol;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32814,6 +33226,7 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32894,6 +33307,7 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -32974,6 +33388,7 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33054,6 +33469,7 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33134,6 +33550,7 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33217,6 +33634,7 @@ return passed;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33296,6 +33714,7 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="no" data-browser="node5">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="unknown" data-browser="xs6">?</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33375,6 +33794,7 @@ return &apos;&apos;.replace(O) === 42;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33454,6 +33874,7 @@ return &apos;&apos;.search(O) === 42;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33533,6 +33954,7 @@ return &apos;&apos;.split(O) === 42;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33612,6 +34034,7 @@ return &apos;&apos;.match(O) === 42;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33691,6 +34114,7 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33772,6 +34196,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33853,6 +34278,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -33934,6 +34360,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34018,6 +34445,7 @@ return passed === 3;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34095,6 +34523,7 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34172,6 +34601,7 @@ return Math[s] === &quot;Math&quot;
 <td class="no flagged" data-browser="node5">Flag</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34251,6 +34681,7 @@ with (a) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[18]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34262,7 +34693,7 @@ with (a) {
 <td class="no" data-browser="ios8">No</td>
 <td class="yes" data-browser="ios9">Yes</td>
 </tr>
-<tr class="category"><td colspan="72">Built-in extensions</td>
+<tr class="category"><td colspan="73">Built-in extensions</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
@@ -34325,6 +34756,7 @@ with (a) {
 <td class="tally" data-browser="node5" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">4/4</td>
 <td class="tally" data-browser="xs6" data-tally="1">4/4</td>
+<td class="tally" data-browser="jxa" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -34401,6 +34833,7 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34478,6 +34911,7 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -34561,6 +34995,7 @@ return result[0] === sym
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34636,6 +35071,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -34708,6 +35144,7 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="node5" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)" data-flagged-tally="0.5882352941176471">6/17</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.29411764705882354" style="background-color:hsl(35,73%,50%)">5/17</td>
 <td class="tally" data-browser="xs6" data-tally="1">17/17</td>
+<td class="tally" data-browser="jxa" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">14/17</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.11764705882352941" style="background-color:hsl(14,80%,50%)">2/17</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.11764705882352941" style="background-color:hsl(14,80%,50%)">2/17</td>
@@ -34785,6 +35222,7 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -34861,6 +35299,7 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -34936,6 +35375,7 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-function-ctor-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35013,6 +35453,7 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35090,6 +35531,7 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35169,6 +35611,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35247,6 +35690,7 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35323,6 +35767,7 @@ return o.foo.name === &quot;foo&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35399,6 +35844,7 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35482,6 +35928,7 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35560,6 +36007,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35636,6 +36084,7 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35716,6 +36165,7 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35795,6 +36245,7 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35871,6 +36322,7 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -35947,6 +36399,7 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36025,6 +36478,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36097,6 +36551,7 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="node5" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">2/2</td>
 <td class="tally" data-browser="xs6" data-tally="1">2/2</td>
+<td class="tally" data-browser="jxa" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -36172,6 +36627,7 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36247,6 +36703,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36319,6 +36776,7 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="node5" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="xs6" data-tally="1">8/8</td>
+<td class="tally" data-browser="jxa" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/8</td>
@@ -36394,6 +36852,7 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36471,6 +36930,7 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36547,6 +37007,7 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36623,6 +37084,7 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36699,6 +37161,7 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36775,6 +37238,7 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36850,6 +37314,7 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -36935,6 +37400,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37007,6 +37473,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="node5" data-tally="0">0/6</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">6/6</td>
 <td class="tally" data-browser="xs6" data-tally="1">6/6</td>
+<td class="tally" data-browser="jxa" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
@@ -37082,6 +37549,7 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37157,6 +37625,7 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37232,6 +37701,7 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37307,6 +37777,7 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37382,6 +37853,7 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37458,6 +37930,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37530,6 +38003,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="node5" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5454545454545454" style="background-color:hsl(65,62%,50%)">6/11</td>
 <td class="tally" data-browser="xs6" data-tally="1">11/11</td>
+<td class="tally" data-browser="jxa" data-tally="0.7272727272727273" style="background-color:hsl(87,54%,50%)">8/11</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/11</td>
@@ -37605,6 +38079,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37681,6 +38156,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37757,6 +38233,7 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37833,6 +38310,7 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37910,6 +38388,7 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -37988,6 +38467,7 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38066,6 +38546,7 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38144,6 +38625,7 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38226,6 +38708,7 @@ return closed;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38302,6 +38785,7 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38378,6 +38862,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38450,6 +38935,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="node5" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="xs6" data-tally="1">10/10</td>
+<td class="tally" data-browser="jxa" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/10</td>
@@ -38525,6 +39011,7 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38600,6 +39087,7 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38675,6 +39163,7 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38750,6 +39239,7 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38825,6 +39315,7 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38900,6 +39391,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -38975,6 +39467,7 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39050,6 +39543,7 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39135,6 +39629,7 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39218,6 +39713,7 @@ return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39290,6 +39786,7 @@ return true;
 <td class="tally" data-browser="node5" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">7/7</td>
 <td class="tally" data-browser="xs6" data-tally="1">7/7</td>
+<td class="tally" data-browser="jxa" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -39365,6 +39862,7 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -39440,6 +39938,7 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39515,6 +40014,7 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39590,6 +40090,7 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -39665,6 +40166,7 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39740,6 +40242,7 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39815,6 +40318,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -39887,6 +40391,7 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="node5" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">17/17</td>
 <td class="tally" data-browser="xs6" data-tally="1">17/17</td>
+<td class="tally" data-browser="jxa" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/17</td>
@@ -39962,6 +40467,7 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40037,6 +40543,7 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40112,6 +40619,7 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40187,6 +40695,7 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40262,6 +40771,7 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40337,6 +40847,7 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40412,6 +40923,7 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40487,6 +40999,7 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40562,6 +41075,7 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40637,6 +41151,7 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40712,6 +41227,7 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40787,6 +41303,7 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40862,6 +41379,7 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -40937,6 +41455,7 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41012,6 +41531,7 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41087,6 +41607,7 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41165,6 +41686,7 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41255,6 +41777,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="no" data-browser="ios9">No</td>
 </tr>
 <tr class="category"><td colspan="72">Subclassing</td>
+<tr class="category"><td colspan="73">Subclassing</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_is_subclassable"><span><a class="anchor" href="#test-Array_is_subclassable">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-array-constructor">Array is subclassable</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/11</td>
@@ -41317,6 +41840,7 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">11/11</td>
 <td class="tally" data-browser="xs6" data-tally="1">11/11</td>
+<td class="tally" data-browser="jxa" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/11</td>
@@ -41397,6 +41921,7 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41476,6 +42001,7 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41553,6 +42079,7 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41629,6 +42156,7 @@ return Array.isArray(new C());
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41706,6 +42234,7 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41783,6 +42312,7 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41860,6 +42390,7 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -41938,6 +42469,7 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42016,6 +42548,7 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42092,6 +42625,7 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42168,6 +42702,7 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42240,6 +42775,7 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">4/4</td>
 <td class="tally" data-browser="xs6" data-tally="1">4/4</td>
+<td class="tally" data-browser="jxa" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -42317,6 +42853,7 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42394,6 +42931,7 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42471,6 +43009,7 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42548,6 +43087,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42620,6 +43160,7 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="0.6666666666666666">0/6</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0">0/6</td>
 <td class="tally" data-browser="xs6" data-tally="1">6/6</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
@@ -42697,6 +43238,7 @@ return c() === &apos;foo&apos;;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42774,6 +43316,7 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42852,6 +43395,7 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -42929,6 +43473,7 @@ return c.call({bar:1}, 2) === 3;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43006,6 +43551,7 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43083,6 +43629,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43155,6 +43702,7 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="xs6" data-tally="1">4/4</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -43252,6 +43800,7 @@ function check() {
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43329,6 +43878,7 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43419,6 +43969,7 @@ function check() {
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43509,6 +44060,7 @@ function check() {
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43581,6 +44133,7 @@ function check() {
 <td class="tally" data-browser="node5" data-tally="0" data-flagged-tally="1">0/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">5/5</td>
 <td class="tally" data-browser="xs6" data-tally="1">5/5</td>
+<td class="tally" data-browser="jxa" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
@@ -43660,6 +44213,7 @@ return c instanceof Boolean
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43739,6 +44293,7 @@ return c instanceof Number
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43820,6 +44375,7 @@ return c instanceof String
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43901,6 +44457,7 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43983,6 +44540,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -43994,7 +44552,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Misc</td>
+<tr class="category"><td colspan="73">Misc</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-prototype_of_bound_functions"><span><a class="anchor" href="#test-prototype_of_bound_functions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-boundfunctioncreate">prototype of bound functions</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/5</td>
@@ -44057,6 +44615,7 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="node5" data-tally="0.6" style="background-color:hsl(72,59%,50%)" data-flagged-tally="1">3/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="xs6" data-tally="1">5/5</td>
+<td class="tally" data-browser="jxa" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
@@ -44145,6 +44704,7 @@ return correctProtoBound(Function.prototype)
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44233,6 +44793,7 @@ return correctProtoBound(Function.prototype)
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44321,6 +44882,7 @@ return correctProtoBound(Function.prototype)
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44409,6 +44971,7 @@ return correctProtoBound(Function.prototype)
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44495,6 +45058,7 @@ return correctProtoBound(function(){})
 <td class="no strict" title="Support for this feature incorrectly requires strict mode." data-browser="node5">Strict</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44567,6 +45131,7 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="node5" data-tally="0">0/36</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
 <td class="tally" data-browser="xs6" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/36</td>
@@ -44646,6 +45211,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44725,6 +45291,7 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44805,6 +45372,7 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44887,6 +45455,7 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No<a href="#ejs-no-with-note"><sup>[18]</sup></a></td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -44966,6 +45535,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45045,6 +45615,7 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45135,6 +45706,7 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45222,6 +45794,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45301,6 +45874,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45380,6 +45954,7 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45459,6 +46034,7 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45538,6 +46114,7 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45618,6 +46195,7 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45699,6 +46277,7 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45778,6 +46357,7 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45857,6 +46437,7 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -45936,6 +46517,7 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="unknown" data-browser="xs6">?</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46017,6 +46599,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46098,6 +46681,7 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46177,6 +46761,7 @@ return get + &apos;&apos; === &quot;lastIndex,exec&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46258,6 +46843,7 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46337,6 +46923,7 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46423,6 +47010,7 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46515,6 +47103,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46594,6 +47183,7 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46673,6 +47263,7 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46752,6 +47343,7 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46832,6 +47424,7 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46911,6 +47504,7 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -46990,6 +47584,7 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47069,6 +47664,7 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47150,6 +47746,7 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47231,6 +47828,7 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47312,6 +47910,7 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47393,6 +47992,7 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47473,6 +48073,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47545,6 +48146,7 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="node5" data-tally="0">0/11</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
 <td class="tally" data-browser="xs6" data-tally="1">11/11</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/11</td>
@@ -47624,6 +48226,7 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47703,6 +48306,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47782,6 +48386,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47861,6 +48466,7 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -47940,6 +48546,7 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48019,6 +48626,7 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48098,6 +48706,7 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48177,6 +48786,7 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48256,6 +48866,7 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48335,6 +48946,7 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48414,6 +49026,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48486,6 +49099,7 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0">0/2</td>
 <td class="tally" data-browser="xs6" data-tally="1">2/2</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -48565,6 +49179,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48644,6 +49259,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48716,6 +49332,7 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="node5" data-tally="0">0/6</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="xs6" data-tally="1">6/6</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
@@ -48795,6 +49412,7 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48874,6 +49492,7 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -48953,6 +49572,7 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49032,6 +49652,7 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49111,6 +49732,7 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49190,6 +49812,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49262,6 +49885,7 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="node5" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="xs6" data-tally="1">4/4</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -49342,6 +49966,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49422,6 +50047,7 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49502,6 +50128,7 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49582,6 +50209,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49654,6 +50282,7 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="node5" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">3/3</td>
 <td class="tally" data-browser="xs6" data-tally="1">3/3</td>
+<td class="tally" data-browser="jxa" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/3</td>
@@ -49733,6 +50362,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49812,6 +50442,7 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49891,6 +50522,7 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -49963,6 +50595,7 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="node5" data-tally="1">10/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="xs6" data-tally="1">10/10</td>
+<td class="tally" data-browser="jxa" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/10</td>
@@ -50038,6 +50671,7 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50113,6 +50747,7 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50190,6 +50825,7 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50265,6 +50901,7 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50340,6 +50977,7 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50415,6 +51053,7 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50490,6 +51129,7 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50565,6 +51205,7 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50640,6 +51281,7 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50716,6 +51358,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -50788,6 +51431,7 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="node5" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally" data-browser="xs6" data-tally="1">7/7</td>
+<td class="tally" data-browser="jxa" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
@@ -50895,6 +51539,7 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -50990,6 +51635,7 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51090,6 +51736,7 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51186,6 +51833,7 @@ return JSON.stringify(obj) ===
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -51269,6 +51917,7 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -51364,6 +52013,7 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51454,6 +52104,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51526,6 +52177,7 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="node5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally" data-browser="xs6" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
+<td class="tally" data-browser="jxa" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
@@ -51606,6 +52258,7 @@ try {
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51682,6 +52335,7 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51757,6 +52411,7 @@ do {} while (false) return true;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -51837,6 +52492,7 @@ catch(e) {
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51916,6 +52572,7 @@ try {
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -51991,6 +52648,7 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -52066,6 +52724,7 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="no" data-browser="node5">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="no" data-browser="jxa">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52141,6 +52800,7 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="no" data-browser="node5">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
 <td class="unknown" data-browser="xs6">?</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52229,6 +52889,7 @@ return true;
 <td class="no" data-browser="node5">No</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="no" data-browser="xs6">No</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52312,6 +52973,7 @@ return false;
 <td class="yes" data-browser="node5">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
 <td class="yes" data-browser="xs6">Yes</td>
+<td class="yes" data-browser="jxa">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52323,7 +52985,7 @@ return false;
 <td class="no" data-browser="ios8">No</td>
 <td class="no" data-browser="ios9">No</td>
 </tr>
-<tr class="category"><td colspan="72">Annex b</td>
+<tr class="category"><td colspan="73">Annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[25]</sup></a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -52386,6 +53048,7 @@ return false;
 <td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
 <td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.6666666666666666">2/3</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -52475,6 +53138,7 @@ return passed;
 <td class="no not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52554,6 +53218,7 @@ return foo() === 2;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -52636,6 +53301,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -52708,6 +53374,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">5/5</td>
 <td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">5/5</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
@@ -52784,6 +53451,7 @@ return { __proto__ : [] } instanceof Array
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -52864,6 +53532,7 @@ catch(e) {
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -52943,6 +53612,7 @@ return !({ [a] : [] } instanceof Array);
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53022,6 +53692,7 @@ return !({ __proto__ } instanceof Array);
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53100,6 +53771,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53172,6 +53844,7 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
 <td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.3333333333333333">2/6</td>
 <td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.5" style="background-color:hsl(60,64%,50%)">3/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">2/6</td>
@@ -53248,6 +53921,7 @@ return (new A()).__proto__ === A.prototype;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -53325,6 +53999,7 @@ return o instanceof Array;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -53402,6 +54077,7 @@ return Object.getPrototypeOf(o) !== p;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53477,6 +54153,7 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53559,6 +54236,7 @@ return (desc
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53634,6 +54312,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -53706,6 +54385,7 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">3/3</td>
@@ -53788,6 +54468,7 @@ return true;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -53870,6 +54551,7 @@ return true;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -53951,6 +54633,7 @@ return true;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54026,6 +54709,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54098,6 +54782,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">8/8</td>
 <td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">4/8</td>
 <td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">5/8</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">8/8</td>
@@ -54173,6 +54858,7 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54249,6 +54935,7 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54324,6 +55011,7 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54400,6 +55088,7 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54476,6 +55165,7 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54552,6 +55242,7 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54628,6 +55319,7 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54704,6 +55396,7 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -54782,6 +55475,7 @@ return a === 3;
 <td class="yes not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>


### PR DESCRIPTION
I tested compatibility by following code.
- OS X 10.11.3
- node 5.5.0

```
function prehandleWithJxa(es6) {
  es6.tests.forEach(function(test) {
    if (test.subtests) {
      test.subtests.forEach(function(subtest) {
        var fn = subtest.exec;

        if (typeof fn === 'function') {
          var expr = (fn + '').match(/[^]*\/\*([^]*)\*\/\}$/);

          if (!expr) {
            return;
          }

          subtest.res.jxa = true;

          var fpath = os.tmpDir() + path.sep + 'temp.js';
          var file = fs.writeFileSync(fpath, `(function(global){global.__createIterableObject=function(arr, methods){methods=methods||{};if(typeof Symbol!=='function'||!Symbol.iterator){return{};}arr.length++;var iterator={next:function(){return{value:arr.shift(),done:arr.length<=0};},'return':methods['return'],'throw': methods['throw']};var iterable={};iterable[Symbol.iterator]=function(){return iterator;};return iterable;};${expr[1]}})(this);`);

          try {
            child_process.execSync(`osascript -l JavaScript ${fpath}`);
          } catch(e) {
            subtest.res.jxa = false;
          }
        }
      });
    }
  });
}
```
