### PR TITLE
Use try/catch blocks so thrown TypeErrors do not give false test results

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -1050,9 +1050,16 @@ exports.tests = [
   {
     name: 'undefined',
     exec: function () {/*
-      undefined = 12345;
-      var result = typeof undefined == 'undefined';
-      undefined = void 0;
+      var result = false;
+      try {
+        undefined = 12345;
+        result = typeof undefined == 'undefined';
+        undefined = void 0;
+      } catch (error) {
+        if (error instanceof TypeError) {
+          result = true;
+        }
+      }
       return result;
     */},
     res: {
@@ -1076,9 +1083,16 @@ exports.tests = [
   {
     name: 'NaN',
     exec: function () {/*
-      NaN = false;
-      var result = typeof NaN == 'number';
-      NaN = Math.sqrt(-1);
+      var result = false;
+      try {
+        NaN = false;
+        result = typeof NaN == 'number';
+        NaN = Math.sqrt(-1);
+      } catch (error) {
+        if (error instanceof TypeError) {
+          result = true;
+        }
+      }
       return result;
     */},
     res: {
@@ -1102,9 +1116,16 @@ exports.tests = [
   {
     name: 'Infinity',
     exec: function () {/*
-      Infinity = false;
-      var result = typeof Infinity == 'number';
-      Infinity = 1/0;
+      var result = false;
+      try {
+        Infinity = false;
+        result = typeof Infinity == 'number';
+        Infinity = 1/0;
+      } catch (error) {
+        if (error instanceof TypeError) {
+          result = true;
+        }
+      }
       return result;
     */},
     res: {


### PR DESCRIPTION
When running the tests in Node a TypeError is thrown and the result is never able to return correctly. This allows the errors to be captured and a successful result returned.
