### PR TITLE
Fix Array.prototype.values support for FF

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -15542,6 +15542,11 @@ exports.tests = [
           note_html: 'Available as <code>Array.prototype[Symbol.iterator]</code>'
         },
         firefox48: true,
+        firefox49: {
+          val: false,
+          note_id: 'array-prototype-values',
+          note_html: 'The feature is enabled by default only in Firefox Nightly due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1299593">compatibility issue</a>.',
+        },
         chrome30: flag,
         chrome38: { val: false, note_id: 'array-prototype-iterator' },
         node012: true,


### PR DESCRIPTION
Fixes #957.

We still need to implement something like #950 because FF52 will show weird results now