### PR TITLE
SharedArrayBuffer now enabled by default on Firefox 52

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1135,6 +1135,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1156,6 +1157,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
       }
     },
@@ -1165,7 +1167,7 @@ exports.tests = [
         return typeof SharedArrayBuffer.prototype.slice === 'function';
       */},
       res: {
-        firefox52: firefox.developer,
+        firefox52: true,
         safaritp: true,
         webkit: true,
       }
@@ -1176,7 +1178,7 @@ exports.tests = [
         return SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';
       */},
       res: {
-        firefox52: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1190,6 +1192,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1203,6 +1206,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1216,6 +1220,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1229,6 +1234,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1242,6 +1248,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1255,6 +1262,7 @@ exports.tests = [
       res: {
         firefox48: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1268,6 +1276,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1281,6 +1290,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1294,6 +1304,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1307,6 +1318,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1320,6 +1332,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,
@@ -1333,6 +1346,7 @@ exports.tests = [
       res: {
         firefox46: firefox.nightly,
         firefox51: firefox.developer,
+        firefox52: true,
         chrome48: chrome.sharedmem,
         safaritp: true,
         webkit: true,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -4884,8 +4884,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="firefox49" data-tally="0">0/17</td>
 <td class="tally" data-browser="firefox50" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="firefox51" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="firefox52" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="firefox53" data-tally="0">0/17</td>
+<td class="tally unstable" data-browser="firefox52" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally unstable" data-browser="firefox53" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
 <td class="tally obsolete" data-browser="chrome46" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="chrome47" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="chrome48" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
@@ -4958,8 +4958,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5106,8 +5106,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5180,8 +5180,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No</td>
 <td class="no" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no obsolete" data-browser="chrome48">No</td>
@@ -5254,8 +5254,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="firefox49">No</td>
 <td class="no" data-browser="firefox50">No</td>
 <td class="no unstable" data-browser="firefox51">No</td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5328,8 +5328,8 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5402,8 +5402,8 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5476,8 +5476,8 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5550,8 +5550,8 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5624,8 +5624,8 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5698,8 +5698,8 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5772,8 +5772,8 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5846,8 +5846,8 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5920,8 +5920,8 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -5994,8 +5994,8 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -6068,8 +6068,8 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>
@@ -6142,8 +6142,8 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no unstable" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
-<td class="no unstable" data-browser="firefox53">No<a href="#firefox-developer-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="no obsolete" data-browser="chrome46">No</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
 <td class="no flagged obsolete" data-browser="chrome48">Flag<a href="#chrome-sharedmem-note"><sup>[10]</sup></a></td>


### PR DESCRIPTION
SharedArrayBuffer now enabled by default on Firefox 52:
https://bugzilla.mozilla.org/show_bug.cgi?id=1312446