### PR TITLE
Updating ES6 and ES2016 results for Firefox 52 (Nightly)

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -533,6 +533,7 @@ exports.tests = [
      */},
     res: {
       edge12: true,
+      firefox52: true,
       chrome47: true,
       safari10: true,
       safaritp: true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -5837,6 +5837,7 @@ exports.tests = [
         safaritp: true,
         safari10: true,
         webkit: true,
+        firefox52:true,
         xs6: true,
         jxa: true,
       },

--- a/data-es6.js
+++ b/data-es6.js
@@ -17358,6 +17358,7 @@ exports.tests = [
         babel: true,
         closure: true,
         typescript: true,
+        firefox52: true,
         chrome45: true,
         safari9: true,
         safaritp: true,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -918,7 +918,7 @@ return true;
 <td class="no" data-browser="firefox49">No</td>
 <td class="no unstable" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
 <td class="no obsolete" data-browser="chrome30">No</td>
 <td class="no obsolete" data-browser="chrome40">No</td>
 <td class="no obsolete" data-browser="chrome41">No</td>


### PR DESCRIPTION
Updating ES6 and ES2016 results for Firefox 52 (Nightly).
