### PR TITLE
[ES6] Promote Edge 14 to stable, mark Edge 12 as obsolete

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -97,7 +97,8 @@ exports.browsers = {
     family: 'Chakra',
     short: 'Edge 12',
     note_id: 'edge-experimental-flag',
-    note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags'
+    note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags',
+    obsolete: true
   },
   edge13: {
     full: 'Microsoft Edge',
@@ -110,7 +111,6 @@ exports.browsers = {
     full: 'Microsoft Edge',
     family: 'Chakra',
     short: 'Edge 14',
-    unstable: true,
     note_id: 'edge-experimental-flag',
     note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags',
   },
@@ -419,7 +419,7 @@ exports.browsers = {
   },
   chrome52: {
     full: 'Chrome, Opera',
-    short: 'CH 52,<br>OP&nbsp;39',
+    short: 'CH&nbsp;52+,<br>OP&nbsp;39+',
     note_id: 'experimental-flag',
   },
   safari51: {

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -32,7 +32,7 @@ exports.browsers = {
     full: 'Microsoft Edge',
     family: 'Chakra',
     short: 'Edge 14',
-    unstable: true
+    unstable: false
   },
   firefox10: {
     full: 'Firefox',

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -111,9 +111,9 @@
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10-</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge14 desktop unstable" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform firefox31 desktop obsolete" data-browser="firefox31"><a href="#firefox31" class="browser-name"><abbr title="Firefox">FF 31<br> ESR</abbr></a></th>
 <th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox39 desktop obsolete" data-browser="firefox39"><a href="#firefox39" class="browser-name"><abbr title="Firefox">FF 39</abbr></a></th>
@@ -170,9 +170,9 @@
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.6666666666666666">0/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
@@ -226,9 +226,9 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -282,9 +282,9 @@ var a = 2; a **= 3; return a === 8;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -343,9 +343,9 @@ return true;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -396,9 +396,9 @@ return true;
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
@@ -456,9 +456,9 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -534,9 +534,9 @@ return 24;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -595,9 +595,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -660,9 +660,9 @@ return true;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -729,9 +729,9 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -790,9 +790,9 @@ return true;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -847,9 +847,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -905,9 +905,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -968,9 +968,9 @@ return passed;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1033,9 +1033,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1094,9 +1094,9 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1157,9 +1157,9 @@ return Array.isArray(e)
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1210,9 +1210,9 @@ return Array.isArray(e)
 <td class="tally" data-browser="es7shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -1274,9 +1274,9 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1333,9 +1333,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1386,9 +1386,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -1445,9 +1445,9 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1504,9 +1504,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1557,9 +1557,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -1613,9 +1613,9 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1669,9 +1669,9 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1722,9 +1722,9 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
@@ -1780,9 +1780,9 @@ return (async function(){
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1838,9 +1838,9 @@ return (async function(){
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1894,9 +1894,9 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1949,9 +1949,9 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -2006,9 +2006,9 @@ return new C instanceof C;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2069,9 +2069,9 @@ return passed;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2130,9 +2130,9 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2189,9 +2189,9 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2244,9 +2244,9 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
-<td class="tally" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="edge14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
@@ -2305,9 +2305,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2367,9 +2367,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2429,9 +2429,9 @@ return true;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2490,9 +2490,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2552,9 +2552,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2614,9 +2614,9 @@ return true;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2677,9 +2677,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2740,9 +2740,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2804,9 +2804,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2865,9 +2865,9 @@ return true;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2925,9 +2925,9 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2988,9 +2988,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3051,9 +3051,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3115,9 +3115,9 @@ return foo() === &quot;bar&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3176,9 +3176,9 @@ return true;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3236,9 +3236,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3289,9 +3289,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3349,9 +3349,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3409,9 +3409,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3474,9 +3474,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3539,9 +3539,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -149,9 +149,9 @@
 <th class="platform es6shim compiler" data-browser="es6shim"><a href="#es6shim" class="browser-name"><abbr title="es6-shim">es6-<br>shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
-<th class="platform edge14 desktop unstable" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[4]</sup></a></th>
 <th class="platform firefox31 desktop obsolete" data-browser="firefox31"><a href="#firefox31" class="browser-name"><abbr title="Firefox">FF 31<br> ESR</abbr></a></th>
 <th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox39 desktop obsolete" data-browser="firefox39"><a href="#firefox39" class="browser-name"><abbr title="Firefox">FF 39</abbr></a></th>
@@ -179,7 +179,7 @@
 <th class="platform chrome49 desktop obsolete" data-browser="chrome49"><a href="#chrome49" class="browser-name"><abbr title="Chrome, Opera">CH 49,<br>OP&#xA0;36</abbr></a><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
 <th class="platform chrome50 desktop obsolete" data-browser="chrome50"><a href="#chrome50" class="browser-name"><abbr title="Chrome, Opera">CH 50,<br>OP&#xA0;37</abbr></a><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
 <th class="platform chrome51 desktop obsolete" data-browser="chrome51"><a href="#chrome51" class="browser-name"><abbr title="Chrome, Opera">CH 51,<br>OP&#xA0;38</abbr></a><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
-<th class="platform chrome52 desktop" data-browser="chrome52"><a href="#chrome52" class="browser-name"><abbr title="Chrome, Opera">CH 52,<br>OP&#xA0;39</abbr></a><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
+<th class="platform chrome52 desktop" data-browser="chrome52"><a href="#chrome52" class="browser-name"><abbr title="Chrome, Opera">CH&#xA0;52+,<br>OP&#xA0;39+</abbr></a><a href="#experimental-flag-note"><sup>[1]</sup></a></th>
 <th class="platform safari51 desktop obsolete" data-browser="safari51"><a href="#safari51" class="browser-name"><abbr title="Safari">SF 5.1</abbr></a></th>
 <th class="platform safari6 desktop obsolete" data-browser="safari6"><a href="#safari6" class="browser-name"><abbr title="Safari">SF 6</abbr></a></th>
 <th class="platform safari7 desktop obsolete" data-browser="safari7"><a href="#safari7" class="browser-name"><abbr title="Safari">SF 6.1,<br>SF 7</abbr></a></th>
@@ -227,9 +227,9 @@
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -308,9 +308,9 @@ return (function f(n){
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -396,9 +396,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -470,9 +470,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.8571428571428571">0/7</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/7</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.42857142857142855" style="background-color:hsl(51,67%,50%)">3/7</td>
@@ -545,9 +545,9 @@ return (function (a = 1, b = 2) { return a === 3 &amp;&amp; b === 2; }(3));
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -620,9 +620,9 @@ return (function (a = 1, b = 2) { return a === 1 &amp;&amp; b === 3; }(undefined
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -695,9 +695,9 @@ return (function (a, b = a) { return b === 5; }(5));
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -777,9 +777,9 @@ return (function (a = &quot;baz&quot;, b = &quot;qux&quot;, c = &quot;quux&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -862,9 +862,9 @@ return (function(x = 1) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -942,9 +942,9 @@ return (function(a=function(){
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1019,9 +1019,9 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1091,9 +1091,9 @@ return new Function(&quot;a = 1&quot;, &quot;b = 2&quot;,
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
-<td class="tally" data-browser="edge12" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -1168,9 +1168,9 @@ return (function (foo, ...args) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1243,9 +1243,9 @@ return function(a, ...b){}.length === 1 &amp;&amp; function(...c){}.length === 0
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1326,9 +1326,9 @@ return (function (foo, ...args) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1407,9 +1407,9 @@ return (function (...args) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1484,9 +1484,9 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1556,9 +1556,9 @@ return new Function(&quot;a&quot;, &quot;...b&quot;,
 <td class="tally" data-browser="es6shim" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/15</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/15</td>
-<td class="tally" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)" data-flagged-tally="0.9333333333333333">12/15</td>
 <td class="tally" data-browser="edge13" data-tally="1">15/15</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">15/15</td>
+<td class="tally" data-browser="edge14" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.7333333333333333" style="background-color:hsl(88,53%,50%)">11/15</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">15/15</td>
@@ -1631,9 +1631,9 @@ return Math.max(...[1, 2, 3]) === 3
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1706,9 +1706,9 @@ return [...[1, 2, 3]][2] === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1782,9 +1782,9 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1858,9 +1858,9 @@ return &quot;0&quot; in a &amp;&amp; &quot;1&quot; in a &amp;&amp; &apos;&apos; 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1933,9 +1933,9 @@ return Math.max(...&quot;1234&quot;) === 4;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2008,9 +2008,9 @@ return [&quot;a&quot;, ...&quot;bcd&quot;, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2083,9 +2083,9 @@ return Array(...&quot;&#x20BB7;&#x20BB6;&quot;)[0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2158,9 +2158,9 @@ return [...&quot;&#x20BB7;&#x20BB6;&quot;][0] === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2234,9 +2234,9 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2310,9 +2310,9 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2386,9 +2386,9 @@ return Math.max(...iterable) === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2462,9 +2462,9 @@ return [&quot;a&quot;, ...iterable, &quot;e&quot;][3] === &quot;d&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2538,9 +2538,9 @@ return Math.max(...Object.create(iterable)) === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2614,9 +2614,9 @@ return [&quot;a&quot;, ...Object.create(iterable), &quot;e&quot;][3] === &quot;d
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2693,9 +2693,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2765,9 +2765,9 @@ try {
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally" data-browser="edge12" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">6/6</td>
@@ -2841,9 +2841,9 @@ return ({ [x]: 1 }).y === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2917,9 +2917,9 @@ return c.a === 7 &amp;&amp; c.b === 8;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -2992,9 +2992,9 @@ return ({ y() { return 2; } }).y() === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes<a href="#ff-shorthand-methods-note"><sup>[10]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox39">Yes<a href="#ff-shorthand-methods-note"><sup>[10]</sup></a></td>
@@ -3067,9 +3067,9 @@ return ({ &quot;foo bar&quot;() { return 4; } })[&quot;foo bar&quot;]() === 4;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3143,9 +3143,9 @@ return ({ [x](){ return 1 } }).y() === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3225,9 +3225,9 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3297,9 +3297,9 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
-<td class="tally" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
 <td class="tally" data-browser="edge13" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">9/9</td>
+<td class="tally" data-browser="edge14" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
@@ -3374,9 +3374,9 @@ for (var item of arr)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3453,9 +3453,9 @@ return count === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3531,9 +3531,9 @@ return str === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3609,9 +3609,9 @@ return str === &quot;&#x20BB7; &#x20BB6; &quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3689,9 +3689,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3769,9 +3769,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3849,9 +3849,9 @@ return result === &quot;123&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -3929,9 +3929,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4011,9 +4011,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4083,9 +4083,9 @@ return closed;
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge13" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">4/4</td>
@@ -4158,9 +4158,9 @@ return 0o10 === 8 &amp;&amp; 0O10 === 8;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4233,9 +4233,9 @@ return 0b10 === 2 &amp;&amp; 0B10 === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4308,9 +4308,9 @@ return Number(&apos;0o1&apos;) === 1;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4383,9 +4383,9 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4455,9 +4455,9 @@ return Number(&apos;0b1&apos;) === 1;
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
-<td class="tally" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">5/5</td>
@@ -4532,9 +4532,9 @@ ${a + &quot;z&quot;} ${b.toLowerCase()}` === &quot;foo bar\nbaz qux&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4611,9 +4611,9 @@ return `${a}` === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4697,9 +4697,9 @@ return fn `foo${123}bar\n${456}` &amp;&amp; called;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4774,9 +4774,9 @@ return (function(parts) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4854,9 +4854,9 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -4926,9 +4926,9 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
-<td class="tally" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
 <td class="tally" data-browser="edge13" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
@@ -5003,9 +5003,9 @@ return (re.exec(&apos;xy&apos;)[0] === &apos;y&apos;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5081,9 +5081,9 @@ return result === &apos;yy&apos; &amp;&amp; re.lastIndex === 5;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5156,9 +5156,9 @@ return &quot;&#x20BB7;&quot;.match(/^.$/u)[0].length === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5231,9 +5231,9 @@ return &quot;&#x1D306;&quot;.match(/\u{1d306}/u)[0].length === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5306,9 +5306,9 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5378,9 +5378,9 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="es6shim" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/22</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/22</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9090909090909091">0/22</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">22/22</td>
+<td class="tally" data-browser="edge14" data-tally="1">22/22</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5909090909090909" style="background-color:hsl(70,60%,50%)">13/22</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
@@ -5454,9 +5454,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5530,9 +5530,9 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5606,9 +5606,9 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5682,9 +5682,9 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5758,9 +5758,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5834,9 +5834,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5910,9 +5910,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5990,9 +5990,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6066,9 +6066,9 @@ return a === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6142,9 +6142,9 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6220,9 +6220,9 @@ return toFixed === Number.prototype.toFixed
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6296,9 +6296,9 @@ return a === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6379,9 +6379,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6456,9 +6456,9 @@ return grault === &quot;garply&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6532,9 +6532,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === 7 &amp;&amp; d === 8;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6610,9 +6610,9 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6687,9 +6687,9 @@ for(var [i, j, k] in { qux: 1 }) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6764,9 +6764,9 @@ for(var [i, j, k] of [[1,2,3]]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6847,9 +6847,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -6925,9 +6925,9 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7003,9 +7003,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -7087,9 +7087,9 @@ return a === 1 &amp;&amp; b === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -7159,9 +7159,9 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/24</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9583333333333334">0/24</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">24/24</td>
+<td class="tally" data-browser="edge14" data-tally="1">24/24</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">20/24</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">20/24</td>
@@ -7236,9 +7236,9 @@ return a === 5 &amp;&amp; b === 6 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7313,9 +7313,9 @@ return a === undefined &amp;&amp; b === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7390,9 +7390,9 @@ return a === &quot;a&quot; &amp;&amp; b === &quot;b&quot; &amp;&amp; c === undef
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7467,9 +7467,9 @@ return c === &quot;&#x20BB7;&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7544,9 +7544,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7621,9 +7621,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7698,9 +7698,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7779,9 +7779,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -7855,9 +7855,9 @@ return ([a, b] = iterable) === iterable;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -7932,9 +7932,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 1 &amp;&amp; d === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8009,9 +8009,9 @@ return a === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8086,9 +8086,9 @@ return c === 7 &amp;&amp; d === 8 &amp;&amp; e === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8165,9 +8165,9 @@ return toFixed === Number.prototype.toFixed
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8242,9 +8242,9 @@ return a === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8318,9 +8318,9 @@ return ({a,b} = obj) === obj;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8400,9 +8400,9 @@ catch(e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -8477,9 +8477,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3 &amp;&amp; d === 4;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8561,9 +8561,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8638,9 +8638,9 @@ return grault === &quot;garply&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8717,9 +8717,9 @@ return e === 9 &amp;&amp; f === 10 &amp;&amp; g === undefined
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8796,9 +8796,9 @@ return a === 3 &amp;&amp; b instanceof Array &amp;&amp; (b + &quot;&quot;) === &
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -8873,9 +8873,9 @@ return first === 1 &amp;&amp; last === 3 &amp;&amp; (a + &quot;&quot;) === &quot
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -8950,9 +8950,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9029,9 +9029,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -9101,9 +9101,9 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="es6shim" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/23</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/23</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">23/23</td>
+<td class="tally" data-browser="edge14" data-tally="1">23/23</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
@@ -9178,9 +9178,9 @@ return function([a, , [b], c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9255,9 +9255,9 @@ return function([a, , b]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9332,9 +9332,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9409,9 +9409,9 @@ return function([c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9486,9 +9486,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9563,9 +9563,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9640,9 +9640,9 @@ return function([a, b, c]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9720,9 +9720,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -9797,9 +9797,9 @@ return function([a,]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9874,9 +9874,9 @@ return function({c, x:d, e}) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -9952,9 +9952,9 @@ return function({toFixed}, {slice}) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10029,9 +10029,9 @@ return function({a,}) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10112,9 +10112,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10190,9 +10190,9 @@ return function({ [qux]: grault }) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10268,9 +10268,9 @@ return function([e, {x:f, g}], {h, x:[i]}) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10346,9 +10346,9 @@ return (function({a, x:b, y:e}, [c, d]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10424,9 +10424,9 @@ return new Function(&quot;{a, x:b, y:e}&quot;,&quot;[c, d]&quot;,
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -10499,9 +10499,9 @@ return function({a, b}, [c, d]){}.length === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10577,9 +10577,9 @@ return function([a, ...b], [c, ...d]) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10654,9 +10654,9 @@ return function ([],{}){
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -10733,9 +10733,9 @@ return (function({a = 1, b = 0, c = 3, x:d = 0, y:e = 5},
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -10813,9 +10813,9 @@ return (function({a=function(){
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -10890,9 +10890,9 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -10962,9 +10962,9 @@ return new Function(&quot;{a = 1, b = 0, c = 3, x:d = 0, y:e = 5}&quot;,
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -11037,9 +11037,9 @@ return &apos;\u{1d306}&apos; == &apos;\ud834\udf06&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -11113,9 +11113,9 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -11185,9 +11185,9 @@ return \u{102C0}[&apos;\ud800\udec0&apos;] === 2;
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -11267,9 +11267,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -11351,9 +11351,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -11425,9 +11425,9 @@ try {
 <td class="tally" data-browser="es6shim" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">16/16</td>
+<td class="tally" data-browser="edge14" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.1875" style="background-color:hsl(22,77%,50%)" data-flagged-tally="0.3125">3/16</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.625" style="background-color:hsl(75,58%,50%)" data-flagged-tally="0.75">10/16</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.625" style="background-color:hsl(75,58%,50%)" data-flagged-tally="0.75">10/16</td>
@@ -11501,9 +11501,9 @@ return (foo === 123);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -11578,9 +11578,9 @@ return bar === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -11658,9 +11658,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -11738,9 +11738,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -11815,9 +11815,9 @@ return baz === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
@@ -11894,9 +11894,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -11973,9 +11973,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -12052,9 +12052,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12129,9 +12129,9 @@ return (foo === 123);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12207,9 +12207,9 @@ return bar === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12288,9 +12288,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12369,9 +12369,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12447,9 +12447,9 @@ return baz === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[0]</sup></a></td>
@@ -12527,9 +12527,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -12607,9 +12607,9 @@ return (scopes[0]() === &quot;a&quot; &amp;&amp; scopes[1]() === &quot;b&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -12687,9 +12687,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -12759,9 +12759,9 @@ return passed;
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally" data-browser="edge13" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">12/12</td>
+<td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0" data-flagged-tally="0.6666666666666666">0/12</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0" data-flagged-tally="0.8333333333333334">0/12</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0" data-flagged-tally="0.8333333333333334">0/12</td>
@@ -12835,9 +12835,9 @@ return (foo === 123);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -12912,9 +12912,9 @@ return bar === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -12992,9 +12992,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13069,9 +13069,9 @@ return baz === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13148,9 +13148,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13234,9 +13234,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -13311,9 +13311,9 @@ return (foo === 123);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13389,9 +13389,9 @@ return bar === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13470,9 +13470,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13548,9 +13548,9 @@ return baz === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no flagged obsolete" data-browser="firefox31">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13628,9 +13628,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no flagged obsolete" data-browser="firefox38">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox39">Flag<a href="#fx-let-note"><sup>[12]</sup></a></td>
@@ -13715,9 +13715,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -13795,9 +13795,9 @@ return f() === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -13869,9 +13869,9 @@ return f() === 1;
 <td class="tally" data-browser="es6shim" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
-<td class="tally" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
 <td class="tally" data-browser="edge13" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">13/13</td>
+<td class="tally" data-browser="edge14" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.6923076923076923" style="background-color:hsl(83,55%,50%)">9/13</td>
@@ -13944,9 +13944,9 @@ return (() =&gt; 5)() === 5;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14020,9 +14020,9 @@ return (b(&quot;fee fie foe &quot;) === &quot;fee fie foe foo&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14096,9 +14096,9 @@ return (c(6, 5, 4, 3, 2) === &quot;65432&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14173,9 +14173,9 @@ return d(&quot;ley&quot;) === &quot;barley&quot; &amp;&amp; e.y(&quot;ley&quot;)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14250,9 +14250,9 @@ return d.y().call(e) === &quot;foo&quot; &amp;&amp; d.y().apply(e) === &quot;foo
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14327,9 +14327,9 @@ return d.y().bind(e, &quot;ley&quot;)() === &quot;barley&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14403,9 +14403,9 @@ return f(6) === 5;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -14480,9 +14480,9 @@ return (() =&gt; {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14557,9 +14557,9 @@ return (() =&gt; {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14633,9 +14633,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -14721,9 +14721,9 @@ return new C instanceof C &amp;&amp; received === &apos;foo&apos;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -14807,9 +14807,9 @@ return arrow() === &quot;quux&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -14885,9 +14885,9 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -14957,9 +14957,9 @@ return new C()() === C &amp;&amp; C()() === undefined;
 <td class="tally" data-browser="es6shim" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/24</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.875">0/24</td>
 <td class="tally" data-browser="edge13" data-tally="1">24/24</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">24/24</td>
+<td class="tally" data-browser="edge14" data-tally="1">24/24</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/24</td>
@@ -15033,9 +15033,9 @@ return typeof C === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15114,9 +15114,9 @@ return C === c1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15189,9 +15189,9 @@ return typeof class C {} === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15264,9 +15264,9 @@ return typeof class {} === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15343,9 +15343,9 @@ return C.prototype.constructor === C
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15422,9 +15422,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15501,9 +15501,9 @@ return typeof C.prototype[&quot;foo bar&quot;] === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15581,9 +15581,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15664,9 +15664,9 @@ return typeof C.prototype.method === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15743,9 +15743,9 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15823,9 +15823,9 @@ return typeof C.method === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15904,9 +15904,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -15985,9 +15985,9 @@ return new C().foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16066,9 +16066,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16147,9 +16147,9 @@ return C.foo === &quot;foo&quot; &amp;&amp; baz;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16227,9 +16227,9 @@ return C === undefined &amp;&amp; M();
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16308,9 +16308,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16387,9 +16387,9 @@ return !C.prototype.propertyIsEnumerable(&quot;foo&quot;) &amp;&amp; !C.property
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16465,9 +16465,9 @@ return (0,C.method)();
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16546,9 +16546,9 @@ catch(e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16624,9 +16624,9 @@ return new C() instanceof B
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16702,9 +16702,9 @@ return new C() instanceof B
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16781,9 +16781,9 @@ return Function.prototype.isPrototypeOf(C)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16868,9 +16868,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -16940,9 +16940,9 @@ return passed;
 <td class="tally" data-browser="es6shim" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td class="tally" data-browser="edge13" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/8</td>
@@ -17023,9 +17023,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17104,9 +17104,9 @@ return new C(&quot;baz&quot;)[0] === &quot;foobarbaz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17186,9 +17186,9 @@ return new C().quux(&quot;bar&quot;) === &quot;foobarbaz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17267,9 +17267,9 @@ return new C().qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17350,9 +17350,9 @@ return obj.qux(&quot;baz&quot;) === &quot;foobarbaz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17433,9 +17433,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17518,9 +17518,9 @@ return obj.qux() === &quot;barley&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17605,9 +17605,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -17677,9 +17677,9 @@ return passed;
 <td class="tally" data-browser="es6shim" data-tally="0">0/27</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/27</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/27</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.9259259259259259">0/27</td>
 <td class="tally" data-browser="edge13" data-tally="1">27/27</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">27/27</td>
+<td class="tally" data-browser="edge14" data-tally="1">27/27</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5185185185185185" style="background-color:hsl(62,63%,50%)">14/27</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7407407407407407" style="background-color:hsl(88,53%,50%)">20/27</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7407407407407407" style="background-color:hsl(88,53%,50%)">20/27</td>
@@ -17762,9 +17762,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -17847,9 +17847,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -17932,9 +17932,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18015,9 +18015,9 @@ catch (e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -18098,9 +18098,9 @@ return sent[0] === &quot;foo&quot; &amp;&amp; sent[1] === &quot;bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18182,9 +18182,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18270,9 +18270,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -18357,9 +18357,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18443,9 +18443,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18528,9 +18528,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18610,9 +18610,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18694,9 +18694,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18778,9 +18778,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18862,9 +18862,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -18946,9 +18946,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19032,9 +19032,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19118,9 +19118,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19204,9 +19204,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19291,9 +19291,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19382,9 +19382,9 @@ return closed === &apos;ab&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -19472,9 +19472,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -19559,9 +19559,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19646,9 +19646,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19734,9 +19734,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -19821,9 +19821,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -19909,9 +19909,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -19993,9 +19993,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -20067,9 +20067,9 @@ try {
 <td class="tally" data-browser="es6shim" data-tally="0">0/46</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
 <td class="tally" data-browser="ie11" data-tally="0.34782608695652173" style="background-color:hsl(41,70%,50%)">16/46</td>
-<td class="tally" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9130434782608695" style="background-color:hsl(109,45%,50%)">42/46</td>
 <td class="tally" data-browser="edge13" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">44/46</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">46/46</td>
+<td class="tally" data-browser="edge14" data-tally="1">46/46</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.391304347826087" style="background-color:hsl(46,68%,50%)">18/46</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8913043478260869" style="background-color:hsl(106,46%,50%)">41/46</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8913043478260869" style="background-color:hsl(106,46%,50%)">41/46</td>
@@ -20144,9 +20144,9 @@ return view[0] === -0x80;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20221,9 +20221,9 @@ return view[0] === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20298,9 +20298,9 @@ return view[0] === 0xFF;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20375,9 +20375,9 @@ return view[0] === -0x8000;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20452,9 +20452,9 @@ return view[0] === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20529,9 +20529,9 @@ return view[0] === -0x80000000;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20606,9 +20606,9 @@ return view[0] === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20683,9 +20683,9 @@ return view[0] === 0.10000000149011612;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20760,9 +20760,9 @@ return view[0] === 0.1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20838,9 +20838,9 @@ return view.getInt8(0) === -0x80;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20916,9 +20916,9 @@ return view.getUint8(0) === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -20994,9 +20994,9 @@ return view.getInt16(0) === -0x8000;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21072,9 +21072,9 @@ return view.getUint16(0) === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21150,9 +21150,9 @@ return view.getInt32(0) === -0x80000000;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21228,9 +21228,9 @@ return view.getUint32(0) === 0;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21306,9 +21306,9 @@ return view.getFloat32(0) === 0.10000000149011612;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21384,9 +21384,9 @@ return view.getFloat64(0) === 0.1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21459,9 +21459,9 @@ return typeof ArrayBuffer[Symbol.species] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -21557,9 +21557,9 @@ return constructors.every(function (constructor) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -21647,9 +21647,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -21745,9 +21745,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21828,9 +21828,9 @@ typeof Float64Array.from === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21911,9 +21911,9 @@ typeof Float64Array.of === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -21994,9 +21994,9 @@ typeof Float64Array.prototype.subarray === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22077,9 +22077,9 @@ typeof Float64Array.prototype.join === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22160,9 +22160,9 @@ typeof Float64Array.prototype.indexOf === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22243,9 +22243,9 @@ typeof Float64Array.prototype.lastIndexOf === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22326,9 +22326,9 @@ typeof Float64Array.prototype.slice === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22409,9 +22409,9 @@ typeof Float64Array.prototype.every === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22492,9 +22492,9 @@ typeof Float64Array.prototype.filter === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22575,9 +22575,9 @@ typeof Float64Array.prototype.forEach === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22658,9 +22658,9 @@ typeof Float64Array.prototype.map === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22741,9 +22741,9 @@ typeof Float64Array.prototype.reduce === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22824,9 +22824,9 @@ typeof Float64Array.prototype.reduceRight === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22907,9 +22907,9 @@ typeof Float64Array.prototype.reverse === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -22990,9 +22990,9 @@ typeof Float64Array.prototype.some === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23073,9 +23073,9 @@ typeof Float64Array.prototype.sort === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -23156,9 +23156,9 @@ typeof Float64Array.prototype.copyWithin === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23239,9 +23239,9 @@ typeof Float64Array.prototype.find === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23322,9 +23322,9 @@ typeof Float64Array.prototype.findIndex === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23405,9 +23405,9 @@ typeof Float64Array.prototype.fill === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23488,9 +23488,9 @@ typeof Float64Array.prototype.keys === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23571,9 +23571,9 @@ typeof Float64Array.prototype.values === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23654,9 +23654,9 @@ typeof Float64Array.prototype.entries === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23737,9 +23737,9 @@ typeof Float64Array.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -23820,9 +23820,9 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -23892,9 +23892,9 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
-<td class="tally" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge14" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
@@ -23972,9 +23972,9 @@ return map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24052,9 +24052,9 @@ return map.has(key1) &amp;&amp; map.get(key1) === 123 &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24133,9 +24133,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -24209,9 +24209,9 @@ return true;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24294,9 +24294,9 @@ return passed;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24376,9 +24376,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -24452,9 +24452,9 @@ return map.set(0, 0) === map;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24533,9 +24533,9 @@ return k === Infinity &amp;&amp; map.get(+0) == &quot;foo&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24613,9 +24613,9 @@ return map.size === 1;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24688,9 +24688,9 @@ return typeof Map.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24763,9 +24763,9 @@ return typeof Map.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24838,9 +24838,9 @@ return typeof Map.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24913,9 +24913,9 @@ return typeof Map.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -24988,9 +24988,9 @@ return typeof Map.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25063,9 +25063,9 @@ return typeof Map.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25138,9 +25138,9 @@ return typeof Map.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25220,9 +25220,9 @@ catch(e) {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25305,9 +25305,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -25381,9 +25381,9 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -25453,9 +25453,9 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="es6shim" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/19</td>
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
-<td class="tally" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge14" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
@@ -25534,9 +25534,9 @@ return set.has(123);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25613,9 +25613,9 @@ return set.has(obj1) &amp;&amp; set.has(obj2);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25694,9 +25694,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -25770,9 +25770,9 @@ return true;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25855,9 +25855,9 @@ return passed;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -25940,9 +25940,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -26016,9 +26016,9 @@ return set.add(0) === set;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26097,9 +26097,9 @@ return k === Infinity &amp;&amp; set.has(+0);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26179,9 +26179,9 @@ return set.size === 2;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26254,9 +26254,9 @@ return typeof Set.prototype.delete === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26329,9 +26329,9 @@ return typeof Set.prototype.clear === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26404,9 +26404,9 @@ return typeof Set.prototype.forEach === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26479,9 +26479,9 @@ return typeof Set.prototype.keys === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26554,9 +26554,9 @@ return typeof Set.prototype.values === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26629,9 +26629,9 @@ return typeof Set.prototype.entries === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26704,9 +26704,9 @@ return typeof Set.prototype[Symbol.iterator] === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26786,9 +26786,9 @@ catch(e) {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -26871,9 +26871,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -26947,9 +26947,9 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -27019,9 +27019,9 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="es6shim" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/12</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
-<td class="tally" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="edge13" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">12/12</td>
+<td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">4/12</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
@@ -27099,9 +27099,9 @@ return weakmap.has(key) &amp;&amp; weakmap.get(key) === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27179,9 +27179,9 @@ return weakmap.has(key1) &amp;&amp; weakmap.get(key1) === 123 &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27260,9 +27260,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -27336,9 +27336,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27421,9 +27421,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27499,9 +27499,9 @@ return m.get(f) === 42;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27581,9 +27581,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -27658,9 +27658,9 @@ return weakmap.set(key, 0) === weakmap;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27733,9 +27733,9 @@ return typeof WeakMap.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27815,9 +27815,9 @@ return m.has(key);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -27893,9 +27893,9 @@ return m.has(1) === false
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -27975,9 +27975,9 @@ catch(e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -28047,9 +28047,9 @@ catch(e) {
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
-<td class="tally" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
@@ -28128,9 +28128,9 @@ return weakset.has(obj1);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28206,9 +28206,9 @@ return weakset.has(obj1) &amp;&amp; weakset.has(obj2);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28287,9 +28287,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28363,9 +28363,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28448,9 +28448,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28530,9 +28530,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -28607,9 +28607,9 @@ return weakset.add(obj) === weakset;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28682,9 +28682,9 @@ return typeof WeakSet.prototype.delete === &quot;function&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28764,9 +28764,9 @@ return s.has(key);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -28841,9 +28841,9 @@ return s.has(1) === false
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28923,9 +28923,9 @@ catch(e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -28995,9 +28995,9 @@ catch(e) {
 <td class="tally" data-browser="es6shim" data-tally="0">0/34</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/34</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/34</td>
-<td class="tally" data-browser="edge12" data-tally="1">34/34</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">34/34</td>
 <td class="tally" data-browser="edge13" data-tally="1">34/34</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">34/34</td>
+<td class="tally" data-browser="edge14" data-tally="1">34/34</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.6176470588235294" style="background-color:hsl(74,58%,50%)">21/34</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">28/34</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)">28/34</td>
@@ -29076,9 +29076,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29152,9 +29152,9 @@ return !Proxy.hasOwnProperty(&apos;prototype&apos;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29233,9 +29233,9 @@ return proxy.foo === 5;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29314,9 +29314,9 @@ return proxy.foo === 5;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#fx-proxy-get-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29416,9 +29416,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29499,9 +29499,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29582,9 +29582,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29684,9 +29684,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29766,9 +29766,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29848,9 +29848,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -29947,9 +29947,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30029,9 +30029,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30119,9 +30119,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30207,9 +30207,9 @@ return (returnedDesc.value     === fakeDesc.value
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30332,9 +30332,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30419,9 +30419,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30522,9 +30522,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -30604,9 +30604,9 @@ return Object.getPrototypeOf(proxy) === fakeProto;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -30692,9 +30692,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -30779,9 +30779,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -30869,9 +30869,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -30953,9 +30953,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31049,9 +31049,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31134,9 +31134,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31222,9 +31222,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31306,9 +31306,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31411,9 +31411,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#fx-proxy-ownkeys-note"><sup>[0]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31496,9 +31496,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31584,9 +31584,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31667,9 +31667,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31765,9 +31765,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -31848,9 +31848,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31923,9 +31923,9 @@ return Array.isArray(new Proxy([], {}));
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -31998,9 +31998,9 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32070,9 +32070,9 @@ return JSON.stringify(new Proxy([&apos;foo&apos;], {})) === &apos;[&quot;foo&quo
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">14/20</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/20</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/20</td>
-<td class="tally" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.65" style="background-color:hsl(78,57%,50%)">13/20</td>
 <td class="tally" data-browser="edge13" data-tally="1">20/20</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">20/20</td>
+<td class="tally" data-browser="edge14" data-tally="1">20/20</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/20</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/20</td>
@@ -32145,9 +32145,9 @@ return Reflect.get({ qux: 987 }, &quot;qux&quot;) === 987;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32222,9 +32222,9 @@ return obj.quux === 654;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32297,9 +32297,9 @@ return Reflect.has({ qux: 987 }, &quot;qux&quot;);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32374,9 +32374,9 @@ return !(&quot;bar&quot; in obj);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32452,9 +32452,9 @@ return desc.value === 789 &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32530,9 +32530,9 @@ return obj.foo === 123 &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32605,9 +32605,9 @@ return Reflect.getPrototypeOf([]) === Array.prototype;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32682,9 +32682,9 @@ return obj instanceof Array;
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[14]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32758,9 +32758,9 @@ return Reflect.isExtensible({}) &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32835,9 +32835,9 @@ return !Object.isExtensible(obj);
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32914,9 +32914,9 @@ return Reflect.ownKeys(obj).sort() + &apos;&apos; === &quot;A,B&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -32997,9 +32997,9 @@ return keys.indexOf(s2) &gt;-1 &amp;&amp; keys.indexOf(s3) &gt;-1 &amp;&amp; key
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33072,9 +33072,9 @@ return Reflect.apply(Array.prototype.push, [1,2], [3,4,5]) === 5;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33149,9 +33149,9 @@ return Reflect.construct(function(a, b, c) {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33228,9 +33228,9 @@ return Reflect.construct(function(a, b, c) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33305,9 +33305,9 @@ return obj.y === 1 &amp;&amp; obj instanceof F;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33383,9 +33383,9 @@ return obj.length === 3 &amp;&amp; obj instanceof F;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33461,9 +33461,9 @@ return RegExp.prototype.exec.call(obj, &quot;foobarbaz&quot;)[0] === &quot;baz&q
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33538,9 +33538,9 @@ return obj() === 2 &amp;&amp; obj instanceof F;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33632,9 +33632,9 @@ function check() {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -33704,9 +33704,9 @@ function check() {
 <td class="tally" data-browser="es6shim" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
-<td class="tally" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="edge13" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.75" style="background-color:hsl(90,53%,50%)">6/8</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -33800,9 +33800,9 @@ function check() {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -33881,9 +33881,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -33961,9 +33961,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34050,9 +34050,9 @@ function check() {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34139,9 +34139,9 @@ function check() {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34228,9 +34228,9 @@ function check() {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34317,9 +34317,9 @@ function check() {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34393,9 +34393,9 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -34465,9 +34465,9 @@ return &apos;get&apos; in prop &amp;&amp; Promise[Symbol.species] === Promise;
 <td class="tally" data-browser="es6shim" data-tally="0.09090909090909091" style="background-color:hsl(10,82%,50%)">1/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
-<td class="tally" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge13" data-tally="1">11/11</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">11/11</td>
@@ -34544,9 +34544,9 @@ return object[symbol] === value;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34619,9 +34619,9 @@ return typeof Symbol() === &quot;symbol&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34706,9 +34706,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34790,9 +34790,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34870,9 +34870,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -34958,9 +34958,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35033,9 +35033,9 @@ return String(Symbol(&quot;foo&quot;)) === &quot;Symbol(foo)&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35113,9 +35113,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35195,9 +35195,9 @@ return typeof symbolObject === &quot;object&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35273,9 +35273,9 @@ return JSON.stringify(object) === &apos;{}&apos; &amp;&amp; JSON.stringify(array
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35350,9 +35350,9 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35422,9 +35422,9 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="es6shim" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/26</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
-<td class="tally" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
 <td class="tally" data-browser="edge13" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.38461538461538464" style="background-color:hsl(46,69%,50%)" data-flagged-tally="0.8076923076923077">10/26</td>
+<td class="tally" data-browser="edge14" data-tally="0.38461538461538464" style="background-color:hsl(46,69%,50%)" data-flagged-tally="0.8076923076923077">10/26</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
@@ -35504,9 +35504,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -35582,9 +35582,9 @@ return a[0] === b;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -35657,9 +35657,9 @@ return &quot;iterator&quot; in Symbol;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -35735,9 +35735,9 @@ return (function() {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -35810,9 +35810,9 @@ return &quot;species&quot; in Symbol;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -35890,9 +35890,9 @@ return Array.prototype.concat.call(obj, []).foo === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -35970,9 +35970,9 @@ return Array.prototype.filter.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36050,9 +36050,9 @@ return Array.prototype.map.call(obj, Boolean).foo === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36130,9 +36130,9 @@ return Array.prototype.slice.call(obj, 0).foo === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36210,9 +36210,9 @@ return Array.prototype.splice.call(obj, 0).foo === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36293,9 +36293,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36372,9 +36372,9 @@ return promise.then(function(){}) instanceof FakePromise2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36451,9 +36451,9 @@ return &apos;&apos;.replace(O) === 42;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36530,9 +36530,9 @@ return &apos;&apos;.search(O) === 42;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36609,9 +36609,9 @@ return &apos;&apos;.split(O) === 42;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36688,9 +36688,9 @@ return &apos;&apos;.match(O) === 42;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36767,9 +36767,9 @@ return RegExp(re) !== re &amp;&amp; RegExp(foo) === foo;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36848,9 +36848,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -36929,9 +36929,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37010,9 +37010,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37094,9 +37094,9 @@ return passed === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37171,9 +37171,9 @@ return (a + &quot;&quot;) === &quot;[object foo]&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37263,9 +37263,9 @@ return passed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37362,9 +37362,9 @@ passed = passed
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37439,9 +37439,9 @@ return Math[s] === &quot;Math&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37518,9 +37518,9 @@ with (a) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37592,9 +37592,9 @@ with (a) {
 <td class="tally" data-browser="es6shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally" data-browser="edge12" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge13" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">4/4</td>
@@ -37668,9 +37668,9 @@ return &quot;a&quot; in o &amp;&amp; &quot;b&quot; in o &amp;&amp; &quot;c&quot;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -37745,9 +37745,9 @@ return typeof Object.is === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -37828,9 +37828,9 @@ return result[0] === sym
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -37903,9 +37903,9 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="no" data-browser="es6shim">No<a href="#compiler-proto-note"><sup>[14]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -37975,9 +37975,9 @@ return Object.setPrototypeOf({}, Array.prototype) instanceof Array;
 <td class="tally" data-browser="es6shim" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
-<td class="tally" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.47058823529411764" style="background-color:hsl(56,65%,50%)" data-flagged-tally="1">8/17</td>
 <td class="tally" data-browser="edge13" data-tally="0.8235294117647058" style="background-color:hsl(98,49%,50%)" data-flagged-tally="0.8823529411764706">14/17</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)" data-flagged-tally="1">16/17</td>
+<td class="tally" data-browser="edge14" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)" data-flagged-tally="1">16/17</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.17647058823529413" style="background-color:hsl(21,78%,50%)">3/17</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)">6/17</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.35294117647058826" style="background-color:hsl(42,70%,50%)">6/17</td>
@@ -38052,9 +38052,9 @@ return foo.name === &apos;foo&apos; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -38128,9 +38128,9 @@ return (function foo(){}).name === &apos;foo&apos; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -38203,9 +38203,9 @@ return (new Function).name === &quot;anonymous&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -38280,9 +38280,9 @@ return foo.bind({}).name === &quot;bound foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38357,9 +38357,9 @@ return foo.name === &quot;foo&quot; &amp;&amp; bar.name === &quot;baz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38436,9 +38436,9 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38514,9 +38514,9 @@ return descriptor.get.name === &quot;get foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38590,9 +38590,9 @@ return o.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -38666,9 +38666,9 @@ return ({f() { return f; }}).f() === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -38749,9 +38749,9 @@ return o[sym1].name === &quot;[foo]&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38827,9 +38827,9 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38903,9 +38903,9 @@ return class foo {}.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -38983,9 +38983,9 @@ return foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -39062,9 +39062,9 @@ return o.foo.name === &quot;foo&quot; &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -39138,9 +39138,9 @@ return (new C).foo.name === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -39214,9 +39214,9 @@ return C.foo.name === &quot;foo&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -39292,9 +39292,9 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39364,9 +39364,9 @@ return descriptor.enumerable   === false &amp;&amp;
 <td class="tally" data-browser="es6shim" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">2/2</td>
@@ -39439,9 +39439,9 @@ return typeof String.raw === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39514,9 +39514,9 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39586,9 +39586,9 @@ return typeof String.fromCodePoint === &apos;function&apos;;
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
-<td class="tally" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="edge13" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">10/10</td>
+<td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8" style="background-color:hsl(96,50%,50%)">8/10</td>
@@ -39661,9 +39661,9 @@ return typeof String.prototype.codePointAt === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39738,9 +39738,9 @@ return typeof String.prototype.normalize === &quot;function&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39814,9 +39814,9 @@ return typeof String.prototype.repeat === &apos;function&apos;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39890,9 +39890,9 @@ return typeof String.prototype.startsWith === &apos;function&apos;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -39969,9 +39969,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -40045,9 +40045,9 @@ return typeof String.prototype.endsWith === &apos;function&apos;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -40124,9 +40124,9 @@ try {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -40200,9 +40200,9 @@ return typeof String.prototype.includes === &apos;function&apos;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="firefox38">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="firefox39">No<a href="#string-contains-note"><sup>[24]</sup></a></td>
@@ -40275,9 +40275,9 @@ return typeof String.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -40360,9 +40360,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40432,9 +40432,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="tally" data-browser="es6shim" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally" data-browser="edge13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
+<td class="tally" data-browser="edge14" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)" data-flagged-tally="1">1/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -40507,9 +40507,9 @@ return /./igm.flags === &quot;gim&quot; &amp;&amp; /./.flags === &quot;&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -40582,9 +40582,9 @@ return typeof RegExp.prototype[Symbol.match] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40657,9 +40657,9 @@ return typeof RegExp.prototype[Symbol.replace] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40732,9 +40732,9 @@ return typeof RegExp.prototype[Symbol.split] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40807,9 +40807,9 @@ return typeof RegExp.prototype[Symbol.search] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40883,9 +40883,9 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -40955,9 +40955,9 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="es6shim" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)">7/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
-<td class="tally" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
 <td class="tally" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.09090909090909091" style="background-color:hsl(10,82%,50%)">1/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
@@ -41030,9 +41030,9 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }) + &apos
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41106,9 +41106,9 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41182,9 +41182,9 @@ return Array.from(iterable) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41258,9 +41258,9 @@ return Array.from(Object.create(iterable)) + &apos;&apos; === &quot;1,2,3&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41335,9 +41335,9 @@ return Array.from({ 0: &quot;foo&quot;, 1: &quot;bar&quot;, length: 2 }, functio
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41413,9 +41413,9 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41491,9 +41491,9 @@ return Array.from(iterable, function(e, i) {
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41569,9 +41569,9 @@ return Array.from(Object.create(iterable), function(e, i) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41651,9 +41651,9 @@ return closed;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -41727,9 +41727,9 @@ return typeof Array.of === &apos;function&apos; &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -41803,9 +41803,9 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -41875,9 +41875,9 @@ return &apos;get&apos; in prop &amp;&amp; Array[Symbol.species] === Array;
 <td class="tally" data-browser="es6shim" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
-<td class="tally" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.9" style="background-color:hsl(108,46%,50%)">9/10</td>
 <td class="tally" data-browser="edge13" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">10/10</td>
+<td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
@@ -41950,9 +41950,9 @@ return typeof Array.prototype.copyWithin === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42025,9 +42025,9 @@ return typeof Array.prototype.find === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42100,9 +42100,9 @@ return typeof Array.prototype.findIndex === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42175,9 +42175,9 @@ return typeof Array.prototype.fill === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42250,9 +42250,9 @@ return typeof Array.prototype.keys === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42325,9 +42325,9 @@ return typeof Array.prototype.values === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[25]</sup></a></td>
 <td class="no obsolete" data-browser="firefox38">No<a href="#array-prototype-iterator-note"><sup>[26]</sup></a></td>
 <td class="no obsolete" data-browser="firefox39">No<a href="#array-prototype-iterator-note"><sup>[26]</sup></a></td>
@@ -42400,9 +42400,9 @@ return typeof Array.prototype.entries === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42475,9 +42475,9 @@ return typeof Array.prototype[Symbol.iterator] === &apos;function&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No<a href="#fx-array-prototype-values-2-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42560,9 +42560,9 @@ return proto2.hasOwnProperty(Symbol.iterator) &amp;&amp;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -42643,9 +42643,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -42715,9 +42715,9 @@ return true;
 <td class="tally" data-browser="es6shim" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
-<td class="tally" data-browser="edge12" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge13" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">7/7</td>
@@ -42790,9 +42790,9 @@ return typeof Number.isFinite === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42865,9 +42865,9 @@ return typeof Number.isInteger === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -42940,9 +42940,9 @@ return typeof Number.isSafeInteger === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43015,9 +43015,9 @@ return typeof Number.isNaN === &apos;function&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43090,9 +43090,9 @@ return typeof Number.EPSILON === &apos;number&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43165,9 +43165,9 @@ return typeof Number.MIN_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43240,9 +43240,9 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43312,9 +43312,9 @@ return typeof Number.MAX_SAFE_INTEGER === &apos;number&apos;;
 <td class="tally" data-browser="es6shim" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
-<td class="tally" data-browser="edge12" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">17/17</td>
 <td class="tally" data-browser="edge13" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">17/17</td>
+<td class="tally" data-browser="edge14" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">17/17</td>
@@ -43387,9 +43387,9 @@ return typeof Math.clz32 === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43462,9 +43462,9 @@ return typeof Math.imul === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43537,9 +43537,9 @@ return typeof Math.sign === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43612,9 +43612,9 @@ return typeof Math.log10 === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43687,9 +43687,9 @@ return typeof Math.log2 === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43762,9 +43762,9 @@ return typeof Math.log1p === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43837,9 +43837,9 @@ return typeof Math.expm1 === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43912,9 +43912,9 @@ return typeof Math.cosh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -43987,9 +43987,9 @@ return typeof Math.sinh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44062,9 +44062,9 @@ return typeof Math.tanh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44137,9 +44137,9 @@ return typeof Math.acosh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44212,9 +44212,9 @@ return typeof Math.asinh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44287,9 +44287,9 @@ return typeof Math.atanh === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44362,9 +44362,9 @@ return typeof Math.trunc === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44437,9 +44437,9 @@ return typeof Math.fround === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44512,9 +44512,9 @@ return typeof Math.cbrt === &quot;function&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44590,9 +44590,9 @@ return Math.hypot() === 0 &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -44668,9 +44668,9 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -44742,9 +44742,9 @@ return tp.call(Object(2), &quot;number&quot;) === 2
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.2727272727272727">0/11</td>
 <td class="tally" data-browser="edge13" data-tally="1">11/11</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/11</td>
@@ -44822,9 +44822,9 @@ return len1 === 0 &amp;&amp; len2 === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -44901,9 +44901,9 @@ return c.length === 1 &amp;&amp; !(2 in c);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -44978,9 +44978,9 @@ return c instanceof C &amp;&amp; c instanceof Array &amp;&amp; Object.getPrototy
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45054,9 +45054,9 @@ return Array.isArray(new C());
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45131,9 +45131,9 @@ return c.concat(1) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45208,9 +45208,9 @@ return c.filter(Boolean) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45285,9 +45285,9 @@ return c.map(Boolean) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45363,9 +45363,9 @@ return c.slice(1,2) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45441,9 +45441,9 @@ return c.splice(1,2) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45517,9 +45517,9 @@ return C.from({ length: 0 }) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45593,9 +45593,9 @@ return C.of(0) instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45665,9 +45665,9 @@ return C.of(0) instanceof C;
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.25">0/4</td>
 <td class="tally" data-browser="edge13" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/4</td>
@@ -45742,9 +45742,9 @@ return r.global &amp;&amp; r.source === &quot;baz&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45819,9 +45819,9 @@ return r instanceof R &amp;&amp; r instanceof RegExp &amp;&amp; Object.getProtot
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45896,9 +45896,9 @@ return r.exec(&quot;foobarbaz&quot;)[0] === &quot;baz&quot; &amp;&amp; r.lastInd
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -45973,9 +45973,9 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46045,9 +46045,9 @@ return r.test(&quot;foobarbaz&quot;);
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/6</td>
@@ -46122,9 +46122,9 @@ return c() === &apos;foo&apos;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46199,9 +46199,9 @@ return c instanceof C &amp;&amp; c instanceof Function &amp;&amp; Object.getProt
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46277,9 +46277,9 @@ return new c().bar === 2 &amp;&amp; new c().baz === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46354,9 +46354,9 @@ return c.call({bar:1}, 2) === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46431,9 +46431,9 @@ return c.apply({bar:1}, [2]) === 3;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46508,9 +46508,9 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46580,9 +46580,9 @@ return c(6) === 9 &amp;&amp; c instanceof C;
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge13" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/4</td>
@@ -46677,9 +46677,9 @@ function check() {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46754,9 +46754,9 @@ return c instanceof C &amp;&amp; c instanceof Promise &amp;&amp; Object.getProto
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46844,9 +46844,9 @@ function check() {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -46934,9 +46934,9 @@ function check() {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47006,9 +47006,9 @@ function check() {
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/6</td>
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/6</td>
@@ -47085,9 +47085,9 @@ return c instanceof Boolean
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47164,9 +47164,9 @@ return c instanceof Number
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47245,9 +47245,9 @@ return c instanceof String
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47324,9 +47324,9 @@ return c instanceof Error
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47405,9 +47405,9 @@ return map instanceof M &amp;&amp; map.has(key) &amp;&amp; map.get(key) === 123;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47487,9 +47487,9 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47561,9 +47561,9 @@ return set instanceof S &amp;&amp; set.has(123);
 <td class="tally" data-browser="es6shim" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/5</td>
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/5</td>
@@ -47649,9 +47649,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47737,9 +47737,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47825,9 +47825,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47913,9 +47913,9 @@ return correctProtoBound(Function.prototype)
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -47999,9 +47999,9 @@ return correctProtoBound(function(){})
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48071,9 +48071,9 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="es6shim" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/36</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
-<td class="tally" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
 <td class="tally" data-browser="edge13" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.8333333333333334">20/36</td>
+<td class="tally" data-browser="edge14" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.8333333333333334">20/36</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.2777777777777778" style="background-color:hsl(33,73%,50%)">10/36</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.4722222222222222" style="background-color:hsl(56,65%,50%)">17/36</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">16/36</td>
@@ -48150,9 +48150,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48229,9 +48229,9 @@ return get + &apos;&apos; === &quot;length,0,1&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -48309,9 +48309,9 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48391,9 +48391,9 @@ return get[0] === Symbol.unscopables &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48470,9 +48470,9 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48549,9 +48549,9 @@ return get + &apos;&apos; === &quot;prototype&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -48639,9 +48639,9 @@ return get + &apos;&apos; === &quot;done,value,done,value&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -48726,9 +48726,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -48805,9 +48805,9 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -48884,9 +48884,9 @@ return get + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -48963,9 +48963,9 @@ return get + &apos;&apos; === &quot;length,name&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -49042,9 +49042,9 @@ return get + &apos;&apos; === &quot;name,message&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -49122,9 +49122,9 @@ return get + &apos;&apos; === &quot;raw,length,0,1&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -49203,9 +49203,9 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49282,9 +49282,9 @@ return get + &apos;&apos; === &quot;global,ignoreCase,multiline,unicode,sticky&q
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49361,9 +49361,9 @@ return get + &apos;&apos; === &quot;exec&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49440,9 +49440,9 @@ return get + &apos;&apos; === &quot;source,flags&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="unknown obsolete" data-browser="firefox39">?</td>
@@ -49521,9 +49521,9 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49602,9 +49602,9 @@ return get + &apos;&apos; === &quot;global,exec,global,unicode,exec&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49681,9 +49681,9 @@ return get + &apos;&apos; === &quot;lastIndex,exec&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49762,9 +49762,9 @@ return get + &apos;&apos; === &quot;constructor,flags,exec&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -49841,9 +49841,9 @@ return get[0] === Symbol.iterator &amp;&amp; get.slice(1) + &apos;&apos; === &qu
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -49927,9 +49927,9 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50019,9 +50019,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50098,9 +50098,9 @@ return get + &apos;&apos; === &quot;length,3&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50177,9 +50177,9 @@ return get + &apos;&apos; === &quot;length,0,4,2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50256,9 +50256,9 @@ return get + &apos;&apos; === &quot;length,0,1,2,3&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50336,9 +50336,9 @@ return get + &apos;&apos; === &quot;length,constructor,1,2,3,length,constructor,
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50415,9 +50415,9 @@ return get + &apos;&apos; === &quot;join&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50494,9 +50494,9 @@ return get + &apos;&apos; === &quot;toJSON&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50573,9 +50573,9 @@ return get + &apos;&apos; === &quot;then&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -50654,9 +50654,9 @@ return get[0] === Symbol.match &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50735,9 +50735,9 @@ return get[0] === Symbol.replace &amp;&amp; get[1] === Symbol.toPrimitive &amp;&
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50816,9 +50816,9 @@ return get[0] === Symbol.search &amp;&amp; get[1] === Symbol.toPrimitive &amp;&a
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50897,9 +50897,9 @@ return get[0] === Symbol.split &amp;&amp; get[1] === Symbol.toPrimitive &amp;&am
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -50977,9 +50977,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51049,9 +51049,9 @@ return get[0] === Symbol.toPrimitive &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="tally" data-browser="es6shim" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/11</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
-<td class="tally" data-browser="edge12" data-tally="1">11/11</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">11/11</td>
 <td class="tally" data-browser="edge13" data-tally="1">11/11</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.2727272727272727" style="background-color:hsl(32,74%,50%)">3/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.45454545454545453" style="background-color:hsl(54,66%,50%)">5/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.45454545454545453" style="background-color:hsl(54,66%,50%)">5/11</td>
@@ -51128,9 +51128,9 @@ return set + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -51207,9 +51207,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -51286,9 +51286,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -51365,9 +51365,9 @@ return set + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51444,9 +51444,9 @@ return set + &apos;&apos; === &quot;3,4,5&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51523,9 +51523,9 @@ return set + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -51602,9 +51602,9 @@ return set + &apos;&apos; === &quot;0,1,2,length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -51681,9 +51681,9 @@ return set + &apos;&apos; === &quot;3,1,2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51760,9 +51760,9 @@ return set + &apos;&apos; === &quot;0,2,length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51839,9 +51839,9 @@ return set + &apos;&apos; === &quot;3,2,1,length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51918,9 +51918,9 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51990,9 +51990,9 @@ return set + &apos;&apos; === &quot;5,3,2,0,1,length&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">2/2</td>
@@ -52069,9 +52069,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -52148,9 +52148,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -52220,9 +52220,9 @@ return def + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally" data-browser="edge12" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/6</td>
@@ -52299,9 +52299,9 @@ return del + &apos;&apos; === &quot;0,1,2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52378,9 +52378,9 @@ return del + &apos;&apos; === &quot;2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52457,9 +52457,9 @@ return del + &apos;&apos; === &quot;0,4,2&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52536,9 +52536,9 @@ return del + &apos;&apos; === &quot;0,2,5&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52615,9 +52615,9 @@ return del + &apos;&apos; === &quot;3,5&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52694,9 +52694,9 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -52766,9 +52766,9 @@ return del + &apos;&apos; === &quot;5,3&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge13" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">4/4</td>
@@ -52846,9 +52846,9 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -52926,9 +52926,9 @@ return gopd + &apos;&apos; === &quot;foo,bar&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53006,9 +53006,9 @@ return gopd + &apos;&apos; === &quot;garply&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53086,9 +53086,9 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53158,9 +53158,9 @@ return gopd + &apos;&apos; === &quot;length&quot;;
 <td class="tally" data-browser="es6shim" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">3/3</td>
@@ -53237,9 +53237,9 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53316,9 +53316,9 @@ return ownKeysCalled === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53395,9 +53395,9 @@ return ownKeysCalled === 2;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53467,9 +53467,9 @@ return ownKeysCalled === 2;
 <td class="tally" data-browser="es6shim" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/10</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/10</td>
-<td class="tally" data-browser="edge12" data-tally="1">10/10</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">10/10</td>
 <td class="tally" data-browser="edge13" data-tally="1">10/10</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">10/10</td>
+<td class="tally" data-browser="edge14" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/10</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">10/10</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">10/10</td>
@@ -53542,9 +53542,9 @@ return Object.getPrototypeOf(&apos;a&apos;).constructor === String;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53617,9 +53617,9 @@ return Object.getOwnPropertyDescriptor(&apos;a&apos;, &apos;foo&apos;) === undef
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53694,9 +53694,9 @@ return s.length === 2 &amp;&amp;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53769,9 +53769,9 @@ return Object.seal(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53844,9 +53844,9 @@ return Object.freeze(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53919,9 +53919,9 @@ return Object.preventExtensions(&apos;a&apos;) === &apos;a&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -53994,9 +53994,9 @@ return Object.isSealed(&apos;a&apos;) === true;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54069,9 +54069,9 @@ return Object.isFrozen(&apos;a&apos;) === true;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54144,9 +54144,9 @@ return Object.isExtensible(&apos;a&apos;) === false;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54220,9 +54220,9 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54292,9 +54292,9 @@ return s.length === 1 &amp;&amp; s[0] === &apos;0&apos;;
 <td class="tally" data-browser="es6shim" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td class="tally" data-browser="edge12" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge13" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.2857142857142857" style="background-color:hsl(34,73%,50%)">2/7</td>
@@ -54399,9 +54399,9 @@ return Object.keys(obj).join(&apos;&apos;) === forInOrder;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54494,9 +54494,9 @@ return Object.getOwnPropertyNames(obj).join(&apos;&apos;) === &quot;012349 DB-1A
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
-<td class="yes" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
-<td class="yes unstable" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -54594,9 +54594,9 @@ return result === &quot;012349 DB-1ACEFGHIJKLMNOPQRST&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
-<td class="yes unstable" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -54690,9 +54690,9 @@ return JSON.stringify(obj) ===
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
-<td class="yes" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="yes" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
-<td class="yes unstable" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[0]</sup></a></td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -54773,9 +54773,9 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
-<td class="yes" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
+<td class="yes obsolete" data-browser="edge12">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
 <td class="yes" data-browser="edge13">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
-<td class="yes unstable" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
+<td class="yes" data-browser="edge14">Yes<a href="#ie_property_order-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -54868,9 +54868,9 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 <td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[28]</sup></a></td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -54958,9 +54958,9 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -55030,9 +55030,9 @@ return result[l-3] === sym1 &amp;&amp; result[l-2] === sym2 &amp;&amp; result[l-
 <td class="tally" data-browser="es6shim" data-tally="0.2" style="background-color:hsl(24,77%,50%)">2/10</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally" data-browser="ie11" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
-<td class="tally" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
 <td class="tally" data-browser="edge13" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.7" style="background-color:hsl(84,55%,50%)" data-flagged-tally="0.9">7/10</td>
+<td class="tally" data-browser="edge14" data-tally="0.7" style="background-color:hsl(84,55%,50%)" data-flagged-tally="0.9">7/10</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.3" style="background-color:hsl(36,72%,50%)">3/10</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">5/10</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7" style="background-color:hsl(84,55%,50%)">7/10</td>
@@ -55110,9 +55110,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55186,9 +55186,9 @@ return this === undefined &amp;&amp; ({ a:1, a:1 }).a === 1;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55261,9 +55261,9 @@ do {} while (false) return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55341,9 +55341,9 @@ catch(e) {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -55420,9 +55420,9 @@ try {
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -55495,9 +55495,9 @@ return new Date(NaN) + &quot;&quot; === &quot;Invalid Date&quot;;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55570,9 +55570,9 @@ return new RegExp(/./im, &quot;g&quot;).global === true;
 <td class="yes" data-browser="es6shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55645,9 +55645,9 @@ return RegExp.prototype.toString.call({source: &apos;foo&apos;, flags: &apos;bar
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55733,9 +55733,9 @@ return true;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -55816,9 +55816,9 @@ return false;
 <td class="no" data-browser="es6shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -55890,9 +55890,9 @@ return false;
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge12" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">3/3</td>
@@ -55979,9 +55979,9 @@ return passed;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56058,9 +56058,9 @@ return foo() === 2;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56140,9 +56140,9 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56212,9 +56212,9 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
-<td class="tally" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">5/5</td>
@@ -56288,9 +56288,9 @@ return { __proto__ : [] } instanceof Array
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56368,9 +56368,9 @@ catch(e) {
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56447,9 +56447,9 @@ return !({ [a] : [] } instanceof Array);
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56526,9 +56526,9 @@ return !({ __proto__ } instanceof Array);
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56604,9 +56604,9 @@ return !({ __proto__(){} } instanceof Function);
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56676,9 +56676,9 @@ return !({ __proto__(){} } instanceof Function);
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
-<td class="tally" data-browser="edge12" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">6/6</td>
@@ -56752,9 +56752,9 @@ return (new A()).__proto__ === A.prototype;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56829,9 +56829,9 @@ return o instanceof Array;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56906,9 +56906,9 @@ return Object.getPrototypeOf(o) !== p;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -56981,9 +56981,9 @@ return Object.prototype.hasOwnProperty(&apos;__proto__&apos;);
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57063,9 +57063,9 @@ return (desc
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57138,9 +57138,9 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57210,9 +57210,9 @@ return Object.getOwnPropertyNames(Object.prototype).indexOf(&apos;__proto__&apos
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="edge12" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">3/3</td>
@@ -57292,9 +57292,9 @@ return true;
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57374,9 +57374,9 @@ return true;
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57455,9 +57455,9 @@ return true;
 <td class="yes not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57527,9 +57527,9 @@ return true;
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge12" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">2/2</td>
@@ -57606,9 +57606,9 @@ return rx.test(&apos;b&apos;);
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57682,9 +57682,9 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57754,9 +57754,9 @@ return rx.compile(&apos;b&apos;) === rx;
 <td class="tally not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">8/8</td>
 <td class="tally" data-browser="ie11" data-tally="1">8/8</td>
-<td class="tally" data-browser="edge12" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge13" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="1">8/8</td>
@@ -57829,9 +57829,9 @@ return /[\w-_]/.exec(&quot;-&quot;)[0] === &quot;-&quot;;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57905,9 +57905,9 @@ return /\z/.exec(&quot;\\z&quot;)[0] === &quot;z&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -57980,9 +57980,9 @@ return /\c2/.exec(&quot;\\c2&quot;)[0] === &quot;\\c2&quot;;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58056,9 +58056,9 @@ return /\u1/.exec(&quot;u1&quot;)[0] === &quot;u1&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58132,9 +58132,9 @@ return /\x1/.exec(&quot;x1&quot;)[0] === &quot;x1&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58208,9 +58208,9 @@ return /x{1/.exec(&quot;x{1&quot;)[0] === &quot;x{1&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58284,9 +58284,9 @@ return /\041/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58360,9 +58360,9 @@ return /\41/.exec(&quot;!&quot;)[0] === &quot;!&quot;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -58438,9 +58438,9 @@ return a === 3;
 <td class="no not-applicable" data-browser="es6shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -124,7 +124,7 @@
 <th class="platform ie10 desktop" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
 <th class="platform edge desktop" data-browser="edge"><a href="#edge" class="browser-name"><abbr title="Microsoft Edge">Edge 12-13</abbr></a></th>
-<th class="platform edge14 desktop unstable" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
 <th class="platform firefox10 desktop obsolete" data-browser="firefox10"><a href="#firefox10" class="browser-name"><abbr title="Firefox">FF 10-28</abbr></a></th>
 <th class="platform firefox29 desktop obsolete" data-browser="firefox29"><a href="#firefox29" class="browser-name"><abbr title="Firefox">FF 29</abbr></a></th>
 <th class="platform firefox30 desktop obsolete" data-browser="firefox30"><a href="#firefox30" class="browser-name"><abbr title="Firefox">FF 30</abbr></a></th>
@@ -164,7 +164,7 @@
 <td class="tally" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">2/2</td>
@@ -203,7 +203,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -242,7 +242,7 @@ return Intl.constructor === Object;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -278,7 +278,7 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">5/5</td>
@@ -317,7 +317,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -356,7 +356,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -395,7 +395,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -439,7 +439,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -506,7 +506,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -542,7 +542,7 @@ try {
 <td class="tally" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -581,7 +581,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -617,7 +617,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -656,7 +656,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -692,7 +692,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">6/6</td>
@@ -731,7 +731,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -770,7 +770,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -809,7 +809,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -848,7 +848,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -892,7 +892,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -959,7 +959,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -995,7 +995,7 @@ try {
 <td class="tally" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="edge" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
@@ -1034,7 +1034,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1073,7 +1073,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1112,7 +1112,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1156,7 +1156,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1223,7 +1223,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1263,7 +1263,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="edge">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="no obsolete" data-browser="firefox29">No</td>
 <td class="no obsolete" data-browser="firefox30">No</td>
@@ -1310,7 +1310,7 @@ try {
 <td class="no" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="edge">No</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox10">No</td>
 <td class="no obsolete" data-browser="firefox29">No</td>
 <td class="no obsolete" data-browser="firefox30">No</td>
@@ -1346,7 +1346,7 @@ try {
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1385,7 +1385,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1421,7 +1421,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1460,7 +1460,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1496,7 +1496,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1535,7 +1535,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1571,7 +1571,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1610,7 +1610,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1646,7 +1646,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1685,7 +1685,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1721,7 +1721,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1760,7 +1760,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>
@@ -1796,7 +1796,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge14" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
@@ -1835,7 +1835,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes" data-browser="edge">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox10">Yes</td>
 <td class="yes obsolete" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="firefox30">Yes</td>

--- a/esnext-browsers.js
+++ b/esnext-browsers.js
@@ -50,7 +50,8 @@ module.exports = {
       family: 'Chakra',
       short: 'Edge 12',
       note_id: 'edge-experimental-flag',
-      note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags'
+      note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags',
+      obsolete: true,
   },
   edge13: {
     full: 'Microsoft Edge',
@@ -63,7 +64,6 @@ module.exports = {
     full: 'Microsoft Edge',
       family: 'Chakra',
       short: 'Edge 14',
-      unstable: true,
       note_id: 'edge-experimental-flag',
       note_html: 'Flagged features have to be enabled via "Enable experimental Javascript features" setting under about:flags'
   },

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -117,9 +117,9 @@
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer">IE 10-</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer">IE 11</abbr></a></th>
-<th class="platform edge12 desktop" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge12 desktop obsolete" data-browser="edge12"><a href="#edge12" class="browser-name"><abbr title="Microsoft Edge">Edge 12</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
-<th class="platform edge14 desktop unstable" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform firefox31 desktop obsolete" data-browser="firefox31"><a href="#firefox31" class="browser-name"><abbr title="Firefox">FF 31<br> ESR</abbr></a></th>
 <th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox39 desktop obsolete" data-browser="firefox39"><a href="#firefox39" class="browser-name"><abbr title="Firefox">FF 39</abbr></a></th>
@@ -176,9 +176,9 @@
 <td class="tally" data-browser="es7shim" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
-<td class="tally" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0" data-flagged-tally="0.017543859649122806">0/57</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.5263157894736842">0/57</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
+<td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.017543859649122806" style="background-color:hsl(2,85%,50%)">1/57</td>
@@ -232,9 +232,9 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged" data-browser="edge12">Flag</td>
+<td class="no flagged obsolete" data-browser="edge12">Flag</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -288,9 +288,9 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -344,9 +344,9 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -400,9 +400,9 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -456,9 +456,9 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -512,9 +512,9 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -568,9 +568,9 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -624,9 +624,9 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -680,9 +680,9 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -736,9 +736,9 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -792,9 +792,9 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -848,9 +848,9 @@ return typeof SIMD.Float32x4.abs === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -904,9 +904,9 @@ return typeof SIMD.Float32x4.add === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -960,9 +960,9 @@ return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1016,9 +1016,9 @@ return typeof SIMD.Bool16x8.and === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1072,9 +1072,9 @@ return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1128,9 +1128,9 @@ return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1184,9 +1184,9 @@ return typeof SIMD.Float32x4.check === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1240,9 +1240,9 @@ return typeof SIMD.Float32x4.equal === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1296,9 +1296,9 @@ return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1352,9 +1352,9 @@ return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1408,9 +1408,9 @@ return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1464,9 +1464,9 @@ return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1520,9 +1520,9 @@ return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1576,9 +1576,9 @@ return typeof SIMD.Float32x4.mul === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1632,9 +1632,9 @@ return typeof SIMD.Float32x4.div === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1688,9 +1688,9 @@ return typeof SIMD.Float32x4.load === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1744,9 +1744,9 @@ return typeof SIMD.Float32x4.load1 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1800,9 +1800,9 @@ return typeof SIMD.Float32x4.load2 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1856,9 +1856,9 @@ return typeof SIMD.Float32x4.load3 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1912,9 +1912,9 @@ return typeof SIMD.Float32x4.max === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -1968,9 +1968,9 @@ return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2024,9 +2024,9 @@ return typeof SIMD.Float32x4.min === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2080,9 +2080,9 @@ return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2136,9 +2136,9 @@ return typeof SIMD.Float32x4.neg === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2192,9 +2192,9 @@ return typeof SIMD.Bool16x8.not === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2248,9 +2248,9 @@ return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2304,9 +2304,9 @@ return typeof SIMD.Bool16x8.or === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2360,9 +2360,9 @@ return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2416,9 +2416,9 @@ return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2472,9 +2472,9 @@ return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2528,9 +2528,9 @@ return typeof SIMD.Float32x4.select === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2584,9 +2584,9 @@ return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2640,9 +2640,9 @@ return typeof SIMD.Int32x4.shiftRightByScalar === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2696,9 +2696,9 @@ return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2752,9 +2752,9 @@ return typeof SIMD.Float32x4.splat === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2808,9 +2808,9 @@ return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2864,9 +2864,9 @@ return typeof SIMD.Float32x4.store === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2920,9 +2920,9 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2976,9 +2976,9 @@ return typeof SIMD.Float32x4.store2 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3032,9 +3032,9 @@ return typeof SIMD.Float32x4.store3 === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3088,9 +3088,9 @@ return typeof SIMD.Float32x4.sub === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3144,9 +3144,9 @@ return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3200,9 +3200,9 @@ return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3256,9 +3256,9 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3314,9 +3314,9 @@ return &apos;Float32x4,Int32x4,Int8x16,Uint32x4,Uint16x8,Uint8x16&apos;.split(&a
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3372,9 +3372,9 @@ return &apos;Float32x4,Uint32x4&apos;.split(&apos;,&apos;).every(function(type){
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3436,9 +3436,9 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3496,9 +3496,9 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3553,9 +3553,9 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3611,9 +3611,9 @@ return O.a + O.b + O.c === 6;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3668,9 +3668,9 @@ return System.global.__system_global_test__ === 42;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3721,9 +3721,9 @@ return System.global.__system_global_test__ === 42;
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/17</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/17</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/17</td>
@@ -3777,9 +3777,9 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3833,9 +3833,9 @@ return SharedArrayBuffer[Symbol.species]() === SharedArrayBuffer;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3889,9 +3889,9 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3945,9 +3945,9 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4001,9 +4001,9 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4057,9 +4057,9 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4113,9 +4113,9 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4169,9 +4169,9 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4225,9 +4225,9 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4281,9 +4281,9 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4337,9 +4337,9 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4393,9 +4393,9 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4449,9 +4449,9 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4505,9 +4505,9 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4561,9 +4561,9 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4617,9 +4617,9 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4673,9 +4673,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4726,9 +4726,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -4789,9 +4789,9 @@ iterator.next().then(function(step){
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4862,9 +4862,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4924,9 +4924,9 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="no flagged unstable" data-browser="edge14">Flag</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4988,9 +4988,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5041,9 +5041,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="es7shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5097,9 +5097,9 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5153,9 +5153,9 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes" data-browser="edge12">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
 <td class="yes" data-browser="edge13">Yes</td>
-<td class="yes unstable" data-browser="edge14">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -5209,9 +5209,9 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5265,9 +5265,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5318,9 +5318,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="es7shim" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/8</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/8</td>
@@ -5374,9 +5374,9 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5430,9 +5430,9 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5486,9 +5486,9 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5552,9 +5552,9 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5609,9 +5609,9 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5666,9 +5666,9 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5722,9 +5722,9 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5778,9 +5778,9 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5844,9 +5844,9 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5904,9 +5904,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5957,9 +5957,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally" data-browser="es7shim" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/7</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/7</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/7</td>
@@ -6013,9 +6013,9 @@ return typeof Zone == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6069,9 +6069,9 @@ return &apos;current&apos; in Zone;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6125,9 +6125,9 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6181,9 +6181,9 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6237,9 +6237,9 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6293,9 +6293,9 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6349,9 +6349,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6406,9 +6406,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6459,9 +6459,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge12" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge14" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/2</td>
@@ -6524,9 +6524,9 @@ return new C(42).x() === 42;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6586,9 +6586,9 @@ return new C().x() === 42;
 <td class="no" data-browser="es7shim">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no" data-browser="edge12">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no unstable" data-browser="edge14">No</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -6641,9 +6641,9 @@ return new C().x() === 42;
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -6699,9 +6699,9 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6756,9 +6756,9 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6815,9 +6815,9 @@ return do {
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6874,9 +6874,9 @@ return typeof Realm === &quot;function&quot;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6930,9 +6930,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6983,9 +6983,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7039,9 +7039,9 @@ return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7095,9 +7095,9 @@ return Math.isubh(0, 4, 1, 1) === 2;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7151,9 +7151,9 @@ return Math.imulh(0xffffffff, 7) === -1;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7207,9 +7207,9 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7260,9 +7260,9 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -7317,9 +7317,9 @@ return f();
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7373,9 +7373,9 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7434,9 +7434,9 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7501,9 +7501,9 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7564,9 +7564,9 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7627,9 +7627,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7683,9 +7683,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7736,9 +7736,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7794,9 +7794,9 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7852,9 +7852,9 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7911,9 +7911,9 @@ passed = true;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7964,9 +7964,9 @@ passed = true;
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8026,9 +8026,9 @@ return (function f(n){
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8095,9 +8095,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8150,9 +8150,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -8206,9 +8206,9 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8262,9 +8262,9 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8318,9 +8318,9 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8374,9 +8374,9 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8430,9 +8430,9 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8486,9 +8486,9 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8542,9 +8542,9 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8598,9 +8598,9 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8654,9 +8654,9 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="es7shim" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="ie10" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ie11" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge12" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox31" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox39" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
Edge 14 is stable now. Edge 12 has, varying by source, between 0.18% in the past
week (Statcounter) and 0.44% in the past month (NetMarketShare) of the browser
market; considering that and the fact that two newer Edge versions have already
been released, it may be marked as obsolete now.
