### PR TITLE
ES6: more precise "block function declaration" test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -10469,11 +10469,15 @@ exports.tests = [
   link: 'http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation',
   exec: function () {/*
     'use strict';
+    if (f() !== 1) return false;
     function f() { return 1; }
     {
+      if (f() !== 2) return false;
       function f() { return 2; }
+      if (f() !== 2) return false;
     }
-    return f() === 1;
+    if (f() !== 1) return false;
+    return true;
   */},
   res: {
     babel:       true,

--- a/es6/index.html
+++ b/es6/index.html
@@ -13967,12 +13967,16 @@ return passed;
 </tr>
 <tr significance="0.25"><td id="test-block-level_function_declaration"><span><a class="anchor" href="#test-block-level_function_declaration">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-functiondeclarationinstantiation">block-level function declaration</a><a href="#block-level-function-note"><sup>[13]</sup></a></span><script data-source="
 &apos;use strict&apos;;
+if (f() !== 1) return false;
 function f() { return 1; }
 {
+  if (f() !== 2) return false;
   function f() { return 2; }
+  if (f() !== 2) return false;
 }
-return f() === 1;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\nfunction f() { return 1; }\n{\n  function f() { return 2; }\n}\nreturn f() === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+if (f() !== 1) return false;
+return true;
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\n'use strict';\nif (f() !== 1) return false;\nfunction f() { return 1; }\n{\n  if (f() !== 2) return false;\n  function f() { return 2; }\n  if (f() !== 2) return false;\n}\nif (f() !== 1) return false;\nreturn true;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\n'use strict';\nif (f() !== 1) return false;\nfunction f() { return 1; }\n{\n  if (f() !== 2) return false;\n  function f() { return 2; }\n  if (f() !== 2) return false;\n}\nif (f() !== 1) return false;\nreturn true;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes" data-browser="tr">Yes</td>
 <td class="yes" data-browser="babel">Yes</td>


### PR DESCRIPTION
That test will now more probably fail in old browsers that don't
support strict mode and would apply some old clunky browser-defined
semantics.
