### PR TITLE
Updating ES2016+ results for Firefox 52 (Nightly)

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -103,6 +103,7 @@ exports.tests = [
         res: {
           babel: true,
           edge14: true,
+          firefox52: true,
           chrome51: flag,
           chrome52: true,
           safaritp: true,
@@ -441,6 +442,7 @@ exports.tests = [
           babel: true,
           typescript: true,
           edge14: true,
+          firefox52: true,
           safari10: true,
           safaritp: true,
           webkit: true,
@@ -455,6 +457,7 @@ exports.tests = [
           babel: true,
           typescript: true,
           edge14: true,
+          firefox52: true,
           safari10: true,
           safaritp: true,
           webkit: true,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -197,7 +197,7 @@
 <td class="tally" data-browser="firefox49" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="firefox50" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="firefox51" data-tally="0">0/3</td>
-<td class="tally unstable" data-browser="firefox52" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally unstable" data-browser="firefox52" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome40" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome41" data-tally="0">0/3</td>
@@ -397,7 +397,7 @@ return true;
 <td class="no" data-browser="firefox49">No</td>
 <td class="no unstable" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>
@@ -2113,7 +2113,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="firefox49" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox50" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox51" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="firefox52" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome30" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome41" data-tally="0">0/2</td>
@@ -2178,7 +2178,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="firefox49">No</td>
 <td class="no unstable" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>
@@ -2243,7 +2243,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="firefox49">No</td>
 <td class="no unstable" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>


### PR DESCRIPTION
Updating ES2016+ results for Firefox 52 (Nightly).  It now has full exponentiation (**) support and allows trailing commas in function syntax.
