### PR TITLE
es5: updates for IE, Edge, Firefox

### DIFF
--- a/data-es5.js
+++ b/data-es5.js
@@ -28,12 +28,18 @@ exports.browsers = {
     full: 'Internet Explorer 9',
     family: 'Chakra',
     short: 'IE 9',
-    obsolete: false
+    obsolete: true
   },
   ie10: {
     full: 'Internet Explorer 10, 11',
     family: 'Chakra',
-    short: 'IE 10+',
+    short: 'IE 10-11',
+    obsolete: false
+  },
+  edge13: {
+    full: 'Edge 13+',
+    family: 'Chakra',
+    short: 'Edge 13+',
     obsolete: false
   },
   firefox3: {
@@ -55,9 +61,15 @@ exports.browsers = {
     obsolete: true
   },
   firefox21: {
-    full: 'Firefox 21+',
+    full: 'Firefox 21-45',
     family: 'SpiderMonkey',
-    short: 'FF 21+',
+    short: 'FF 21-45',
+    obsolete: false
+  },
+  firefox46: {
+    full: 'Firefox 46+',
+    family: 'SpiderMonkey',
+    short: 'FF 46+',
     obsolete: false
   },
   safari3: {
@@ -1375,6 +1387,7 @@ exports.tests = [
     res: {
       ie7: null,
       ie9: false,
+      edge13: true,
       firefox3: true,
       safari3: false,
       chrome5: false,
@@ -1469,12 +1482,33 @@ exports.tests = [
         && (function(){ return typeof this === 'number' }).call(1)
         && (function(){ return typeof this === 'boolean' }).call(true);
     */},
+    res: temp.strict,
+  },
+  {
+    name: '"this" is not coerced to object in primitive accessors',
+    exec: function() {/*
+      'use strict';
+
+      function test(Class, instance) {
+        Object.defineProperty(Class.prototype, 'test', {
+          get: function () { passed = passed && this === instance; },
+          set: function () { passed = passed && this === instance; },
+          configurable: true
+        });
+
+        var passed = true;
+        instance.test;
+        instance.test = 42;
+        return passed;
+      }
+
+      return test(String, '')
+        && test(Number, 1)
+        && test(Boolean, true);
+    */},
     res: Object.assign({}, temp.strict, {
-      firefox4: {
-        val: true,
-        note_id: 'strict-mode-ff21',
-        note_html: 'In Firefox, strict getters on String, Boolean and Number prototypes receive wrapped <code>this</code> values (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=603201">Bugzilla reference</a>).'
-      },
+      firefox4: false,
+      firefox46: true,
     }),
   },
   {

--- a/data-es5.js
+++ b/data-es5.js
@@ -28,7 +28,7 @@ exports.browsers = {
     full: 'Internet Explorer 9',
     family: 'Chakra',
     short: 'IE 9',
-    obsolete: true
+    obsolete: false
   },
   ie10: {
     full: 'Internet Explorer 10, 11',

--- a/es5/index.html
+++ b/es5/index.html
@@ -107,7 +107,7 @@
         <th class="platform es5shim compiler" data-browser="es5shim"><a href="#es5shim" class="browser-name"><abbr title="es5-shim">es5-shim</abbr></a></th>
 <th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
 <th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie9 desktop" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10, 11">IE 10-11</abbr></a></th>
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Edge 13+">Edge 13+</abbr></a></th>
 <th class="platform firefox3 desktop obsolete" data-browser="firefox3"><a href="#firefox3" class="browser-name"><abbr title="Firefox 3">FF 3</abbr></a></th>
@@ -152,7 +152,7 @@
 <td class="tally" data-browser="es5shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
+<td class="tally" data-browser="ie9" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="1">5/5</td>
@@ -196,7 +196,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -242,7 +242,7 @@ return value === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -286,7 +286,7 @@ return { a: true, }.a === true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -330,7 +330,7 @@ return [1,].length === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -374,7 +374,7 @@ return ({ if: 1 }).if === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -417,7 +417,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
+<td class="tally" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0">0/13</td>
@@ -463,7 +463,7 @@ return typeof Object.create == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -509,7 +509,7 @@ return typeof Object.defineProperty == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[1]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -555,7 +555,7 @@ return typeof Object.defineProperties == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -601,7 +601,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -647,7 +647,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -693,7 +693,7 @@ return typeof Object.seal == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -739,7 +739,7 @@ return typeof Object.freeze == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -785,7 +785,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -831,7 +831,7 @@ return typeof Object.isSealed == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -877,7 +877,7 @@ return typeof Object.isFrozen == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -923,7 +923,7 @@ return typeof Object.isExtensible == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -969,7 +969,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[3]</sup></a></td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1015,7 +1015,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1056,7 +1056,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="es5shim" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">10/10</td>
+<td class="tally" data-browser="ie9" data-tally="1">10/10</td>
 <td class="tally" data-browser="ie10" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
@@ -1102,7 +1102,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1148,7 +1148,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1194,7 +1194,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1240,7 +1240,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1286,7 +1286,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1332,7 +1332,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1378,7 +1378,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1424,7 +1424,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1470,7 +1470,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1516,7 +1516,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1557,7 +1557,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="tally" data-browser="es5shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
+<td class="tally" data-browser="ie9" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1603,7 +1603,7 @@ return "foobar"[3] === "b";
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1649,7 +1649,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1690,7 +1690,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="es5shim" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1736,7 +1736,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1782,7 +1782,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -1836,7 +1836,7 @@ try {
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1882,7 +1882,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1928,7 +1928,7 @@ return typeof JSON == 'object';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -1971,7 +1971,7 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0">0/3</td>
@@ -2018,7 +2018,7 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2065,7 +2065,7 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2112,7 +2112,7 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2153,7 +2153,7 @@ return result;
 <td class="tally" data-browser="es5shim" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally" data-browser="ie9" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="ie10" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
@@ -2239,7 +2239,7 @@ return true;
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2295,7 +2295,7 @@ try {
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2341,7 +2341,7 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2387,7 +2387,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2431,7 +2431,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2475,7 +2475,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2520,7 +2520,7 @@ return _\u200c\u200d;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2566,7 +2566,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -2618,7 +2618,7 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -2668,7 +2668,7 @@ catch(e) {
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes obsolete" data-browser="ie9">Yes</td>
+<td class="yes" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
@@ -2709,7 +2709,7 @@ catch(e) {
 <td class="tally" data-browser="es5shim" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/18</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/18</td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/18</td>
+<td class="tally" data-browser="ie9" data-tally="0">0/18</td>
 <td class="tally" data-browser="ie10" data-tally="1">18/18</td>
 <td class="tally" data-browser="edge13" data-tally="1">18/18</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0">0/18</td>
@@ -2758,7 +2758,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2803,7 +2803,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
 <td class="yes" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2850,7 +2850,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2911,7 +2911,7 @@ return test(String, &apos;&apos;)
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -2958,7 +2958,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3003,7 +3003,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3052,7 +3052,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3101,7 +3101,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3152,7 +3152,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3199,7 +3199,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3246,7 +3246,7 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3297,7 +3297,7 @@ return (function(x){
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3342,7 +3342,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3387,7 +3387,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3432,7 +3432,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3477,7 +3477,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3522,7 +3522,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
@@ -3567,7 +3567,7 @@ return typeof foo === &apos;function&apos;;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -107,12 +107,14 @@
         <th class="platform es5shim compiler" data-browser="es5shim"><a href="#es5shim" class="browser-name"><abbr title="es5-shim">es5-shim</abbr></a></th>
 <th class="platform ie7 desktop obsolete" data-browser="ie7"><a href="#ie7" class="browser-name"><abbr title="Internet Explorer 7">IE 7</abbr></a></th>
 <th class="platform ie8 desktop obsolete" data-browser="ie8"><a href="#ie8" class="browser-name"><abbr title="Internet Explorer 8">IE 8</abbr></a></th>
-<th class="platform ie9 desktop" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
-<th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10, 11">IE 10+</abbr></a></th>
+<th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
+<th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10, 11">IE 10-11</abbr></a></th>
+<th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Edge 13+">Edge 13+</abbr></a></th>
 <th class="platform firefox3 desktop obsolete" data-browser="firefox3"><a href="#firefox3" class="browser-name"><abbr title="Firefox 3">FF 3</abbr></a></th>
 <th class="platform firefox3_5 desktop obsolete" data-browser="firefox3_5"><a href="#firefox3_5" class="browser-name"><abbr title="Firefox 3.5, Firefox 3.6">FF 3.5, 3.6</abbr></a></th>
 <th class="platform firefox4 desktop obsolete" data-browser="firefox4"><a href="#firefox4" class="browser-name"><abbr title="Firefox 4-20">FF 4-20</abbr></a></th>
-<th class="platform firefox21 desktop" data-browser="firefox21"><a href="#firefox21" class="browser-name"><abbr title="Firefox 21+">FF 21+</abbr></a></th>
+<th class="platform firefox21 desktop" data-browser="firefox21"><a href="#firefox21" class="browser-name"><abbr title="Firefox 21-45">FF 21-45</abbr></a></th>
+<th class="platform firefox46 desktop" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox 46+">FF 46+</abbr></a></th>
 <th class="platform safari3 desktop obsolete" data-browser="safari3"><a href="#safari3" class="browser-name"><abbr title="Safari 3.2">SF 3.2</abbr></a></th>
 <th class="platform safari4 desktop obsolete" data-browser="safari4"><a href="#safari4" class="browser-name"><abbr title="Safari 4.0.5">SF 4</abbr></a></th>
 <th class="platform safari5 desktop obsolete" data-browser="safari5"><a href="#safari5" class="browser-name"><abbr title="Safari 5.0.5">SF 5</abbr></a></th>
@@ -150,12 +152,14 @@
 <td class="tally" data-browser="es5shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
-<td class="tally" data-browser="ie9" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie10" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox21" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox46" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -192,12 +196,14 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -236,12 +242,14 @@ return value === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -278,12 +286,14 @@ return { a: true, }.a === true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -320,12 +330,14 @@ return [1,].length === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -362,12 +374,14 @@ return ({ if: 1 }).if === 1;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -397,18 +411,20 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><th colspan="40" class="separator"></th>
+<tr><th colspan="42" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0.15384615384615385" style="background-color:hsl(18,79%,50%)">2/13</td>
-<td class="tally" data-browser="ie9" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie10" data-tally="1">13/13</td>
+<td class="tally" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox21" data-tally="1">13/13</td>
+<td class="tally" data-browser="firefox46" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="0.5384615384615384" style="background-color:hsl(64,62%,50%)">7/13</td>
@@ -447,12 +463,14 @@ return typeof Object.create == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -491,12 +509,14 @@ return typeof Object.defineProperty == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes<a href="#define-property-ie-note"><sup>[1]</sup></a></td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes<a href="#define-property-webkit-note"><sup>[2]</sup></a></td>
@@ -535,12 +555,14 @@ return typeof Object.defineProperties == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -579,12 +601,14 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -623,12 +647,14 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -667,12 +693,14 @@ return typeof Object.seal == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -711,12 +739,14 @@ return typeof Object.freeze == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -755,12 +785,14 @@ return typeof Object.preventExtensions == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -799,12 +831,14 @@ return typeof Object.isSealed == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -843,12 +877,14 @@ return typeof Object.isFrozen == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -887,12 +923,14 @@ return typeof Object.isExtensible == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -931,12 +969,14 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes<a href="#get-own-property-descriptor-ie-note"><sup>[3]</sup></a></td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -975,12 +1015,14 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1014,12 +1056,14 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="es5shim" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally" data-browser="ie9" data-tally="1">10/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">10/10</td>
 <td class="tally" data-browser="ie10" data-tally="1">10/10</td>
+<td class="tally" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">10/10</td>
 <td class="tally" data-browser="firefox21" data-tally="1">10/10</td>
+<td class="tally" data-browser="firefox46" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="1">10/10</td>
@@ -1058,12 +1102,14 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1102,12 +1148,14 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1146,12 +1194,14 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1190,12 +1240,14 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1234,12 +1286,14 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1278,12 +1332,14 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1322,12 +1378,14 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1366,12 +1424,14 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1410,12 +1470,14 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1454,12 +1516,14 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="es5shim">Yes<a href="#sparse_arrays-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1493,12 +1557,14 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="tally" data-browser="es5shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="ie9" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie10" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox21" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox46" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="1">2/2</td>
@@ -1537,12 +1603,14 @@ return "foobar"[3] === "b";
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="yes obsolete" data-browser="safari3">Yes</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1581,12 +1649,14 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1620,12 +1690,14 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="es5shim" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie10" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox21" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox46" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -1664,12 +1736,14 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1708,12 +1782,14 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1760,12 +1836,14 @@ try {
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -1804,12 +1882,14 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -1848,12 +1928,14 @@ return typeof JSON == 'object';
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="yes obsolete" data-browser="ie8">Yes</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1883,18 +1965,20 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="android44">Yes</td>
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
-<tr><th colspan="40" class="separator"></th>
+<tr><th colspan="42" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/3</td>
-<td class="tally" data-browser="ie9" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie10" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox21" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox46" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="1">3/3</td>
@@ -1934,12 +2018,14 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -1979,12 +2065,14 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2024,12 +2112,14 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2063,12 +2153,14 @@ return result;
 <td class="tally" data-browser="es5shim" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="ie7" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/10</td>
-<td class="tally" data-browser="ie9" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="ie10" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally" data-browser="edge13" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox3" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="firefox3_5" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="firefox4" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally" data-browser="firefox21" data-tally="1">10/10</td>
+<td class="tally" data-browser="firefox46" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="safari3" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="safari4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="safari5" data-tally="0.6" style="background-color:hsl(72,59%,50%)">6/10</td>
@@ -2147,12 +2239,14 @@ return true;
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2201,12 +2295,14 @@ try {
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2245,12 +2341,14 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2289,12 +2387,14 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="es5shim">Yes</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="no obsolete" data-browser="firefox4">No</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2331,12 +2431,14 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2373,12 +2475,14 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2416,12 +2520,14 @@ return _\u200c\u200d;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes<a href="#zero-width-char-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2460,12 +2566,14 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2510,12 +2618,14 @@ return result;
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="no" data-browser="ie10">No</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2558,12 +2668,14 @@ catch(e) {
 <td class="no" data-browser="es5shim">No</td>
 <td class="unknown obsolete" data-browser="ie7">?</td>
 <td class="unknown obsolete" data-browser="ie8">?</td>
-<td class="yes" data-browser="ie9">Yes</td>
+<td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes obsolete" data-browser="firefox3">Yes</td>
 <td class="yes obsolete" data-browser="firefox3_5">Yes</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="unknown obsolete" data-browser="safari3">?</td>
 <td class="yes obsolete" data-browser="safari4">Yes</td>
 <td class="yes obsolete" data-browser="safari5">Yes</td>
@@ -2594,43 +2706,45 @@ catch(e) {
 <td class="yes" data-browser="ios78">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Strict_mode"><span><a class="anchor" href="#test-Strict_mode">&#xA7;</a>Strict mode</span></td>
-<td class="tally" data-browser="es5shim" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="ie8" data-tally="0">0/17</td>
-<td class="tally" data-browser="ie9" data-tally="0">0/17</td>
-<td class="tally" data-browser="ie10" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="firefox3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="firefox3_5" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="firefox4" data-tally="1">17/17</td>
-<td class="tally" data-browser="firefox21" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="safari3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="safari4" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="safari5" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="safari51" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally" data-browser="safari6" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally" data-browser="webkit" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome5" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="chrome6" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="chrome7" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="chrome13" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome19" data-tally="1">17/17</td>
-<td class="tally" data-browser="chrome23" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera10_10" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="opera10_50" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="opera12" data-tally="1">17/17</td>
-<td class="tally" data-browser="opera12_10" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="konq43" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="konq49" data-tally="0">0/17</td>
-<td class="tally" data-browser="konq413" data-tally="0">0/17</td>
-<td class="tally" data-browser="besen" data-tally="1">17/17</td>
-<td class="tally" data-browser="rhino" data-tally="0">0/17</td>
-<td class="tally" data-browser="phantom" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally unstable" data-browser="ejs" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="android41" data-tally="1">17/17</td>
-<td class="tally" data-browser="android44" data-tally="1">17/17</td>
-<td class="tally" data-browser="ios78" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally" data-browser="es5shim" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/18</td>
+<td class="tally" data-browser="ie10" data-tally="1">18/18</td>
+<td class="tally" data-browser="edge13" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="firefox3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="firefox3_5" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="firefox4" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally" data-browser="firefox21" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally" data-browser="firefox46" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="safari3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari4" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari5" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally" data-browser="safari6" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally" data-browser="webkit" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="chrome5" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome7" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome13" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="chrome19" data-tally="1">18/18</td>
+<td class="tally" data-browser="chrome23" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="opera10_10" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera10_50" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera12" data-tally="1">18/18</td>
+<td class="tally" data-browser="opera12_10" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="konq43" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="konq49" data-tally="0">0/18</td>
+<td class="tally" data-browser="konq413" data-tally="0">0/18</td>
+<td class="tally" data-browser="besen" data-tally="1">18/18</td>
+<td class="tally" data-browser="rhino" data-tally="0">0/18</td>
+<td class="tally" data-browser="phantom" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
+<td class="tally unstable" data-browser="ejs" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="android41" data-tally="1">18/18</td>
+<td class="tally" data-browser="android44" data-tally="1">18/18</td>
+<td class="tally" data-browser="ios78" data-tally="0.9444444444444444" style="background-color:hsl(113,44%,50%)">17/18</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_reserved_words"><td><span><a class="anchor" href="#test-Strict_mode_reserved_words">&#xA7;</a>reserved words</span><script data-source="
 &apos;use strict&apos;;
@@ -2644,12 +2758,14 @@ return true;
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2687,12 +2803,14 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
+<td class="yes" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2732,12 +2850,75 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
-<td class="yes obsolete" data-browser="firefox4">Yes<a href="#strict-mode-ff21-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="firefox21">Yes<a href="#strict-mode-ff21-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox4">Yes</td>
+<td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
+<td class="no obsolete" data-browser="safari3">No</td>
+<td class="no obsolete" data-browser="safari4">No</td>
+<td class="no obsolete" data-browser="safari5">No</td>
+<td class="yes obsolete" data-browser="safari51">Yes</td>
+<td class="yes" data-browser="safari6">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="chrome5">No</td>
+<td class="no obsolete" data-browser="chrome6">No</td>
+<td class="no obsolete" data-browser="chrome7">No</td>
+<td class="yes obsolete" data-browser="chrome13">Yes</td>
+<td class="yes obsolete" data-browser="chrome19">Yes</td>
+<td class="yes" data-browser="chrome23">Yes</td>
+<td class="no obsolete" data-browser="opera10_10">No</td>
+<td class="no obsolete" data-browser="opera10_50">No</td>
+<td class="yes obsolete" data-browser="opera12">Yes</td>
+<td class="yes" data-browser="opera12_10">Yes</td>
+<td class="no obsolete" data-browser="konq43">No</td>
+<td class="no obsolete" data-browser="konq49">No</td>
+<td class="no" data-browser="konq413">No</td>
+<td class="yes" data-browser="besen">Yes</td>
+<td class="no" data-browser="rhino">No</td>
+<td class="yes" data-browser="phantom">Yes</td>
+<td class="yes unstable" data-browser="ejs">Yes</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="yes obsolete" data-browser="android41">Yes</td>
+<td class="yes" data-browser="android44">Yes</td>
+<td class="yes" data-browser="ios78">Yes</td>
+</tr>
+<tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors"><td><span><a class="anchor" href="#test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors">&#xA7;</a>&quot;this&quot; is not coerced to object in primitive accessors</span><script data-source="
+&apos;use strict&apos;;
+
+function test(Class, instance) {
+  Object.defineProperty(Class.prototype, &apos;test&apos;, {
+    get: function () { passed = passed &amp;&amp; this === instance; },
+    set: function () { passed = passed &amp;&amp; this === instance; },
+    configurable: true
+  });
+
+  var passed = true;
+  instance.test;
+  instance.test = 42;
+  return passed;
+}
+
+return test(String, &apos;&apos;)
+  &amp;&amp; test(Number, 1)
+  &amp;&amp; test(Boolean, true);
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\n'use strict';\n\nfunction test(Class, instance) {\n  Object.defineProperty(Class.prototype, 'test', {\n    get: function () { passed = passed && this === instance; },\n    set: function () { passed = passed && this === instance; },\n    configurable: true\n  });\n\n  var passed = true;\n  instance.test;\n  instance.test = 42;\n  return passed;\n}\n\nreturn test(String, '')\n  && test(Number, 1)\n  && test(Boolean, true);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\n\nfunction test(Class, instance) {\n  Object.defineProperty(Class.prototype, 'test', {\n    get: function () { passed = passed && this === instance; },\n    set: function () { passed = passed && this === instance; },\n    configurable: true\n  });\n\n  var passed = true;\n  instance.test;\n  instance.test = 42;\n  return passed;\n}\n\nreturn test(String, '')\n  && test(Number, 1)\n  && test(Boolean, true);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no" data-browser="es5shim">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
+<td class="no obsolete" data-browser="firefox3">No</td>
+<td class="no obsolete" data-browser="firefox3_5">No</td>
+<td class="no obsolete" data-browser="firefox4">No</td>
+<td class="no" data-browser="firefox21">No</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2772,17 +2953,19 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 try { eval(&apos;010&apos;); }     catch (err) { if (!(err instanceof SyntaxError)) return false; }
 try { eval(&apos;&quot;\\010&quot;&apos;); } catch (err) { if (!(err instanceof SyntaxError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('010'); }     catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('\"\\\\010\"'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('010'); }     catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('\"\\\\010\"'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('010'); }     catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('\"\\\\010\"'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('010'); }     catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('\"\\\\010\"'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2815,17 +2998,19 @@ return true;
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError">&#xA7;</a>assignment to unresolvable identifiers is a ReferenceError</span><script data-source="
 &apos;use strict&apos;;
 try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceof ReferenceError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('__i_dont_exist = 1'); } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('__i_dont_exist = 1'); } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('__i_dont_exist = 1'); } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('__i_dont_exist = 1'); } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2862,17 +3047,19 @@ try { eval(&apos;arguments = 1&apos;); } catch (err) { if (!(err instanceof Synt
 try { eval(&apos;eval++&apos;); }        catch (err) { if (!(err instanceof SyntaxError)) return false; }
 try { eval(&apos;arguments++&apos;); }   catch (err) { if (!(err instanceof SyntaxError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('eval = 1'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments = 1'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('eval++'); }        catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments++'); }   catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('eval = 1'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments = 1'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('eval++'); }        catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments++'); }   catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('eval = 1'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments = 1'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('eval++'); }        catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments++'); }   catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('eval = 1'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments = 1'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('eval++'); }        catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('arguments++'); }   catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2909,17 +3096,19 @@ try { Object.preventExtensions({}).x = 1 }                      catch (err) { if
 try { ({ get x(){ } }).x = 1; }                                 catch (err) { if (!(err instanceof TypeError)) return false; }
 try { (function f() { f = 123; })() }                           catch (err) { if (!(err instanceof TypeError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\n'use strict';\ntry { Object.defineProperty({},\"x\",{ writable: false }).x = 1 } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { Object.preventExtensions({}).x = 1 }                      catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { ({ get x(){ } }).x = 1; }                                 catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function f() { f = 123; })() }                           catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { Object.defineProperty({},\"x\",{ writable: false }).x = 1 } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { Object.preventExtensions({}).x = 1 }                      catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { ({ get x(){ } }).x = 1; }                                 catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function f() { f = 123; })() }                           catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\n'use strict';\ntry { Object.defineProperty({},\"x\",{ writable: false }).x = 1 } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { Object.preventExtensions({}).x = 1 }                      catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { ({ get x(){ } }).x = 1; }                                 catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function f() { f = 123; })() }                           catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { Object.defineProperty({},\"x\",{ writable: false }).x = 1 } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { Object.preventExtensions({}).x = 1 }                      catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { ({ get x(){ } }).x = 1; }                                 catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function f() { f = 123; })() }                           catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -2958,17 +3147,19 @@ try { eval(&apos;(function(arguments){})&apos;); } catch (err) { if (!(err insta
 try { eval(&apos;try{}catch(eval){}&apos;); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }
 try { eval(&apos;try{}catch(arguments){}&apos;); } catch (err) { if (!(err instanceof SyntaxError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var eval'); }                catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('var arguments'); }           catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(eval){})'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(arguments){})'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(eval){}'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(arguments){}'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var eval'); }                catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('var arguments'); }           catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(eval){})'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(arguments){})'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(eval){}'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(arguments){}'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var eval'); }                catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('var arguments'); }           catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(eval){})'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(arguments){})'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(eval){}'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(arguments){}'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var eval'); }                catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('var arguments'); }           catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(eval){})'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('(function(arguments){})'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(eval){}'); }      catch (err) { if (!(err instanceof SyntaxError)) return false; }\ntry { eval('try{}catch(arguments){}'); } catch (err) { if (!(err instanceof SyntaxError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3003,17 +3194,19 @@ return true;
 try { arguments.caller; } catch (err) { if (!(err instanceof TypeError)) return false; }
 try { arguments.callee; } catch (err) { if (!(err instanceof TypeError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\n'use strict';\ntry { arguments.caller; } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { arguments.callee; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { arguments.caller; } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { arguments.callee; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\n'use strict';\ntry { arguments.caller; } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { arguments.callee; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { arguments.caller; } catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { arguments.callee; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3048,17 +3241,19 @@ return true;
 try { (function(){}).caller; }    catch (err) { if (!(err instanceof TypeError)) return false; }
 try { (function(){}).arguments; } catch (err) { if (!(err instanceof TypeError)) return false; }
 return true;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\n'use strict';\ntry { (function(){}).caller; }    catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function(){}).arguments; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { (function(){}).caller; }    catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function(){}).arguments; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\n'use strict';\ntry { (function(){}).caller; }    catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function(){}).arguments; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { (function(){}).caller; }    catch (err) { if (!(err instanceof TypeError)) return false; }\ntry { (function(){}).arguments; } catch (err) { if (!(err instanceof TypeError)) return false; }\nreturn true;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3097,17 +3292,19 @@ return (function(x){
   arguments[0] = 2;
   return x === 1;
 })(1);
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\n'use strict';\nreturn (function(x){\n  x = 2;\n  return arguments[0] === 1;\n})(1) && (function(x){\n  arguments[0] = 2;\n  return x === 1;\n})(1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\nreturn (function(x){\n  x = 2;\n  return arguments[0] === 1;\n})(1) && (function(x){\n  arguments[0] = 2;\n  return x === 1;\n})(1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\n'use strict';\nreturn (function(x){\n  x = 2;\n  return arguments[0] === 1;\n})(1) && (function(x){\n  arguments[0] = 2;\n  return x === 1;\n})(1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\nreturn (function(x){\n  x = 2;\n  return arguments[0] === 1;\n})(1) && (function(x){\n  arguments[0] = 2;\n  return x === 1;\n})(1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3140,17 +3337,19 @@ return (function(x){
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_eval()_can&apos;t_create_bindings"><td><span><a class="anchor" href="#test-Strict_mode_eval()_can&apos;t_create_bindings">&#xA7;</a>eval() can&apos;t create bindings</span><script data-source="
 &apos;use strict&apos;;
 try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } catch (err) { return err instanceof ReferenceError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var __some_unique_variable;'); __some_unique_variable; } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var __some_unique_variable;'); __some_unique_variable; } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var __some_unique_variable;'); __some_unique_variable; } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var __some_unique_variable;'); __some_unique_variable; } catch (err) { return err instanceof ReferenceError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3183,17 +3382,19 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_bindings_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_bindings_is_a_SyntaxError">&#xA7;</a>deleting bindings is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
 try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof SyntaxError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var x; delete x;'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var x; delete x;'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('var x; delete x;'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('var x; delete x;'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3226,17 +3427,19 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError">&#xA7;</a>deleting non-configurable properties is a TypeError</span><script data-source="
 &apos;use strict&apos;;
 try { delete Object.prototype; } catch (err) { return err instanceof TypeError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\n'use strict';\ntry { delete Object.prototype; } catch (err) { return err instanceof TypeError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { delete Object.prototype; } catch (err) { return err instanceof TypeError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\n'use strict';\ntry { delete Object.prototype; } catch (err) { return err instanceof TypeError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { delete Object.prototype; } catch (err) { return err instanceof TypeError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3269,17 +3472,19 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_with_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_with_is_a_SyntaxError">&#xA7;</a>&quot;with&quot; is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
 try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof SyntaxError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('with({}){}'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('with({}){}'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('with({}){}'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('with({}){}'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3312,17 +3517,19 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_repeated_parameter_names_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_repeated_parameter_names_is_a_SyntaxError">&#xA7;</a>repeated parameter names is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
 try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanceof SyntaxError; }
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('function f(x, x) { }'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('function f(x, x) { }'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\n'use strict';\ntry { eval('function f(x, x) { }'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\ntry { eval('function f(x, x) { }'); } catch (err) { return err instanceof SyntaxError; }\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3355,17 +3562,19 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid"><td><span><a class="anchor" href="#test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid">&#xA7;</a>function expressions with matching name and argument are valid</span><script data-source="
 var foo = function bar(bar) {&apos;use strict&apos;};
 return typeof foo === &apos;function&apos;;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nvar foo = function bar(bar) {'use strict'};\nreturn typeof foo === 'function';\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nvar foo = function bar(bar) {'use strict'};\nreturn typeof foo === 'function';\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nvar foo = function bar(bar) {'use strict'};\nreturn typeof foo === 'function';\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nvar foo = function bar(bar) {'use strict'};\nreturn typeof foo === 'function';\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no" data-browser="es5shim">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
 <td class="no obsolete" data-browser="ie8">No</td>
-<td class="no" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
 <td class="yes" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="no obsolete" data-browser="firefox3">No</td>
 <td class="no obsolete" data-browser="firefox3_5">No</td>
 <td class="yes obsolete" data-browser="firefox4">Yes</td>
 <td class="yes" data-browser="firefox21">Yes</td>
+<td class="yes" data-browser="firefox46">Yes</td>
 <td class="no obsolete" data-browser="safari3">No</td>
 <td class="no obsolete" data-browser="safari4">No</td>
 <td class="no obsolete" data-browser="safari5">No</td>
@@ -3399,7 +3608,7 @@ return typeof foo === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p><p id="define-property-ie-note">  <sup>[1]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="define-property-webkit-note">  <sup>[2]</sup> In some versions of Safari 5, <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.</p><p id="get-own-property-descriptor-ie-note">  <sup>[3]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[4]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[5]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="zero-width-char-note">  <sup>[6]</sup> Firefox 4 &amp; 5 fail this test</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p><p id="strict-mode-ff21-note">  <sup>[8]</sup> In Firefox, strict getters on String, Boolean and Number prototypes receive wrapped <code>this</code> values (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=603201">Bugzilla reference</a>).</p></p></div>
+    <p><p id="define-property-ie-note">  <sup>[1]</sup> In Internet Explorer 8 <code>Object.defineProperty</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="define-property-webkit-note">  <sup>[2]</sup> In some versions of Safari 5, <code>Object.defineProperty</code> does <b>not</b> work with DOM objects.</p><p id="get-own-property-descriptor-ie-note">  <sup>[3]</sup> In Internet Explorer 8 <code>Object.getOwnPropertyDescriptor</code> only accepts DOM objects (<a href="http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx">MSDN reference</a>).</p><p id="sparse_arrays-note">  <sup>[4]</sup> Internet Explorer 6 - 8 do not differentiate between a dense array with undefined values, and a sparse array. Specifically, `0 in [,]` and `0 in [undefined]` both yield false - whereas in a compliant browser, the former would give `false`, the latter `true`. As such, ES5 array iteration methods can only be shimmed reliably when dealing with dense arrays.</p><p id="Date.prototype.toJSON-OP11_60-OP11_64-note">  <sup>[5]</sup> In Opera 11.60-11.64 Date.prototype.toJSON is undefined.</p><p id="zero-width-char-note">  <sup>[6]</sup> Firefox 4 &amp; 5 fail this test</p><p id="strict-mode-ie10-note">  <sup>[7]</sup> IE10 PP2 fails this test.</p></p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>


### PR DESCRIPTION
- <del>Mark IE 9 as obsolete.</del>
- Add Edge. As I can't test Edge 12, I've included Edge 13+ only.
- Morph a footnote about a bug of FF into a subtest for strict mode.
- Add FF 46+, that fixed the aforementioned bug.
