### PR TITLE
Test only for "do" syntax, instead of "let"

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -51,7 +51,7 @@ exports.tests = [
   spec: 'http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions',
   exec: function () {/*
     return do {
-      let x = 23;
+      var x = 23;
       x + 19;
     } === 42;
   */},


### PR DESCRIPTION
Currently this test verifies not only "do" syntax, but also "let".

I'm changing "let" to "var" so only "do" is tested.. 