### PR TITLE
[ES6] Chrome 52+ removed Array.prototype.values (again)

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -15191,6 +15191,7 @@ exports.tests = [
         es6shim:     true,
         edge12:      true,
         chrome51:    true,
+        chrome52:    false,
         safari9:     true,
         safaritp:    true,
         safari10:    true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -42957,7 +42957,7 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally obsolete" data-browser="chrome49" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="chrome50" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally" data-browser="chrome51" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="chrome52" data-tally="1">10/10</td>
+<td class="tally unstable" data-browser="chrome52" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="safari51" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari6" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari7" data-tally="0">0/10</td>
@@ -43419,7 +43419,7 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome49">No<a href="#array-prototype-iterator-note"><sup>[26]</sup></a></td>
 <td class="no obsolete" data-browser="chrome50">No<a href="#array-prototype-iterator-note"><sup>[26]</sup></a></td>
 <td class="yes" data-browser="chrome51">Yes</td>
-<td class="yes unstable" data-browser="chrome52">Yes</td>
+<td class="no unstable" data-browser="chrome52">No</td>
 <td class="no obsolete" data-browser="safari51">No</td>
 <td class="no obsolete" data-browser="safari6">No</td>
 <td class="no obsolete" data-browser="safari7">No</td>


### PR DESCRIPTION
Refs https://crbug.com/615873
