### PR TITLE
Non-standard: better tests for SpiderMonkey's uneval/toSource

### DIFF
--- a/build.js
+++ b/build.js
@@ -397,6 +397,7 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler) {
   var $ = cheerio.load(skeleton);
   var head = $('table thead tr:last-child');
   var body = $('table tbody');
+  var isNonStandardTable = $('.non-standard table').length > 0;
   var footnoteIndex = {};
   var rowNum = 0;
   // rawBrowsers includes very obsolete browsers which mustn't be printed, but should
@@ -649,7 +650,7 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler) {
           var cell = resultCell(browserId, 'tally')
             .text((tally|0) + "/" + outOf)
             .attr('data-tally', grade);
-          if (grade > 0 && grade < 1 && !cell.hasClass('not-applicable')) {
+          if (grade > 0 && grade < 1 && !cell.hasClass('not-applicable') && !isNonStandardTable) {
             cell.attr('style','background-color:hsl(' + (120*grade|0) + ','
               +((86 - (grade*44))|0)  +'%,50%)');
           }

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -4,48 +4,150 @@ exports.skeleton_file = 'non-standard/skeleton.html';
 
 exports.tests = [
 {
-  name: 'uneval',
-  spec: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval',
-  exec: function () {
-    return typeof uneval == 'function';
-  },
-  res: {
-    ie7: false,
-    firefox2: true,
-    safari3: false,
-    chrome7: false,
-    opera10_10: false,
-    konq44: false,
-    besen: false,
-    rhino17: true,
-    phantom: false,
-  }
-},
-{
-  name: '"toSource" method',
-  spec: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource',
-  exec: function () {
-    return 'toSource' in Object.prototype
-        && Number   .prototype.hasOwnProperty('toSource')
-        && Boolean  .prototype.hasOwnProperty('toSource')
-        && String   .prototype.hasOwnProperty('toSource')
-        && Function .prototype.hasOwnProperty('toSource')
-        && Array    .prototype.hasOwnProperty('toSource')
-        && RegExp   .prototype.hasOwnProperty('toSource')
-        && Date     .prototype.hasOwnProperty('toSource')
-        && Error    .prototype.hasOwnProperty('toSource');
-  },
-  res: {
-    ie7: false,
-    firefox2: true,
-    safari3: false,
-    chrome7: false,
-    opera10_10: false,
-    konq44: false,
-    besen: true,
-    rhino17: true,
-    phantom: false
-  },
+  name: 'decompilation',
+  subtests: [
+    {
+      name: 'uneval, existence',
+      spec: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval',
+      exec: function () {/*
+        return typeof uneval == 'function';
+      */},
+      res: {
+        firefox2: true,
+        rhino17: true,
+      }
+    },
+    {
+      name: 'built-in "toSource" methods',
+      spec: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource',
+      exec: function () {/*
+        return 'toSource' in Object.prototype
+            && Number   .prototype.hasOwnProperty('toSource')
+            && Boolean  .prototype.hasOwnProperty('toSource')
+            && String   .prototype.hasOwnProperty('toSource')
+            && Function .prototype.hasOwnProperty('toSource')
+            && Array    .prototype.hasOwnProperty('toSource')
+            && RegExp   .prototype.hasOwnProperty('toSource')
+            && Date     .prototype.hasOwnProperty('toSource')
+            && Error    .prototype.hasOwnProperty('toSource');
+      */},
+      res: {
+        firefox2: true,
+        besen: true,
+        rhino17: true,
+      },
+    },
+    {
+      name: '"toSource" method as hook for uneval',
+      exec: function () {/*
+        return uneval({ toSource: function() { return "pwnd!" } }) === "pwnd!";
+      */} ,
+      res: {
+        firefox2: true,
+        rhino17: null,
+      },
+    },
+    {
+      name: 'eval(uneval(value)) is functionally equivalent to value',
+      exec: function () {/*
+
+        function isEquivalent(x, y) {
+
+            if (x == null || y == null)
+                return x === y;
+
+            if (typeof x !== typeof y)
+                return false;
+
+            switch (typeof x) {
+            case 'number':
+                return x === y && 1/x === 1/y || isNaN(x) && isNaN(y)
+            case 'boolean':
+            case 'string':
+            case 'symbol':
+                return x === y;
+            }
+
+            if ({}.toString.call(x) !== {}.toString.call(y))
+                return false;
+
+            switch ({}.toString.call(x)) {
+
+            case '[object Boolean]':
+            case '[object Number]':
+            case '[object String]':
+            case '[object Date]':
+                return x.valueOf() === y.valueOf();
+
+            case '[object Function]':
+            case '[object RegExp]':
+            case '[object Error]':
+                return x.toString() === y.toString();
+
+            case '[object Array]':
+                if (x.length !== y.length)
+                    return false;
+                for (var i = 0; i < x.length; i++) {
+                    if (!isEquivalent(x[i], y[i]))
+                        return false;
+                }
+                return true;
+
+            default:
+                for (var i in x) {
+                    if ({}.hasOwnProperty.call(x, i)) {
+                        if (!{}.hasOwnProperty.call(y, i) || !isEquivalent(x[i], y[i]))
+                            return false;
+                    }
+                }
+                for (var i in y) {
+                    if ({}.hasOwnProperty.call(y, i) && !{}.hasOwnProperty.call(x, i))
+                        return false;
+                }
+                return true;
+
+            }
+
+        }
+
+
+        var sample = [
+            undefined,
+            null,
+            false,
+            1,
+            NaN,
+            -0,
+            "foo",
+            typeof Symbol !== "undefined" && Symbol.iterator,
+            typeof Symbol !== "undefined" && Symbol.for && Symbol.for('bingo'),
+            Object(true),
+            Object(3),
+            Object("x"),
+            function x(y) { return 42 + y; },
+            new Date(1234567890123),
+            new Error("message"),
+            new EvalError("WTF"),
+            /rx/gim,
+            [ 3, undefined, "%&@", null, function() {} ],
+            { foo: "x", bar: [ 42, new Date ] }
+        ];
+
+        for (var k in sample) {
+            if (!isEquivalent(sample[k], eval(uneval(sample[k])))) {
+                return false;
+            }
+        }
+
+        return true;
+      */} ,
+      res: {
+        firefox2: true,
+        besen: null,
+        rhino17: null,
+      },
+    },
+  ]
 },
 {
   name: 'optional "scope" argument of "eval"',

--- a/master.css
+++ b/master.css
@@ -262,7 +262,8 @@ td[title] {
 }
 
 /* non-standard no */
-.non-standard .no {
+.non-standard .no,
+.non-standard [data-tally="0"] {
     background: #4444ac;
 }
 

--- a/master.js
+++ b/master.js
@@ -92,6 +92,7 @@ $(function() {
 
   window.__updateSupertest = function() {
     var tr = $(this);
+    var isNonStandardTable = $('.non-standard table').length > 0;
     var subtests = tr.nextUntil('tr:not(.subtest)');
     if (subtests.length === 0) {
       return;
@@ -103,7 +104,7 @@ $(function() {
       .find('td:first-child')
       .after(
       '<td class="tally current" data-tally="' + tally/subtests.length
-      + '" style="background-color:hsl(' + (120*grade|0) + ',' +((86 - (grade*44))|0)  +'%,50%)'
+      + (isNonStandardTable ? '' : '" style="background-color:hsl(' + (120*grade|0) + ',' +((86 - (grade*44))|0)  +'%,50%)')
       + '">' +
       tally + '/' + subtests.length + '</td><td></td>'
     );

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -170,12 +170,74 @@
         </thead>
         <tbody>
           <!-- TABLE BODY -->
-        <tr significance="1"><td id="test-uneval"><span><a class="anchor" href="#test-uneval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval</a></span><script data-source="function () {
+        <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
+<td class="tally obsolete" data-browser="konq44" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="konq49" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
+<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0">0/4</td>
+<td class="tally" data-browser="edge13" data-tally="0">0/4</td>
+<td class="tally" data-browser="edge14" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="edge15" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox43" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox49" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox51" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox52" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox53" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox54" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome52" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome53" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome54" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome55" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome56" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="chrome57" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="chrome58" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari5" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/4</td>
+<td class="tally" data-browser="safari9" data-tally="0">0/4</td>
+<td class="tally" data-browser="safari10" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="safari10_1" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="rhino17" data-tally="0.5">2/4</td>
+<td class="tally" data-browser="besen" data-tally="0.25">1/4</td>
+<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android43" data-tally="0">0/4</td>
+<td class="tally" data-browser="android44" data-tally="0">0/4</td>
+<td class="tally" data-browser="android50" data-tally="0">0/4</td>
+<td class="tally" data-browser="android51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios6" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios9" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios10" data-tally="0">0/4</td>
+</tr>
+<tr class="subtest" data-parent="decompilation" id="test-decompilation_uneval,_existence"><td><span><a class="anchor" href="#test-decompilation_uneval,_existence">&#xA7;</a>uneval, existence</span><script data-source="
 return typeof uneval == &apos;function&apos;;
-  }">test(
-function () {
-return typeof uneval == 'function';
-  }())</script></td>
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn typeof uneval == 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof uneval == 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
@@ -239,7 +301,7 @@ return typeof uneval == 'function';
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr significance="1"><td id="test-toSource_method"><span><a class="anchor" href="#test-toSource_method">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">&quot;toSource&quot; method</a></span><script data-source="function () {
+<tr class="subtest" data-parent="decompilation" id="test-decompilation_built-in_toSource_methods"><td><span><a class="anchor" href="#test-decompilation_built-in_toSource_methods">&#xA7;</a>built-in &quot;toSource&quot; methods</span><script data-source="
 return &apos;toSource&apos; in Object.prototype
     &amp;&amp; Number   .prototype.hasOwnProperty(&apos;toSource&apos;)
     &amp;&amp; Boolean  .prototype.hasOwnProperty(&apos;toSource&apos;)
@@ -249,18 +311,8 @@ return &apos;toSource&apos; in Object.prototype
     &amp;&amp; RegExp   .prototype.hasOwnProperty(&apos;toSource&apos;)
     &amp;&amp; Date     .prototype.hasOwnProperty(&apos;toSource&apos;)
     &amp;&amp; Error    .prototype.hasOwnProperty(&apos;toSource&apos;);
-  }">test(
-function () {
-return 'toSource' in Object.prototype
-    && Number   .prototype.hasOwnProperty('toSource')
-    && Boolean  .prototype.hasOwnProperty('toSource')
-    && String   .prototype.hasOwnProperty('toSource')
-    && Function .prototype.hasOwnProperty('toSource')
-    && Array    .prototype.hasOwnProperty('toSource')
-    && RegExp   .prototype.hasOwnProperty('toSource')
-    && Date     .prototype.hasOwnProperty('toSource')
-    && Error    .prototype.hasOwnProperty('toSource');
-  }())</script></td>
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nreturn 'toSource' in Object.prototype\n    && Number   .prototype.hasOwnProperty('toSource')\n    && Boolean  .prototype.hasOwnProperty('toSource')\n    && String   .prototype.hasOwnProperty('toSource')\n    && Function .prototype.hasOwnProperty('toSource')\n    && Array    .prototype.hasOwnProperty('toSource')\n    && RegExp   .prototype.hasOwnProperty('toSource')\n    && Date     .prototype.hasOwnProperty('toSource')\n    && Error    .prototype.hasOwnProperty('toSource');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nreturn 'toSource' in Object.prototype\n    && Number   .prototype.hasOwnProperty('toSource')\n    && Boolean  .prototype.hasOwnProperty('toSource')\n    && String   .prototype.hasOwnProperty('toSource')\n    && Function .prototype.hasOwnProperty('toSource')\n    && Array    .prototype.hasOwnProperty('toSource')\n    && RegExp   .prototype.hasOwnProperty('toSource')\n    && Date     .prototype.hasOwnProperty('toSource')\n    && Error    .prototype.hasOwnProperty('toSource');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
 <td class="no obsolete" data-browser="ie7">No</td>
@@ -324,10 +376,233 @@ return 'toSource' in Object.prototype
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
+<tr class="subtest" data-parent="decompilation" id="test-decompilation_toSource_method_as_hook_for_uneval"><td><span><a class="anchor" href="#test-decompilation_toSource_method_as_hook_for_uneval">&#xA7;</a>&quot;toSource&quot; method as hook for uneval</span><script data-source="
+return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;pwnd!&quot;;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");try{return Function("asyncTestPassed","\nreturn uneval({ toSource: function() { return \"pwnd!\" } }) === \"pwnd!\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("3");return Function("asyncTestPassed","'use strict';"+"\nreturn uneval({ toSource: function() { return \"pwnd!\" } }) === \"pwnd!\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no obsolete" data-browser="konq44">No</td>
+<td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
+<td class="no" data-browser="edge13">No</td>
+<td class="no" data-browser="edge14">No</td>
+<td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox43">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes obsolete" data-browser="firefox47">Yes</td>
+<td class="yes obsolete" data-browser="firefox48">Yes</td>
+<td class="yes obsolete" data-browser="firefox49">Yes</td>
+<td class="yes obsolete" data-browser="firefox50">Yes</td>
+<td class="yes" data-browser="firefox51">Yes</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
+<td class="yes unstable" data-browser="firefox54">Yes</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no obsolete" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome49">No</td>
+<td class="no obsolete" data-browser="chrome50">No</td>
+<td class="no obsolete" data-browser="chrome51">No</td>
+<td class="no obsolete" data-browser="chrome52">No</td>
+<td class="no obsolete" data-browser="chrome53">No</td>
+<td class="no obsolete" data-browser="chrome54">No</td>
+<td class="no obsolete" data-browser="chrome55">No</td>
+<td class="no" data-browser="chrome56">No</td>
+<td class="no unstable" data-browser="chrome57">No</td>
+<td class="no unstable" data-browser="chrome58">No</td>
+<td class="no obsolete" data-browser="safari5">No</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari7">No</td>
+<td class="no obsolete" data-browser="safari71_8">No</td>
+<td class="no" data-browser="safari9">No</td>
+<td class="no" data-browser="safari10">No</td>
+<td class="no unstable" data-browser="safari10_1">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
+<td class="no unstable" data-browser="webkit">No</td>
+<td class="unknown obsolete" data-browser="rhino17">?</td>
+<td class="no" data-browser="besen">No</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no obsolete" data-browser="android42">No</td>
+<td class="no obsolete" data-browser="android43">No</td>
+<td class="no" data-browser="android44">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
+<td class="no obsolete" data-browser="ios51">No</td>
+<td class="no obsolete" data-browser="ios6">No</td>
+<td class="no obsolete" data-browser="ios7">No</td>
+<td class="no obsolete" data-browser="ios8">No</td>
+<td class="no" data-browser="ios9">No</td>
+<td class="no" data-browser="ios10">No</td>
+</tr>
+<tr class="subtest" data-parent="decompilation" id="test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value"><td><span><a class="anchor" href="#test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value">&#xA7;</a>eval(uneval(value)) is functionally equivalent to value</span><script data-source="
+
+function isEquivalent(x, y) {
+
+    if (x == null || y == null)
+        return x === y;
+
+    if (typeof x !== typeof y)
+        return false;
+
+    switch (typeof x) {
+    case &apos;number&apos;:
+        return x === y &amp;&amp; 1/x === 1/y || isNaN(x) &amp;&amp; isNaN(y)
+    case &apos;boolean&apos;:
+    case &apos;string&apos;:
+    case &apos;symbol&apos;:
+        return x === y;
+    }
+
+    if ({}.toString.call(x) !== {}.toString.call(y))
+        return false;
+
+    switch ({}.toString.call(x)) {
+
+    case &apos;[object Boolean]&apos;:
+    case &apos;[object Number]&apos;:
+    case &apos;[object String]&apos;:
+    case &apos;[object Date]&apos;:
+        return x.valueOf() === y.valueOf();
+
+    case &apos;[object Function]&apos;:
+    case &apos;[object RegExp]&apos;:
+    case &apos;[object Error]&apos;:
+        return x.toString() === y.toString();
+
+    case &apos;[object Array]&apos;:
+        if (x.length !== y.length)
+            return false;
+        for (var i = 0; i &lt; x.length; i++) {
+            if (!isEquivalent(x[i], y[i]))
+                return false;
+        }
+        return true;
+
+    default:
+        for (var i in x) {
+            if ({}.hasOwnProperty.call(x, i)) {
+                if (!{}.hasOwnProperty.call(y, i) || !isEquivalent(x[i], y[i]))
+                    return false;
+            }
+        }
+        for (var i in y) {
+            if ({}.hasOwnProperty.call(y, i) &amp;&amp; !{}.hasOwnProperty.call(x, i))
+                return false;
+        }
+        return true;
+
+    }
+
+}
+
+
+var sample = [
+    undefined,
+    null,
+    false,
+    1,
+    NaN,
+    -0,
+    &quot;foo&quot;,
+    typeof Symbol !== &quot;undefined&quot; &amp;&amp; Symbol.iterator,
+    typeof Symbol !== &quot;undefined&quot; &amp;&amp; Symbol.for &amp;&amp; Symbol.for(&apos;bingo&apos;),
+    Object(true),
+    Object(3),
+    Object(&quot;x&quot;),
+    function x(y) { return 42 + y; },
+    new Date(1234567890123),
+    new Error(&quot;message&quot;),
+    new EvalError(&quot;WTF&quot;),
+    /rx/gim,
+    [ 3, undefined, &quot;%&amp;@&quot;, null, function() {} ],
+    { foo: &quot;x&quot;, bar: [ 42, new Date ] }
+];
+
+for (var k in sample) {
+    if (!isEquivalent(sample[k], eval(uneval(sample[k])))) {
+        return false;
+    }
+}
+
+return true;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\n\nfunction isEquivalent(x, y) {\n\n    if (x == null || y == null)\n        return x === y;\n\n    if (typeof x !== typeof y)\n        return false;\n\n    switch (typeof x) {\n    case 'number':\n        return x === y && 1/x === 1/y || isNaN(x) && isNaN(y)\n    case 'boolean':\n    case 'string':\n    case 'symbol':\n        return x === y;\n    }\n\n    if ({}.toString.call(x) !== {}.toString.call(y))\n        return false;\n\n    switch ({}.toString.call(x)) {\n\n    case '[object Boolean]':\n    case '[object Number]':\n    case '[object String]':\n    case '[object Date]':\n        return x.valueOf() === y.valueOf();\n\n    case '[object Function]':\n    case '[object RegExp]':\n    case '[object Error]':\n        return x.toString() === y.toString();\n\n    case '[object Array]':\n        if (x.length !== y.length)\n            return false;\n        for (var i = 0; i < x.length; i++) {\n            if (!isEquivalent(x[i], y[i]))\n                return false;\n        }\n        return true;\n\n    default:\n        for (var i in x) {\n            if ({}.hasOwnProperty.call(x, i)) {\n                if (!{}.hasOwnProperty.call(y, i) || !isEquivalent(x[i], y[i]))\n                    return false;\n            }\n        }\n        for (var i in y) {\n            if ({}.hasOwnProperty.call(y, i) && !{}.hasOwnProperty.call(x, i))\n                return false;\n        }\n        return true;\n\n    }\n\n}\n\n\nvar sample = [\n    undefined,\n    null,\n    false,\n    1,\n    NaN,\n    -0,\n    \"foo\",\n    typeof Symbol !== \"undefined\" && Symbol.iterator,\n    typeof Symbol !== \"undefined\" && Symbol.for && Symbol.for('bingo'),\n    Object(true),\n    Object(3),\n    Object(\"x\"),\n    function x(y) { return 42 + y; },\n    new Date(1234567890123),\n    new Error(\"message\"),\n    new EvalError(\"WTF\"),\n    /rx/gim,\n    [ 3, undefined, \"%&@\", null, function() {} ],\n    { foo: \"x\", bar: [ 42, new Date ] }\n];\n\nfor (var k in sample) {\n    if (!isEquivalent(sample[k], eval(uneval(sample[k])))) {\n        return false;\n    }\n}\n\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\n\nfunction isEquivalent(x, y) {\n\n    if (x == null || y == null)\n        return x === y;\n\n    if (typeof x !== typeof y)\n        return false;\n\n    switch (typeof x) {\n    case 'number':\n        return x === y && 1/x === 1/y || isNaN(x) && isNaN(y)\n    case 'boolean':\n    case 'string':\n    case 'symbol':\n        return x === y;\n    }\n\n    if ({}.toString.call(x) !== {}.toString.call(y))\n        return false;\n\n    switch ({}.toString.call(x)) {\n\n    case '[object Boolean]':\n    case '[object Number]':\n    case '[object String]':\n    case '[object Date]':\n        return x.valueOf() === y.valueOf();\n\n    case '[object Function]':\n    case '[object RegExp]':\n    case '[object Error]':\n        return x.toString() === y.toString();\n\n    case '[object Array]':\n        if (x.length !== y.length)\n            return false;\n        for (var i = 0; i < x.length; i++) {\n            if (!isEquivalent(x[i], y[i]))\n                return false;\n        }\n        return true;\n\n    default:\n        for (var i in x) {\n            if ({}.hasOwnProperty.call(x, i)) {\n                if (!{}.hasOwnProperty.call(y, i) || !isEquivalent(x[i], y[i]))\n                    return false;\n            }\n        }\n        for (var i in y) {\n            if ({}.hasOwnProperty.call(y, i) && !{}.hasOwnProperty.call(x, i))\n                return false;\n        }\n        return true;\n\n    }\n\n}\n\n\nvar sample = [\n    undefined,\n    null,\n    false,\n    1,\n    NaN,\n    -0,\n    \"foo\",\n    typeof Symbol !== \"undefined\" && Symbol.iterator,\n    typeof Symbol !== \"undefined\" && Symbol.for && Symbol.for('bingo'),\n    Object(true),\n    Object(3),\n    Object(\"x\"),\n    function x(y) { return 42 + y; },\n    new Date(1234567890123),\n    new Error(\"message\"),\n    new EvalError(\"WTF\"),\n    /rx/gim,\n    [ 3, undefined, \"%&@\", null, function() {} ],\n    { foo: \"x\", bar: [ 42, new Date ] }\n];\n\nfor (var k in sample) {\n    if (!isEquivalent(sample[k], eval(uneval(sample[k])))) {\n        return false;\n    }\n}\n\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no obsolete" data-browser="konq44">No</td>
+<td class="no obsolete" data-browser="konq49">No</td>
+<td class="no obsolete" data-browser="ie7">No</td>
+<td class="no obsolete" data-browser="ie8">No</td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no obsolete" data-browser="edge12">No</td>
+<td class="no" data-browser="edge13">No</td>
+<td class="no" data-browser="edge14">No</td>
+<td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox43">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes obsolete" data-browser="firefox47">Yes</td>
+<td class="yes obsolete" data-browser="firefox48">Yes</td>
+<td class="yes obsolete" data-browser="firefox49">Yes</td>
+<td class="yes obsolete" data-browser="firefox50">Yes</td>
+<td class="yes" data-browser="firefox51">Yes</td>
+<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
+<td class="yes unstable" data-browser="firefox54">Yes</td>
+<td class="no obsolete" data-browser="chrome47">No</td>
+<td class="no obsolete" data-browser="chrome48">No</td>
+<td class="no obsolete" data-browser="chrome49">No</td>
+<td class="no obsolete" data-browser="chrome50">No</td>
+<td class="no obsolete" data-browser="chrome51">No</td>
+<td class="no obsolete" data-browser="chrome52">No</td>
+<td class="no obsolete" data-browser="chrome53">No</td>
+<td class="no obsolete" data-browser="chrome54">No</td>
+<td class="no obsolete" data-browser="chrome55">No</td>
+<td class="no" data-browser="chrome56">No</td>
+<td class="no unstable" data-browser="chrome57">No</td>
+<td class="no unstable" data-browser="chrome58">No</td>
+<td class="no obsolete" data-browser="safari5">No</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari7">No</td>
+<td class="no obsolete" data-browser="safari71_8">No</td>
+<td class="no" data-browser="safari9">No</td>
+<td class="no" data-browser="safari10">No</td>
+<td class="no unstable" data-browser="safari10_1">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
+<td class="no unstable" data-browser="webkit">No</td>
+<td class="unknown obsolete" data-browser="rhino17">?</td>
+<td class="unknown" data-browser="besen">?</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no obsolete" data-browser="android42">No</td>
+<td class="no obsolete" data-browser="android43">No</td>
+<td class="no" data-browser="android44">No</td>
+<td class="no" data-browser="android50">No</td>
+<td class="no" data-browser="android51">No</td>
+<td class="no obsolete" data-browser="ios51">No</td>
+<td class="no obsolete" data-browser="ios6">No</td>
+<td class="no obsolete" data-browser="ios7">No</td>
+<td class="no obsolete" data-browser="ios8">No</td>
+<td class="no" data-browser="ios9">No</td>
+<td class="no" data-browser="ios10">No</td>
+</tr>
 <tr significance="1"><td id="test-optional_scope_argument_of_eval"><span><a class="anchor" href="#test-optional_scope_argument_of_eval">&#xA7;</a>optional &quot;scope&quot; argument of &quot;eval&quot;</span><script data-source="
 var x = 1;
 return eval(&quot;x&quot;, { x: 2 }) === 2;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nvar x = 1;\nreturn eval(\"x\", { x: 2 }) === 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nvar x = 1;\nreturn eval(\"x\", { x: 2 }) === 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nvar x = 1;\nreturn eval(\"x\", { x: 2 }) === 2;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nvar x = 1;\nreturn eval(\"x\", { x: 2 }) === 2;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -685,7 +960,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
 return new C instanceof C;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nclass C extends null {}\nreturn new C instanceof C;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nclass C extends null {}\nreturn new C instanceof C;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nclass C extends null {}\nreturn new C instanceof C;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nclass C extends null {}\nreturn new C instanceof C;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1113,7 +1388,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var a = [i * 2 for (i in obj) if (i !== &quot;foo&quot;)];
 return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar a = [i * 2 for (i in obj) if (i !== \"foo\")];\nreturn a instanceof Array && a[0] === 4 && a[1] === 8;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1180,7 +1455,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 </tr>
 <tr significance="0.5"><td id="test-Array_comprehensions_(ES_draft_style)"><span><a class="anchor" href="#test-Array_comprehensions_(ES_draft_style)">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions (ES draft style)</a></span><script data-source="
 return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nreturn [for (a of [1, 2, 3]) a * a] + '' === '1,4,9';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1247,7 +1522,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 </tr>
 <tr significance="1"><td id="test-Expression_closures"><span><a class="anchor" href="#test-Expression_closures">&#xA7;</a>Expression closures</span><script data-source="
 return (function(x)x)(1) === 1;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nreturn (function(x)x)(1) === 1;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1314,7 +1589,7 @@ return (function(x)x)(1) === 1;
 </tr>
 <tr significance="1"><td id="test-ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#test-ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a></span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof <foo/> === \"xml\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1385,7 +1660,7 @@ for each (var item in {a: &quot;foo&quot;, b: &quot;bar&quot;, c: &quot;baz&quot
   str += item;
 }
 return str === &quot;foobarbaz&quot;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nvar str = '';\nfor each (var item in {a: \"foo\", b: \"bar\", c: \"baz\"}) {\n  str += item;\n}\nreturn str === \"foobarbaz\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1453,7 +1728,7 @@ return str === &quot;foobarbaz&quot;;
 <tr significance="1"><td id="test-Sharp_variables"><span><a class="anchor" href="#test-Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a></span><script data-source="
 var arr = #1=[1, #1#, 3];
 return arr[1] === arr;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nvar arr = #1=[1, #1#, 3];\nreturn arr[1] === arr;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1836,7 +2111,7 @@ global.test((function () {
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
 var g = (i * 2 for (i in obj) if (i !== &quot;foo&quot;));
 return g.next() === 4 &amp;&amp; g.next() === 8;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { 2: true, \"foo\": true, 4: true };\nvar g = (i * 2 for (i in obj) if (i !== \"foo\"));\nreturn g.next() === 4 && g.next() === 8;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -1910,7 +2185,7 @@ passed    &amp;= item.value === 6 &amp;&amp; item.done === false;
 item = iterator.next();
 passed    &amp;= item.value === undefined &amp;&amp; item.done === true;
 return passed;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = (for (a of [1,2]) a + 4);\nvar item = iterator.next();\nvar passed = item.value === 5 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === 6 && item.done === false;\nitem = iterator.next();\npassed    &= item.value === undefined && item.done === true;\nreturn passed;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -2210,7 +2485,7 @@ return true;
 </tr>
 <tr significance="1"><td id="test-Callable_RegExp"><span><a class="anchor" href="#test-Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn /\\\\w/(\"x\")[0] === \"x\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>
@@ -2277,7 +2552,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 </tr>
 <tr significance="1"><td id="test-RegExp_named_groups"><span><a class="anchor" href="#test-RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?P<name>a)(?P=name)/.test(\"aa\");\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="konq44">?</td>
 <td class="yes obsolete" data-browser="konq49">Yes</td>
@@ -2945,7 +3220,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 </tr>
 <tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a></span><script data-source="
 return typeof Object.observe == &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Object.observe == 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.observe == 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn typeof Object.observe == 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.observe == 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="konq44">No</td>
 <td class="no obsolete" data-browser="konq49">No</td>


### PR DESCRIPTION
more precise tests for "uneval", "toSource", and interaction between
the two.

The proposed tests enlighten the semantics of this not-well-documented feature.

Tested as supported since at least Firefox 2.