### PR TITLE
More precise tests for RegExp#compile

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -14701,27 +14701,53 @@ exports.tests = [
   category: 'annex b',
   significance: 'tiny',
   link: 'http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.compile',
-  exec: function () {/*
-    return typeof RegExp.prototype.compile === 'function';
-  */},
-  res: {
-    tr:          false,
-    ejs:         false,
-    closure:     false,
-    ie10:        true,
-    firefox11:   true,
-    chrome:      true,
-    safari51:    true,
-    safaritp:    true,
-    safari10:    true,
-    webkit:      true,
-    opera:       true,
-    konq49:      true,
-    rhino17:     true,
-    node012:     true,
-    android40:   true,
-    xs6:         true,
-  }
+  subtests: [
+    {
+      name: "basic functionality",
+      exec: function () {/*
+        if (typeof RegExp.prototype.compile !== 'function')
+          return false
+        var rx = /a/;
+        rx.compile('b');
+        return rx.test('b');
+      */},
+      res: {
+        ie10:        true,
+        firefox11:   true,
+        chrome:      true,
+        safari51:    true,
+        safaritp:    true,
+        safari10:    true,
+        webkit:      true,
+        konq49:      true,
+        rhino17:     true,
+        node012:     true,
+        android40:   true,
+        xs6:         true,
+      }
+    },
+    {
+      name: "returns the RegExp object",
+      exec: function () {/*
+        var rx = /a/;
+        return rx.compile('b') === rx;
+      */},
+      res: {
+        ie10:        true,
+        firefox11:   true,
+        chrome:      false,
+        safari51:    false,
+        safaritp:    true,
+        safari10:    null,
+        webkit:      true,
+        konq49:      null,
+        rhino17:     null,
+        node012:     false,
+        android40:   false,
+        xs6:         null,
+      }
+    },
+  ]
 },
 {
   name: 'RegExp syntax extensions',

--- a/es6/index.html
+++ b/es6/index.html
@@ -58965,9 +58965,87 @@ return true;
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 </tr>
-<tr significance="0.125" class="optional-feature"><td id="test-RegExp.prototype.compile"><span><a class="anchor" href="#test-RegExp.prototype.compile">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span><script data-source="
-return typeof RegExp.prototype.compile === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("723");try{return Function("asyncTestPassed","\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("723");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof RegExp.prototype.compile === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+<tr class="supertest optional-feature" significance="0.125"><td id="test-RegExp.prototype.compile"><span><a class="anchor" href="#test-RegExp.prototype.compile">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regexp.prototype.compile">RegExp.prototype.compile</a></span></td>
+<td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
+<td class="tally" data-browser="ie11" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge12" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge13" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox35" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox36" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox37" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox39" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox40" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox41" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox42" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox43" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox47" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox48" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox49" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome39" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome40" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome41" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome42" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome43" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="chrome52" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="safari7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="safari71_8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="safari9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="safari10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera" data-tally="0">0/2</td>
+<td class="tally" data-browser="konq49" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally" data-browser="phantom" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally not-applicable" data-browser="node012" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">1/2</td>
+<td class="tally not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="android42" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="android43" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="android44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="android50" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="android51" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ios7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="ios8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="ios9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+</tr>
+<tr class="subtest" data-parent="RegExp.prototype.compile" id="test-RegExp.prototype.compile_basic_functionality"><td><span><a class="anchor" href="#test-RegExp.prototype.compile_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
+if (typeof RegExp.prototype.compile !== &apos;function&apos;)
+  return false
+var rx = /a/;
+rx.compile(&apos;b&apos;);
+return rx.test(&apos;b&apos;);
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("724");try{return Function("asyncTestPassed","\nif (typeof RegExp.prototype.compile !== 'function')\n  return false\nvar rx = /a/;\nrx.compile('b');\nreturn rx.test('b');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("724");return Function("asyncTestPassed","'use strict';"+"\nif (typeof RegExp.prototype.compile !== 'function')\n  return false\nvar rx = /a/;\nrx.compile('b');\nreturn rx.test('b');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59019,7 +59097,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes unstable" data-browser="safari10">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
 <td class="yes" data-browser="konq49">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes" data-browser="phantom">Yes</td>
@@ -59041,6 +59119,84 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ios7">Yes</td>
 <td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
+</tr>
+<tr class="subtest" data-parent="RegExp.prototype.compile" id="test-RegExp.prototype.compile_returns_the_RegExp_object"><td><span><a class="anchor" href="#test-RegExp.prototype.compile_returns_the_RegExp_object">&#xA7;</a>returns the RegExp object</span><script data-source="
+var rx = /a/;
+return rx.compile(&apos;b&apos;) === rx;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("725");try{return Function("asyncTestPassed","\nvar rx = /a/;\nreturn rx.compile('b') === rx;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("725");return Function("asyncTestPassed","'use strict';"+"\nvar rx = /a/;\nreturn rx.compile('b') === rx;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="jsx" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="typescript" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="yes obsolete" data-browser="ie10">Yes</td>
+<td class="yes" data-browser="ie11">Yes</td>
+<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
+<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes obsolete" data-browser="firefox35">Yes</td>
+<td class="yes obsolete" data-browser="firefox36">Yes</td>
+<td class="yes obsolete" data-browser="firefox37">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox39">Yes</td>
+<td class="yes obsolete" data-browser="firefox40">Yes</td>
+<td class="yes obsolete" data-browser="firefox41">Yes</td>
+<td class="yes obsolete" data-browser="firefox42">Yes</td>
+<td class="yes obsolete" data-browser="firefox43">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes" data-browser="firefox47">Yes</td>
+<td class="yes unstable" data-browser="firefox48">Yes</td>
+<td class="yes unstable" data-browser="firefox49">Yes</td>
+<td class="no obsolete" data-browser="chrome">No</td>
+<td class="no obsolete" data-browser="chrome39">No</td>
+<td class="no obsolete" data-browser="chrome40">No</td>
+<td class="no obsolete" data-browser="chrome41">No</td>
+<td class="no obsolete" data-browser="chrome42">No</td>
+<td class="no obsolete" data-browser="chrome43">No</td>
+<td class="no obsolete" data-browser="chrome44">No</td>
+<td class="no obsolete" data-browser="chrome45">No</td>
+<td class="no obsolete" data-browser="chrome46">No</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no obsolete" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome49">No</td>
+<td class="no obsolete" data-browser="chrome50">No</td>
+<td class="no obsolete" data-browser="chrome51">No</td>
+<td class="no" data-browser="chrome52">No</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari7">No</td>
+<td class="no" data-browser="safari71_8">No</td>
+<td class="no" data-browser="safari9">No</td>
+<td class="unknown unstable" data-browser="safari10">?</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera">No</td>
+<td class="unknown" data-browser="konq49">?</td>
+<td class="unknown obsolete not-applicable" data-browser="rhino17" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no not-applicable" data-browser="node012" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="iojs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no unstable not-applicable" data-browser="ejs" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="unknown not-applicable" data-browser="xs6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="no not-applicable" data-browser="jxa" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no obsolete" data-browser="android42">No</td>
+<td class="no obsolete" data-browser="android43">No</td>
+<td class="no" data-browser="android44">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
+<td class="no obsolete" data-browser="ios7">No</td>
+<td class="no obsolete" data-browser="ios8">No</td>
+<td class="no" data-browser="ios9">No</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-RegExp_syntax_extensions"><span><a class="anchor" href="#test-RegExp_syntax_extensions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-regular-expressions-patterns">RegExp syntax extensions</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -59118,7 +59274,7 @@ return typeof RegExp.prototype.compile === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_hyphens_in_character_sets"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_hyphens_in_character_sets">&#xA7;</a>hyphens in character sets</span><script data-source="
 return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("725");try{return Function("asyncTestPassed","\nreturn /[\\w-_]/.exec(\"-\")[0] === \"-\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("725");return Function("asyncTestPassed","'use strict';"+"\nreturn /[\\w-_]/.exec(\"-\")[0] === \"-\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("727");try{return Function("asyncTestPassed","\nreturn /[\\w-_]/.exec(\"-\")[0] === \"-\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("727");return Function("asyncTestPassed","'use strict';"+"\nreturn /[\\w-_]/.exec(\"-\")[0] === \"-\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59196,7 +59352,7 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_invalid_character_escapes"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_invalid_character_escapes">&#xA7;</a>invalid character escapes</span><script data-source="
 return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
   &amp;&amp; /[\z]/.exec(&quot;[\\z]&quot;)[0] === &quot;z&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("726");try{return Function("asyncTestPassed","\nreturn /\\z/.exec(\"\\\\z\")[0] === \"z\"\n  && /[\\z]/.exec(\"[\\\\z]\")[0] === \"z\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("726");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\z/.exec(\"\\\\z\")[0] === \"z\"\n  && /[\\z]/.exec(\"[\\\\z]\")[0] === \"z\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("728");try{return Function("asyncTestPassed","\nreturn /\\z/.exec(\"\\\\z\")[0] === \"z\"\n  && /[\\z]/.exec(\"[\\\\z]\")[0] === \"z\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("728");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\z/.exec(\"\\\\z\")[0] === \"z\"\n  && /[\\z]/.exec(\"[\\\\z]\")[0] === \"z\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59273,7 +59429,7 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 </tr>
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_invalid_control-character_escapes"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_invalid_control-character_escapes">&#xA7;</a>invalid control-character escapes</span><script data-source="
 return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("727");try{return Function("asyncTestPassed","\nreturn /\\c2/.exec(\"\\\\c2\")[0] === \"\\\\c2\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("727");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\c2/.exec(\"\\\\c2\")[0] === \"\\\\c2\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("729");try{return Function("asyncTestPassed","\nreturn /\\c2/.exec(\"\\\\c2\")[0] === \"\\\\c2\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("729");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\c2/.exec(\"\\\\c2\")[0] === \"\\\\c2\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59351,7 +59507,7 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_invalid_Unicode_escapes"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_invalid_Unicode_escapes">&#xA7;</a>invalid Unicode escapes</span><script data-source="
 return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
   &amp;&amp; /[\u1]/.exec(&quot;u&quot;)[0] === &quot;u&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("728");try{return Function("asyncTestPassed","\nreturn /\\u1/.exec(\"u1\")[0] === \"u1\"\n  && /[\\u1]/.exec(\"u\")[0] === \"u\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("728");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\u1/.exec(\"u1\")[0] === \"u1\"\n  && /[\\u1]/.exec(\"u\")[0] === \"u\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("730");try{return Function("asyncTestPassed","\nreturn /\\u1/.exec(\"u1\")[0] === \"u1\"\n  && /[\\u1]/.exec(\"u\")[0] === \"u\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("730");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\u1/.exec(\"u1\")[0] === \"u1\"\n  && /[\\u1]/.exec(\"u\")[0] === \"u\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59429,7 +59585,7 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_invalid_hexadecimal_escapes"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_invalid_hexadecimal_escapes">&#xA7;</a>invalid hexadecimal escapes</span><script data-source="
 return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
   &amp;&amp; /[\x1]/.exec(&quot;x&quot;)[0] === &quot;x&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("729");try{return Function("asyncTestPassed","\nreturn /\\x1/.exec(\"x1\")[0] === \"x1\"\n  && /[\\x1]/.exec(\"x\")[0] === \"x\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("729");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\x1/.exec(\"x1\")[0] === \"x1\"\n  && /[\\x1]/.exec(\"x\")[0] === \"x\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("731");try{return Function("asyncTestPassed","\nreturn /\\x1/.exec(\"x1\")[0] === \"x1\"\n  && /[\\x1]/.exec(\"x\")[0] === \"x\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("731");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\x1/.exec(\"x1\")[0] === \"x1\"\n  && /[\\x1]/.exec(\"x\")[0] === \"x\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59507,7 +59663,7 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_incomplete_patterns_and_quantifiers"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_incomplete_patterns_and_quantifiers">&#xA7;</a>incomplete patterns and quantifiers</span><script data-source="
 return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
   &amp;&amp; /x]1/.exec(&quot;x]1&quot;)[0] === &quot;x]1&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("730");try{return Function("asyncTestPassed","\nreturn /x{1/.exec(\"x{1\")[0] === \"x{1\"\n  && /x]1/.exec(\"x]1\")[0] === \"x]1\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("730");return Function("asyncTestPassed","'use strict';"+"\nreturn /x{1/.exec(\"x{1\")[0] === \"x{1\"\n  && /x]1/.exec(\"x]1\")[0] === \"x]1\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("732");try{return Function("asyncTestPassed","\nreturn /x{1/.exec(\"x{1\")[0] === \"x{1\"\n  && /x]1/.exec(\"x]1\")[0] === \"x]1\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("732");return Function("asyncTestPassed","'use strict';"+"\nreturn /x{1/.exec(\"x{1\")[0] === \"x{1\"\n  && /x]1/.exec(\"x]1\")[0] === \"x]1\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59585,7 +59741,7 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_octal_escape_sequences"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_octal_escape_sequences">&#xA7;</a>octal escape sequences</span><script data-source="
 return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
   &amp;&amp; /[\041]/.exec(&quot;!&quot;)[0] === &quot;!&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("731");try{return Function("asyncTestPassed","\nreturn /\\041/.exec(\"!\")[0] === \"!\"\n  && /[\\041]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("731");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\041/.exec(\"!\")[0] === \"!\"\n  && /[\\041]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("733");try{return Function("asyncTestPassed","\nreturn /\\041/.exec(\"!\")[0] === \"!\"\n  && /[\\041]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("733");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\041/.exec(\"!\")[0] === \"!\"\n  && /[\\041]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59663,7 +59819,7 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <tr class="subtest" data-parent="RegExp_syntax_extensions" id="test-RegExp_syntax_extensions_invalid_backreferences_become_octal_escapes"><td><span><a class="anchor" href="#test-RegExp_syntax_extensions_invalid_backreferences_become_octal_escapes">&#xA7;</a>invalid backreferences become octal escapes</span><script data-source="
 return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
   &amp;&amp; /[\41]/.exec(&quot;!&quot;)[0] === &quot;!&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("732");try{return Function("asyncTestPassed","\nreturn /\\41/.exec(\"!\")[0] === \"!\"\n  && /[\\41]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("732");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\41/.exec(\"!\")[0] === \"!\"\n  && /[\\41]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("734");try{return Function("asyncTestPassed","\nreturn /\\41/.exec(\"!\")[0] === \"!\"\n  && /[\\41]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("734");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\41/.exec(\"!\")[0] === \"!\"\n  && /[\\41]/.exec(\"!\")[0] === \"!\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -59743,7 +59899,7 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 &lt;!-- Another comment
 var a = 3; &lt;!-- Another comment
 return a === 3;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("733");try{return Function("asyncTestPassed","\n--> A comment\n<!-- Another comment\nvar a = 3; <!-- Another comment\nreturn a === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("733");return Function("asyncTestPassed","'use strict';"+"\n--> A comment\n<!-- Another comment\nvar a = 3; <!-- Another comment\nreturn a === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("735");try{return Function("asyncTestPassed","\n--> A comment\n<!-- Another comment\nvar a = 3; <!-- Another comment\nreturn a === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("735");return Function("asyncTestPassed","'use strict';"+"\n--> A comment\n<!-- Another comment\nvar a = 3; <!-- Another comment\nreturn a === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
More precise tests for RegExp#compile

The second subtest checks for a known deviation of V8 and WebKit. That
deviation was recently corrected in WebKit and Safari TP.
