### PR TITLE
update results for Edge 13

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -900,7 +900,7 @@ exports.tests = [
        */},
       res: {
         firefox24:   true,
-        edge14:      true,
+        edge13:      true,
         chrome52:    true,
         safari10:    true,
         safaritp:    true,
@@ -918,7 +918,7 @@ exports.tests = [
          */},
         res: {
           firefox24:   true,
-          edge14:      true,
+          edge13:      true,
           chrome52:    true,
           safari10:    true,
           safaritp:    true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -911,7 +911,7 @@ exports.tests = [
         chrome39:    flag,
         chrome40:    false,
         chrome45:    true,
-        edge14:      true,
+        edge13:      true,
         safaritp:    true,
         safari10:    true,
         webkit:      true,
@@ -5403,7 +5403,7 @@ exports.tests = [
         tr:          true,
         babel:       true,
         typescript:  typescript.fallthrough,
-        edge14:      true,
+        edge13:      true,
         firefox46:   true,
         chrome50:    true,
         safaritp:    true,
@@ -10821,11 +10821,17 @@ exports.tests = [
         try {
           var {a} = null;
           return false;
-        } catch(e) {}
+        } catch(e) {
+          if (!(e instanceof TypeError))
+            return false;
+        }
         try {
           var {b} = undefined;
           return false;
-        } catch(e) {}
+        } catch(e) {
+          if (!(e instanceof TypeError))
+            return false;
+        }
         return true;
       */},
       res: Object.assign({}, temp.destructuringResults, {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -3290,7 +3290,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge13" data-tally="0">0/4</td>
+<td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3350,7 +3350,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no" data-browser="edge13">No</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
@@ -3410,7 +3410,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no" data-browser="edge13">No</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -4927,7 +4927,7 @@ return cr.length === 3 &amp;&amp; lf.length === 3 &amp;&amp; crlf.length === 3
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
-<td class="tally" data-browser="edge13" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
@@ -5307,7 +5307,7 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no" data-browser="edge13">No</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
@@ -6362,13 +6362,19 @@ return a === 1;
 try {
   var {a} = null;
   return false;
-} catch(e) {}
+} catch(e) {
+  if (!(e instanceof TypeError))
+    return false;
+}
 try {
   var {b} = undefined;
   return false;
-} catch(e) {}
+} catch(e) {
+  if (!(e instanceof TypeError))
+    return false;
+}
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\ntry {\n  var {a} = null;\n  return false;\n} catch(e) {}\ntry {\n  var {b} = undefined;\n  return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  var {a} = null;\n  return false;\n} catch(e) {}\ntry {\n  var {b} = undefined;\n  return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\ntry {\n  var {a} = null;\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\ntry {\n  var {b} = undefined;\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  var {a} = null;\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\ntry {\n  var {b} = undefined;\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>
@@ -13870,7 +13876,7 @@ return f() === 1;
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/13</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)" data-flagged-tally="0.7692307692307693">8/13</td>
-<td class="tally" data-browser="edge13" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
+<td class="tally" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge14" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.6153846153846154" style="background-color:hsl(73,58%,50%)">8/13</td>
@@ -14634,7 +14640,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
-<td class="no" data-browser="edge13">No</td>
+<td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>


### PR DESCRIPTION
- correct the results for Edge 13 for four tests (two on ES6, two on ES2016+);
- tighten one test that was giving a false positive on a platform
  supporting shorthand properties but not destructuring assignments.
