### PR TITLE
[WIP] Add raw data generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ es*/compilers/*
 .ruby-version
 _site/
 .idea/
+raw-data/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+node_modules/*
+es*/compilers/*
+.DS_Store
+.ruby-version
+_site/
+.idea/
+es5/
+es6/
+es7/
+es2016plus/
+esnext/
+esintl/
+non-standard/
+strict-mode/

--- a/generate-raw-data.js
+++ b/generate-raw-data.js
@@ -1,0 +1,28 @@
+var fs = require('fs');
+var path = require('path');
+
+var RAW_DATA_DIR = 'raw-data';
+
+function omitTests(test) {
+  if (test.subtests) {
+    test.subtests = test.subtests.map(omitTests);
+    return test;
+  }
+  delete test.exec;
+  return test;
+}
+
+function processFile(file) {
+  var content = require('./data-' + file + '.js').tests.map(omitTests);
+  var json = JSON.stringify(content, null, 2);
+  var fileName = 'data-' + file + '.json';
+  fs.writeFile(path.join(__dirname, RAW_DATA_DIR, file), json, function (err) {
+    if (err) throw err;
+    console.log(fileName + ' generated.');
+  });
+}
+
+if (!fs.existsSync(RAW_DATA_DIR)){
+  fs.mkdirSync(RAW_DATA_DIR);
+}
+['es5', 'es6', 'es2016plus', 'esnext', 'esintl', 'non-standard'].map(processFile);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "type": "git",
     "url": "git://github.com/kangax/compat-table.git"
   },
-  "private": true,
   "dependencies": {
     "babel-core": "latest",
     "babel-polyfill": "latest",
@@ -39,6 +38,7 @@
   "scripts": {
     "lint": "jshint .",
     "build": "node build.js",
+    "gen-data": "node generate-raw-data.js",
     "pretest": "npm run lint",
     "build:compilers": "node build.js compilers",
     "git:clean": "if type git > /dev/null 2>&1; then git stash save --keep-index; fi",


### PR DESCRIPTION
I found it much harder to build all data from JSON files (as I wanted in #965) than generating raw data from current js data files. Having js files allows to have autocomplete in editors when using shared data from 'data-common.json'. Also removing tests is not so trivial and it doesn't brings any significant profits. 

Also we need to register npm name and setup CI for automated package version bumping and publishing.