### PR TITLE
Tighten a test that was giving a false positive on a platform supporting shorthand properties but not destructuring assignments

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -11440,11 +11440,17 @@ exports.tests = [
         try {
           ({a} = null);
           return false;
-        } catch(e) {}
+        } catch(e) {
+          if (!(e instanceof TypeError))
+            return false;
+        }
         try {
           ({b} = undefined);
           return false;
-        } catch(e) {}
+        } catch(e) {
+          if (!(e instanceof TypeError))
+            return false;
+        }
         return true;
       */},
       res: Object.assign({}, temp.destructuringResults, {

--- a/es6/index.html
+++ b/es6/index.html
@@ -8659,13 +8659,19 @@ var a,b;
 try {
   ({a} = null);
   return false;
-} catch(e) {}
+} catch(e) {
+  if (!(e instanceof TypeError))
+    return false;
+}
 try {
   ({b} = undefined);
   return false;
-} catch(e) {}
+} catch(e) {
+  if (!(e instanceof TypeError))
+    return false;
+}
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nvar a,b;\ntry {\n  ({a} = null);\n  return false;\n} catch(e) {}\ntry {\n  ({b} = undefined);\n  return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nvar a,b;\ntry {\n  ({a} = null);\n  return false;\n} catch(e) {}\ntry {\n  ({b} = undefined);\n  return false;\n} catch(e) {}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nvar a,b;\ntry {\n  ({a} = null);\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\ntry {\n  ({b} = undefined);\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nvar a,b;\ntry {\n  ({a} = null);\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\ntry {\n  ({b} = undefined);\n  return false;\n} catch(e) {\n  if (!(e instanceof TypeError))\n    return false;\n}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>


### PR DESCRIPTION
Followup of #865 and 3bc88a01d78aabf112ecbe473d86ca1d64303d3b

I modified the corresponding subtest for "detructuring, declaration",
but I  forgot the same subtest in ""detructuring, assignment".
