### PR TITLE
Consolidating Firefox versions with identical results on ES intl

### DIFF
--- a/data-esintl.js
+++ b/data-esintl.js
@@ -41,42 +41,7 @@ exports.browsers = {
   },
   firefox29: {
     full: 'Firefox',
-    short: 'FF 29',
-    obsolete: true
-  },
-  firefox30: {
-    full: 'Firefox',
-    short: 'FF 30',
-    obsolete: true
-  },
-  firefox31: {
-    full: 'Firefox',
-    short: 'FF 31',
-    obsolete: true
-  },
-  firefox32: {
-    full: 'Firefox',
-    short: 'FF 32',
-    obsolete: true
-  },
-  firefox33: {
-    full: 'Firefox',
-    short: 'FF 33',
-    obsolete: true
-  },
-  firefox34: {
-    full: 'Firefox',
-    short: 'FF 34',
-    obsolete: true
-  },
-  firefox35: {
-    full: 'Firefox',
-    short: 'FF 35',
-    obsolete: true
-  },
-  firefox36: {
-    full: 'Firefox',
-    short: 'FF 36+'
+    short: 'FF 29+',
   },
   chrome22: {
     full: 'Chrome 22',

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -126,14 +126,7 @@
 <th class="platform edge desktop" data-browser="edge"><a href="#edge" class="browser-name"><abbr title="Microsoft Edge">Edge 12-13</abbr></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a></th>
 <th class="platform firefox2 desktop obsolete" data-browser="firefox2"><a href="#firefox2" class="browser-name"><abbr title="Firefox">FF 2-28</abbr></a></th>
-<th class="platform firefox29 desktop obsolete" data-browser="firefox29"><a href="#firefox29" class="browser-name"><abbr title="Firefox">FF 29</abbr></a></th>
-<th class="platform firefox30 desktop obsolete" data-browser="firefox30"><a href="#firefox30" class="browser-name"><abbr title="Firefox">FF 30</abbr></a></th>
-<th class="platform firefox31 desktop obsolete" data-browser="firefox31"><a href="#firefox31" class="browser-name"><abbr title="Firefox">FF 31</abbr></a></th>
-<th class="platform firefox32 desktop obsolete" data-browser="firefox32"><a href="#firefox32" class="browser-name"><abbr title="Firefox">FF 32</abbr></a></th>
-<th class="platform firefox33 desktop obsolete" data-browser="firefox33"><a href="#firefox33" class="browser-name"><abbr title="Firefox">FF 33</abbr></a></th>
-<th class="platform firefox34 desktop obsolete" data-browser="firefox34"><a href="#firefox34" class="browser-name"><abbr title="Firefox">FF 34</abbr></a></th>
-<th class="platform firefox35 desktop obsolete" data-browser="firefox35"><a href="#firefox35" class="browser-name"><abbr title="Firefox">FF 35</abbr></a></th>
-<th class="platform firefox36 desktop" data-browser="firefox36"><a href="#firefox36" class="browser-name"><abbr title="Firefox">FF 36+</abbr></a></th>
+<th class="platform firefox29 desktop" data-browser="firefox29"><a href="#firefox29" class="browser-name"><abbr title="Firefox">FF 29+</abbr></a></th>
 <th class="platform chrome22 desktop obsolete" data-browser="chrome22"><a href="#chrome22" class="browser-name"><abbr title="Chrome 22">CH 22</abbr></a></th>
 <th class="platform chrome24 desktop obsolete" data-browser="chrome24"><a href="#chrome24" class="browser-name"><abbr title="Chrome 24-29, Opera 16+">CH 24-29,<br>OP 15+</abbr></a></th>
 <th class="platform chrome29 desktop" data-browser="chrome29"><a href="#chrome29" class="browser-name"><abbr title="Chrome 29+, Opera 16+">CH 29+,<br>OP 16+</abbr></a></th>
@@ -166,14 +159,7 @@
 <td class="tally" data-browser="edge" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox36" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox29" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome29" data-tally="1">2/2</td>
@@ -205,14 +191,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -244,14 +223,7 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -280,14 +252,7 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="edge" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox36" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox29" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="chrome29" data-tally="1">5/5</td>
@@ -319,14 +284,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -358,14 +316,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -397,14 +348,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -441,14 +385,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -508,14 +445,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="no obsolete" data-browser="chrome24">No</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -544,14 +474,7 @@ try {
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -583,14 +506,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -619,14 +535,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -658,14 +567,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -694,14 +596,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">6/6</td>
-<td class="tally" data-browser="firefox36" data-tally="1">6/6</td>
+<td class="tally" data-browser="firefox29" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="chrome29" data-tally="1">6/6</td>
@@ -733,14 +628,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -772,14 +660,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -811,14 +692,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -850,14 +724,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -894,14 +761,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -961,14 +821,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="no obsolete" data-browser="chrome24">No</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -997,14 +850,7 @@ try {
 <td class="tally" data-browser="edge" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="firefox36" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally" data-browser="firefox29" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="chrome29" data-tally="1">7/7</td>
@@ -1036,14 +882,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1075,14 +914,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1114,14 +946,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1158,14 +983,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1225,14 +1043,7 @@ try {
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="no obsolete" data-browser="chrome24">No</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1265,14 +1076,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no" data-browser="edge">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="no obsolete" data-browser="firefox29">No</td>
-<td class="no obsolete" data-browser="firefox30">No</td>
-<td class="no obsolete" data-browser="firefox31">No</td>
-<td class="no obsolete" data-browser="firefox32">No</td>
-<td class="no obsolete" data-browser="firefox33">No</td>
-<td class="no obsolete" data-browser="firefox34">No</td>
-<td class="no obsolete" data-browser="firefox35">No</td>
-<td class="no" data-browser="firefox36">No</td>
+<td class="no" data-browser="firefox29">No</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="unknown obsolete" data-browser="chrome24">?</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1312,14 +1116,7 @@ try {
 <td class="no" data-browser="edge">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox2">No</td>
-<td class="no obsolete" data-browser="firefox29">No</td>
-<td class="no obsolete" data-browser="firefox30">No</td>
-<td class="no obsolete" data-browser="firefox31">No</td>
-<td class="no obsolete" data-browser="firefox32">No</td>
-<td class="no obsolete" data-browser="firefox33">No</td>
-<td class="no obsolete" data-browser="firefox34">No</td>
-<td class="no obsolete" data-browser="firefox35">No</td>
-<td class="no" data-browser="firefox36">No</td>
+<td class="no" data-browser="firefox29">No</td>
 <td class="no obsolete" data-browser="chrome22">No</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1348,14 +1145,7 @@ try {
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1387,14 +1177,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1423,14 +1206,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1462,14 +1238,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1498,14 +1267,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1537,14 +1299,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1573,14 +1328,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1612,14 +1360,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1648,14 +1389,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1687,14 +1421,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1723,14 +1450,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1762,14 +1482,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>
@@ -1798,14 +1511,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="edge" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox29" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox30" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox31" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox32" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox33" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox34" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox35" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox36" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox29" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome22" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome24" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome29" data-tally="1">1/1</td>
@@ -1837,14 +1543,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="edge">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox2">Yes</td>
-<td class="yes obsolete" data-browser="firefox29">Yes</td>
-<td class="yes obsolete" data-browser="firefox30">Yes</td>
-<td class="yes obsolete" data-browser="firefox31">Yes</td>
-<td class="yes obsolete" data-browser="firefox32">Yes</td>
-<td class="yes obsolete" data-browser="firefox33">Yes</td>
-<td class="yes obsolete" data-browser="firefox34">Yes</td>
-<td class="yes obsolete" data-browser="firefox35">Yes</td>
-<td class="yes" data-browser="firefox36">Yes</td>
+<td class="yes" data-browser="firefox29">Yes</td>
 <td class="yes obsolete" data-browser="chrome22">Yes</td>
 <td class="yes obsolete" data-browser="chrome24">Yes</td>
 <td class="yes" data-browser="chrome29">Yes</td>


### PR DESCRIPTION
This patch consolidates Firefox versions 29...35 with "36+", which all have identical results.  This makes the resulting HTML both shorter and faster to process, without any loss of information.
