### PR TITLE
Add test: Intl.DateTimeFormat should allow IANA timezone names to be used

### DIFF
--- a/data-esintl.js
+++ b/data-esintl.js
@@ -707,6 +707,33 @@ exports.tests = [
         ios7: false,
         ios9: false
       }
+    },
+    {
+      name: 'accepts IANA timezone names',
+      exec: function() {/*
+        try {
+          new Intl.DateTimeFormat('en-US', {
+            timeZone: 'Australia/Sydney',
+            timeZoneName: 'long'
+          }).format();
+          return true;
+        } catch (e) {
+          return false;
+        }
+      */},
+      res: {
+        ie9: false,
+        ie10: false,
+        ie11: false,
+        ie11: false,
+        edge: false,
+        edge14: true,
+        firefox29: false, // Firefox bug #1266290
+        chrome24: true,
+        chrome29: true,
+        node12: true,
+        node4: true,
+      }
     }
   ],
 },

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -990,40 +990,40 @@ try {
 <td class="no" data-browser="ios8">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a></span></td>
-<td class="tally" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally" data-browser="ie10" data-tally="0">0/6</td>
-<td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally" data-browser="edge" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox16" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally" data-browser="firefox36" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="chrome22" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="chrome24" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally" data-browser="chrome29" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
-<td class="tally" data-browser="safari7" data-tally="0">0/6</td>
-<td class="tally" data-browser="safari71_8" data-tally="0">0/6</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally" data-browser="webkit" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally obsolete" data-browser="opera" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="node10" data-tally="0">0/6</td>
-<td class="tally" data-browser="node12" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="iojs1_0" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="iojs1_1" data-tally="1">6/6</td>
-<td class="tally" data-browser="node4" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
-<td class="tally" data-browser="android44" data-tally="1">6/6</td>
-<td class="tally" data-browser="ios7" data-tally="0">0/6</td>
-<td class="tally" data-browser="ios8" data-tally="0">0/6</td>
+<td class="tally" data-browser="ie9" data-tally="0">0/7</td>
+<td class="tally" data-browser="ie10" data-tally="0">0/7</td>
+<td class="tally" data-browser="ie11" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally" data-browser="edge" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally unstable" data-browser="edge14" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox16" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="firefox29" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox30" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox31" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox32" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox33" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox34" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="firefox35" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally" data-browser="firefox36" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="chrome22" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="chrome24" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally" data-browser="chrome29" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0">0/7</td>
+<td class="tally" data-browser="safari7" data-tally="0">0/7</td>
+<td class="tally" data-browser="safari71_8" data-tally="0">0/7</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally" data-browser="webkit" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="opera" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node10" data-tally="0">0/7</td>
+<td class="tally" data-browser="node12" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="iojs1_0" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="iojs1_1" data-tally="1">7/7</td>
+<td class="tally" data-browser="node4" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0">0/7</td>
+<td class="tally" data-browser="android44" data-tally="1">7/7</td>
+<td class="tally" data-browser="ios7" data-tally="0">0/7</td>
+<td class="tally" data-browser="ios8" data-tally="0">0/7</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-DateTimeFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
@@ -1293,6 +1293,53 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no" data-browser="ios7">No</td>
 <td class="no" data-browser="ios8">No</td>
 </tr>
+<tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_IANA_timezone_names"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_IANA_timezone_names">&#xA7;</a>accepts IANA timezone names</span><script data-source="
+try {
+  new Intl.DateTimeFormat(&apos;en-US&apos;, {
+    timeZone: &apos;Australia/Sydney&apos;,
+    timeZoneName: &apos;long&apos;
+  }).format();
+  return true;
+} catch (e) {
+  return false;
+}
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="ie9">No</td>
+<td class="no" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no" data-browser="edge">No</td>
+<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="no obsolete" data-browser="firefox16">No</td>
+<td class="no obsolete" data-browser="firefox29">No</td>
+<td class="no obsolete" data-browser="firefox30">No</td>
+<td class="no obsolete" data-browser="firefox31">No</td>
+<td class="no obsolete" data-browser="firefox32">No</td>
+<td class="no obsolete" data-browser="firefox33">No</td>
+<td class="no obsolete" data-browser="firefox34">No</td>
+<td class="no obsolete" data-browser="firefox35">No</td>
+<td class="no" data-browser="firefox36">No</td>
+<td class="no obsolete" data-browser="chrome22">No</td>
+<td class="yes obsolete" data-browser="chrome24">Yes</td>
+<td class="yes" data-browser="chrome29">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
+<td class="no" data-browser="webkit">No</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="no obsolete" data-browser="node10">No</td>
+<td class="yes" data-browser="node12">Yes</td>
+<td class="yes obsolete" data-browser="iojs1_0">Yes</td>
+<td class="yes obsolete" data-browser="iojs1_1">Yes</td>
+<td class="yes" data-browser="node4">Yes</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="yes" data-browser="android44">Yes</td>
+<td class="no" data-browser="ios7">No</td>
+<td class="no" data-browser="ios8">No</td>
+</tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a></span></td>
 <td class="tally" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
@@ -1331,7 +1378,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 </tr>
 <tr class="subtest" data-parent="String.prototype.localeCompare" id="test-String.prototype.localeCompare_exists_on_String_prototype"><td><span><a class="anchor" href="#test-String.prototype.localeCompare_exists_on_String_prototype">&#xA7;</a>exists on String prototype</span><script data-source="
 return typeof String.prototype.localeCompare === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1406,7 +1453,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number.prototype.toLocaleString" id="test-Number.prototype.toLocaleString_exists_on_Number_prototype"><td><span><a class="anchor" href="#test-Number.prototype.toLocaleString_exists_on_Number_prototype">&#xA7;</a>exists on Number prototype</span><script data-source="
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1481,7 +1528,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype.toLocaleString" id="test-Array.prototype.toLocaleString_exists_on_Array_prototype"><td><span><a class="anchor" href="#test-Array.prototype.toLocaleString_exists_on_Array_prototype">&#xA7;</a>exists on Array prototype</span><script data-source="
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1556,7 +1603,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Object.prototype.toLocaleString" id="test-Object.prototype.toLocaleString_exists_on_Object_prototype"><td><span><a class="anchor" href="#test-Object.prototype.toLocaleString_exists_on_Object_prototype">&#xA7;</a>exists on Object prototype</span><script data-source="
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1631,7 +1678,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleString" id="test-Date.prototype.toLocaleString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1706,7 +1753,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleDateString" id="test-Date.prototype.toLocaleDateString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
@@ -1781,7 +1828,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleTimeString" id="test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>


### PR DESCRIPTION
Version 1.0 of the Intl spec (ECMA-402) specified that only UTC needed to be supported and all other timezones were optional. Version 2.0 of the spec modified this to say that IANA timezone names **must** be supported. Some browsers are still using the 1.0 version of this spec.

References:
- Old spec, 12.1.1.1 InitializeDateTimeFormat, step 16c: http://www.ecma-international.org/ecma-402/1.0/#sec-12.1.1.1
  
  > If tz is not "UTC", then throw a RangeError exception.
- New spec, 12.1.1 InitializeDateTimeFormat, steps 19c and 19d: http://www.ecma-international.org/ecma-402/2.0/#sec-InitializeDateTimeFormat
  
  > If the result of IsValidTimeZoneName(tz) is false, then Throw a RangeError exception.
  > Let tz be CanonicalizeTimeZoneName(tz).
  > 
  > The IsValidTimeZoneName abstract operation verifies that the timeZone argument (which must be a String value) represents a valid Zone or Link name of the IANA Time Zone Database.
- Firefox bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=1266290

To be verified:
- Edge 12 support. It _should_ be supported now (as per https://github.com/Microsoft/ChakraCore/pull/19), but I can't figure out how to actually get a copy of Edge 12 :stuck_out_tongue: 
- Webkit site only has Mac OS X builds, so I couldn't test Webkit. Likewise, Safari is Mac-only. Would appreciate if someone could test these for me.
