### PR TITLE
corrections for edge14 in es6 and es2016+

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -401,7 +401,7 @@ exports.tests = [
           typescript: typescript.asyncawait,
           chrome52: flag,
           edge13: flag,
-          edge14: true,
+          edge14: flag,
         }
       },
       {
@@ -417,7 +417,7 @@ exports.tests = [
           typescript: typescript.asyncawait,
           chrome52: flag,
           edge13: flag,
-          edge14: true,
+          edge14: flag,
         }
       },
       {
@@ -431,7 +431,7 @@ exports.tests = [
           typescript: false, // still buggy output
           chrome52: flag,
           edge13: flag,
-          edge14: true,
+          edge14: flag,
         }
       }
     ]
@@ -482,6 +482,7 @@ exports.tests = [
      return iter['throw']().value === 'bar';
      */},
     res: {
+      edge14: true,
       firefox27: true,
       chrome39: true,
       node: flag,
@@ -949,6 +950,7 @@ exports.tests = [
          return gopd + '' === "foo" && gpo;
          */},
         res: {
+          edge14: true,
           firefox49: true,
           safari10: true,
           safaritp: true,
@@ -970,6 +972,7 @@ exports.tests = [
          return gopd + '' === "foo" && gpo;
          */},
         res: {
+          edge14: true,
           firefox49: true,
           safari10: true,
           safaritp: true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -4074,7 +4074,7 @@ exports.tests = [
         tr: true,
         babel: true,
         typescript: false,
-        edge14: true,
+        edge14: false,
         safari9: true,
         safaritp: true,
         webkit: true,
@@ -4099,7 +4099,7 @@ exports.tests = [
         tr: true,
         babel: true,
         typescript: false,
-        edge14: true,
+        edge14: false,
         safari9: true,
         safaritp: true,
         webkit: true,
@@ -6311,7 +6311,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -6795,7 +6795,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -7300,7 +7300,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -7571,7 +7571,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: typescript.corejs,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -8808,7 +8808,7 @@ exports.tests = [
         return get[0] === Symbol.hasInstance && get.slice(1) + '' === "prototype";
       */},
       res: {
-        edge14: flag,
+        edge14: false,
         firefox50: true,
         chrome50: flag,
         chrome51: true,
@@ -9241,7 +9241,7 @@ exports.tests = [
           && get.length === 7;
       */},
       res: {
-        edge14: flag,
+        edge14: false,
         chrome50: flag,
         chrome51: true,
         firefox48: true,
@@ -10767,7 +10767,7 @@ exports.tests = [
         tr: true,
         babel: true,
         typescript: false,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -11251,7 +11251,7 @@ exports.tests = [
         babel: true,
         typescript: false,
         chrome51: true,
-        edge14: true,
+        edge14: false,
         safari9: true,
         safaritp: true,
         webkit: true,
@@ -11789,7 +11789,7 @@ exports.tests = [
       res: {
         babel: true,
         typescript: false,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,
@@ -14038,7 +14038,7 @@ exports.tests = [
       res: {
         babel: flag,
         typescript: typescript.fallthrough,
-        edge14: flag,
+        edge14: false,
         chrome50: flag,
         chrome51: true,
         firefox50: true,
@@ -14060,7 +14060,7 @@ exports.tests = [
       */},
       res: {
         typescript: typescript.fallthrough,
-        edge14: flag,
+        edge14: false,
         ejs: true,
         chrome48: true,
         firefox48: true,
@@ -15138,7 +15138,7 @@ exports.tests = [
         tr: true,
         babel: true,
         typescript: typescript.corejs,
-        edge14: true,
+        edge14: false,
         chrome51: true,
         safari9: true,
         safaritp: true,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -801,7 +801,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no" data-browser="edge14">No</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="yes obsolete" data-browser="firefox31">Yes</td>
 <td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox39">Yes</td>
@@ -1913,7 +1913,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="1">0/3</td>
-<td class="tally" data-browser="edge14" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0">0/3</td>
@@ -1978,7 +1978,7 @@ return (async function(){
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2043,7 +2043,7 @@ return (async function(){
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -2106,7 +2106,7 @@ return (async () =&gt; 42 + await Promise.resolve(42))() instanceof Promise
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no flagged" data-browser="edge13">Flag</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3662,7 +3662,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -3868,7 +3868,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no" data-browser="edge14">No</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -3940,7 +3940,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no" data-browser="edge14">No</td>
+<td class="yes" data-browser="edge14">Yes</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -3504,7 +3504,7 @@ return obj.y === 1 &amp;&amp; valueSet === &apos;foo&apos;;
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.7777777777777778">6/9</td>
 <td class="tally" data-browser="edge13" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
-<td class="tally" data-browser="edge14" data-tally="1">9/9</td>
+<td class="tally" data-browser="edge14" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)">5/9</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">7/9</td>
@@ -4176,7 +4176,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -4263,7 +4263,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -5720,7 +5720,7 @@ return &quot;&#x17F;&quot;.match(/S/iu) &amp;&amp; &quot;S&quot;.match(/&#x17F;/
 <td class="tally" data-browser="ie11" data-tally="0">0/22</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/22</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9090909090909091">0/22</td>
-<td class="tally" data-browser="edge14" data-tally="1">22/22</td>
+<td class="tally" data-browser="edge14" data-tally="0.9545454545454546" style="background-color:hsl(114,44%,50%)">21/22</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5909090909090909" style="background-color:hsl(70,60%,50%)">13/22</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8636363636363636" style="background-color:hsl(103,48%,50%)">19/22</td>
@@ -6372,7 +6372,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -7622,7 +7622,7 @@ return a === 1 &amp;&amp; b === 2;
 <td class="tally" data-browser="ie11" data-tally="0">0/24</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/24</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9583333333333334">0/24</td>
-<td class="tally" data-browser="edge14" data-tally="1">24/24</td>
+<td class="tally" data-browser="edge14" data-tally="0.9583333333333334" style="background-color:hsl(115,43%,50%)">23/24</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5833333333333334" style="background-color:hsl(70,60%,50%)">14/24</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">20/24</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">20/24</td>
@@ -8282,7 +8282,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -9695,7 +9695,7 @@ return a === 1 &amp;&amp; b === 2 &amp;&amp; c === 3
 <td class="tally" data-browser="ie11" data-tally="0">0/23</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0">0/23</td>
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.9565217391304348">0/23</td>
-<td class="tally" data-browser="edge14" data-tally="1">23/23</td>
+<td class="tally" data-browser="edge14" data-tally="0.9565217391304348" style="background-color:hsl(114,43%,50%)">22/23</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5217391304347826" style="background-color:hsl(62,63%,50%)">12/23</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.782608695652174" style="background-color:hsl(93,51%,50%)">18/23</td>
@@ -10354,7 +10354,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -25410,7 +25410,7 @@ typeof Float64Array[Symbol.species] === &quot;function&quot;;
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
-<td class="tally" data-browser="edge14" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge14" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
@@ -25924,7 +25924,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -27071,7 +27071,7 @@ return &apos;get&apos; in prop &amp;&amp; Map[Symbol.species] === Map;
 <td class="tally" data-browser="ie11" data-tally="0.42105263157894735" style="background-color:hsl(50,67%,50%)">8/19</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.8421052631578947" style="background-color:hsl(101,48%,50%)">16/19</td>
 <td class="tally" data-browser="edge13" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
-<td class="tally" data-browser="edge14" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge14" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.7894736842105263" style="background-color:hsl(94,51%,50%)">15/19</td>
@@ -27588,7 +27588,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -28737,7 +28737,7 @@ return &apos;get&apos; in prop &amp;&amp; Set[Symbol.species] === Set;
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">6/12</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally" data-browser="edge13" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
-<td class="tally" data-browser="edge14" data-tally="1">12/12</td>
+<td class="tally" data-browser="edge14" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">4/12</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">8/12</td>
@@ -29334,7 +29334,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -29830,7 +29830,7 @@ catch(e) {
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
-<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
@@ -30343,7 +30343,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37743,7 +37743,7 @@ return Symbol.for(&apos;foo&apos;) === symbol &amp;&amp;
 <td class="tally" data-browser="ie11" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.11538461538461539" style="background-color:hsl(13,80%,50%)">3/26</td>
 <td class="tally" data-browser="edge13" data-tally="0.34615384615384615" style="background-color:hsl(41,70%,50%)">9/26</td>
-<td class="tally" data-browser="edge14" data-tally="0.38461538461538464" style="background-color:hsl(46,69%,50%)" data-flagged-tally="0.8076923076923077">10/26</td>
+<td class="tally" data-browser="edge14" data-tally="0.38461538461538464" style="background-color:hsl(46,69%,50%)" data-flagged-tally="0.7307692307692307">10/26</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.038461538461538464" style="background-color:hsl(4,84%,50%)">1/26</td>
@@ -37830,7 +37830,7 @@ return passed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -37913,7 +37913,7 @@ return a[0] === b;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -43631,7 +43631,7 @@ return &apos;get&apos; in prop &amp;&amp; RegExp[Symbol.species] === RegExp;
 <td class="tally" data-browser="ie11" data-tally="0">0/11</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.6363636363636364" style="background-color:hsl(76,58%,50%)" data-flagged-tally="0.8181818181818182">7/11</td>
 <td class="tally" data-browser="edge13" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
-<td class="tally" data-browser="edge14" data-tally="1">11/11</td>
+<td class="tally" data-browser="edge14" data-tally="0.9090909090909091" style="background-color:hsl(109,46%,50%)">10/11</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.09090909090909091" style="background-color:hsl(10,82%,50%)">1/11</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.8181818181818182" style="background-color:hsl(98,50%,50%)">9/11</td>
@@ -44372,7 +44372,7 @@ return closed;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="yes" data-browser="edge14">Yes</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -51207,7 +51207,7 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="ie11" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="edge12" data-tally="0.3888888888888889" style="background-color:hsl(46,68%,50%)" data-flagged-tally="0.4166666666666667">14/36</td>
 <td class="tally" data-browser="edge13" data-tally="0.5277777777777778" style="background-color:hsl(63,62%,50%)">19/36</td>
-<td class="tally" data-browser="edge14" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.8333333333333334">20/36</td>
+<td class="tally" data-browser="edge14" data-tally="0.5555555555555556" style="background-color:hsl(66,61%,50%)" data-flagged-tally="0.7777777777777778">20/36</td>
 <td class="tally obsolete" data-browser="firefox31" data-tally="0.2777777777777778" style="background-color:hsl(33,73%,50%)">10/36</td>
 <td class="tally obsolete" data-browser="firefox38" data-tally="0.4722222222222222" style="background-color:hsl(56,65%,50%)">17/36</td>
 <td class="tally obsolete" data-browser="firefox39" data-tally="0.4444444444444444" style="background-color:hsl(53,66%,50%)">16/36</td>
@@ -51460,7 +51460,7 @@ return get[0] === Symbol.hasInstance &amp;&amp; get.slice(1) + &apos;&apos; === 
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>
@@ -53178,7 +53178,7 @@ return get[0] === &quot;constructor&quot;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="edge12">No</td>
 <td class="no" data-browser="edge13">No</td>
-<td class="no flagged" data-browser="edge14">Flag</td>
+<td class="no" data-browser="edge14">No</td>
 <td class="no obsolete" data-browser="firefox31">No</td>
 <td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox39">No</td>


### PR DESCRIPTION
According to testing on v14.14393
- es6: doesn't support iterator closing;
- es6: doesn't support Symbol.hasInstance, Symbol.isConcatSpreadable;
- es2016: supports catching generator throw() by inner generator;
- es2017: support of async functions still behind flag;
- es2017: supports Proxy internal calls for **define{G,S}etter**;
