### PR TITLE
fix broken url for proposal-trailing-function-commas which moved to t…

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -317,7 +317,7 @@ exports.tests = [
   },
   {
     name: 'trailing commas in function syntax',
-    spec: 'https://jeffmo.github.io/es-trailing-function-commas/',
+    spec: 'https://github.com/tc39/proposal-trailing-function-commas',
     category: '2017 features',
     significance: 'small',
     subtests: [

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
@@ -1910,7 +1910,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://jeffmo.github.io/es-trailing-function-commas/">trailing commas in function syntax</a></span></td>
+<tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-trailing-function-commas">trailing commas in function syntax</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel" data-tally="1">2/2</td>
 <td class="tally" data-browser="closure" data-tally="0">0/2</td>


### PR DESCRIPTION
Fixes the broken URL for the "proposal-trailing-function-commas", it moved from https://jeffmo.github.io/es-trailing-function-commas/ to tc39/proposal-trailing-function-commas