### PR TITLE
babylon now parses the exponential operator correctly

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -59,7 +59,7 @@ exports.tests = [
          */},
         res: {
           tr:          true,
-          babel:       false,
+          babel:       true,
           typescript:  true,
           edge13:      flag,
           edge14:      true,


### PR DESCRIPTION
The support for exponential operator has been fixed in babylon 6.9.0 (https://github.com/babel/babylon/pull/75)

Also the `basic support` test is now green opened on Firefox (which does not support `**`)
