### PR TITLE
New subtest for __lookup{G,S}etter__: data properties can shadow accessors

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -665,6 +665,27 @@ exports.tests = [
         },
       },
       {
+        name: '__lookupGetter__, data properties can shadow accessors',
+        exec: function () {/*
+         var a = { };
+         var b = Object.create(a);
+         b.foo = 1;
+         a.__defineGetter__("foo", function () {})
+         return b.__lookupGetter__("foo") === undefined
+         */},
+        res: (temp.lookupGetterShadowResults = {
+          babel:       true,
+          typescript:  typescript.corejs,
+          firefox31:   true,
+          safari51:    true,
+          safari9:     true,
+          safari10:    true,
+          safaritp:    true,
+          webkit:      true,
+          ios51:       true,
+        }),
+      },
+      {
         name: '__lookupSetter__',
         exec: function () {/*
          var obj = {
@@ -728,6 +749,17 @@ exports.tests = [
           safaritp:    true,
           webkit:      true,
         },
+      },
+      {
+        name: '__lookupSetter__, data properties can shadow accessors',
+        exec: function () {/*
+         var a = { };
+         var b = Object.create(a);
+         b.foo = 1;
+         a.__defineSetter__("foo", function () {})
+         return b.__lookupSetter__("foo") === undefined
+         */},
+        res: temp.lookupGetterShadowResults,
       }
     ]
   },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -1762,58 +1762,58 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <tr class="category"><td colspan="54">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
-<td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/14</td>
-<td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">14/14</td>
-<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/14</td>
-<td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">14/14</td>
-<td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/14</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/14</td>
-<td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">8/14</td>
-<td class="tally" data-browser="edge12" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally" data-browser="edge13" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">8/14</td>
-<td class="tally obsolete" data-browser="firefox36" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox38" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox39" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox41" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox42" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox43" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox44" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally" data-browser="firefox45" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally obsolete" data-browser="firefox46" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally" data-browser="firefox47" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">12/14</td>
-<td class="tally unstable" data-browser="firefox48" data-tally="1">14/14</td>
-<td class="tally unstable" data-browser="firefox49" data-tally="1">14/14</td>
-<td class="tally obsolete" data-browser="chrome30" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)" data-flagged-tally="0.7142857142857143">6/14</td>
-<td class="tally obsolete" data-browser="chrome40" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome41" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome42" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome43" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome46" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome47" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome48" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome49" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome50" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="chrome51" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally" data-browser="chrome52" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally" data-browser="safari51" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally" data-browser="safari9" data-tally="1">14/14</td>
-<td class="tally unstable" data-browser="safari10" data-tally="1">14/14</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="1">14/14</td>
-<td class="tally unstable" data-browser="webkit" data-tally="1">14/14</td>
-<td class="tally not-applicable" data-browser="node" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.7142857142857143">10/14</td>
-<td class="tally obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.7142857142857143">10/14</td>
-<td class="tally not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.7142857142857143">10/14</td>
-<td class="tally not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.7142857142857143">10/14</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="android41" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally" data-browser="android44" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">6/14</td>
-<td class="tally" data-browser="android50" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">6/14</td>
-<td class="tally" data-browser="android51" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally obsolete" data-browser="ios51" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">6/14</td>
-<td class="tally obsolete" data-browser="ios6" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">10/14</td>
-<td class="tally" data-browser="ios9" data-tally="1">14/14</td>
+<td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
+<td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
+<td class="tally" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally unstable" data-browser="edge14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="firefox35" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="firefox36" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox39" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox41" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox43" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="firefox45" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="firefox47" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally unstable" data-browser="firefox48" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="firefox49" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome30" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
+<td class="tally obsolete" data-browser="chrome40" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome41" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome42" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome43" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome46" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="chrome52" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="safari51" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="safari9" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="safari10" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="node" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="android44" data-tally="0.375" style="background-color:hsl(45,69%,50%)">6/16</td>
+<td class="tally" data-browser="android50" data-tally="0.375" style="background-color:hsl(45,69%,50%)">6/16</td>
+<td class="tally" data-browser="android51" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="ios51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
+<td class="tally obsolete" data-browser="ios6" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="ios9" data-tally="1">16/16</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter__"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter__">&#xA7;</a>__defineGetter__</span><script data-source="
 var obj = {};
@@ -2446,6 +2446,67 @@ return true;
 <td class="yes obsolete" data-browser="ios6">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 </tr>
+<tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupGetter__, data properties can shadow accessors</span><script data-source="
+var a = { };
+var b = Object.create(a);
+b.foo = 1;
+a.__defineGetter__(&quot;foo&quot;, function () {})
+return b.__lookupGetter__(&quot;foo&quot;) === undefined
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no" data-browser="edge12">No</td>
+<td class="no" data-browser="edge13">No</td>
+<td class="no unstable" data-browser="edge14">No</td>
+<td class="yes obsolete" data-browser="firefox35">Yes</td>
+<td class="yes obsolete" data-browser="firefox36">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox39">Yes</td>
+<td class="yes obsolete" data-browser="firefox41">Yes</td>
+<td class="yes obsolete" data-browser="firefox42">Yes</td>
+<td class="yes obsolete" data-browser="firefox43">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes" data-browser="firefox47">Yes</td>
+<td class="yes unstable" data-browser="firefox48">Yes</td>
+<td class="yes unstable" data-browser="firefox49">Yes</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="no obsolete" data-browser="chrome43">No</td>
+<td class="no obsolete" data-browser="chrome46">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no obsolete" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome49">No</td>
+<td class="no obsolete" data-browser="chrome50">No</td>
+<td class="no obsolete" data-browser="chrome51">No</td>
+<td class="no" data-browser="chrome52">No</td>
+<td class="yes" data-browser="safari51">Yes</td>
+<td class="yes" data-browser="safari9">Yes</td>
+<td class="yes unstable" data-browser="safari10">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no" data-browser="android44">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
+<td class="yes obsolete" data-browser="ios51">Yes</td>
+<td class="yes obsolete" data-browser="ios6">Yes</td>
+<td class="yes" data-browser="ios9">Yes</td>
+</tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__">&#xA7;</a>__lookupSetter__</span><script data-source="
 var obj = {
 set foo(baz) { return &quot;bar&quot;; },
@@ -2455,7 +2516,7 @@ var foo = Object.prototype.__lookupSetter__.call(obj, &quot;foo&quot;);
 return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;qux&quot;) === undefined
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;baz&quot;) === undefined;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -2519,7 +2580,7 @@ var foo = Object.prototype.__lookupSetter__.call(Object.create(obj), &quot;foo&q
 return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;qux&quot;) === undefined
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, &quot;baz&quot;) === undefined;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -2584,7 +2645,7 @@ var foo = Object.prototype.__lookupSetter__.call(obj, sym);
 return foo() === &quot;bar&quot;
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, sym2) === undefined
 &amp;&amp; Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -2646,7 +2707,7 @@ __lookupSetter__.call(null, &apos;key&apos;);
 } catch(e){
 return true;
 }
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -2698,6 +2759,67 @@ return true;
 <td class="no" data-browser="android50">No</td>
 <td class="no" data-browser="android51">No</td>
 <td class="no obsolete" data-browser="ios51">No</td>
+<td class="yes obsolete" data-browser="ios6">Yes</td>
+<td class="yes" data-browser="ios9">Yes</td>
+</tr>
+<tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupSetter__, data properties can shadow accessors</span><script data-source="
+var a = { };
+var b = Object.create(a);
+b.foo = 1;
+a.__defineSetter__(&quot;foo&quot;, function () {})
+return b.__lookupSetter__(&quot;foo&quot;) === undefined
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
+<td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no" data-browser="edge12">No</td>
+<td class="no" data-browser="edge13">No</td>
+<td class="no unstable" data-browser="edge14">No</td>
+<td class="yes obsolete" data-browser="firefox35">Yes</td>
+<td class="yes obsolete" data-browser="firefox36">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox39">Yes</td>
+<td class="yes obsolete" data-browser="firefox41">Yes</td>
+<td class="yes obsolete" data-browser="firefox42">Yes</td>
+<td class="yes obsolete" data-browser="firefox43">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes" data-browser="firefox47">Yes</td>
+<td class="yes unstable" data-browser="firefox48">Yes</td>
+<td class="yes unstable" data-browser="firefox49">Yes</td>
+<td class="no obsolete" data-browser="chrome30">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="no obsolete" data-browser="chrome43">No</td>
+<td class="no obsolete" data-browser="chrome46">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no obsolete" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome49">No</td>
+<td class="no obsolete" data-browser="chrome50">No</td>
+<td class="no obsolete" data-browser="chrome51">No</td>
+<td class="no" data-browser="chrome52">No</td>
+<td class="yes" data-browser="safari51">Yes</td>
+<td class="yes" data-browser="safari9">Yes</td>
+<td class="yes unstable" data-browser="safari10">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no not-applicable" data-browser="node" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no" data-browser="android44">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
+<td class="yes obsolete" data-browser="ios51">Yes</td>
 <td class="yes obsolete" data-browser="ios6">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 </tr>
@@ -2761,7 +2883,7 @@ var def = [];
 var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
 Object.prototype.__defineGetter__.call(p, &quot;foo&quot;, Object);
 return def + &apos;&apos; === &quot;foo&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -2822,7 +2944,7 @@ var def = [];
 var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
 Object.prototype.__defineSetter__.call(p, &quot;foo&quot;, Object);
 return def + &apos;&apos; === &quot;foo&quot;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -2888,7 +3010,7 @@ getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPro
 });
 Object.prototype.__lookupGetter__.call(p, &quot;foo&quot;);
 return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -2954,7 +3076,7 @@ getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPro
 });
 Object.prototype.__lookupSetter__.call(p, &quot;foo&quot;);
 return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
This is a known deviation of V8 copied by Chakra.
