### PR TITLE
Add Node 7.6 results, fix the labels for node65 & node76 entries

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -925,6 +925,7 @@ exports.tests = [
       node6: true,
       node65: true,
       node7: true,
+      node76: true,
     }
   }, {
     name: '"global" global property has correct property descriptor',
@@ -961,6 +962,7 @@ exports.tests = [
       node6: false,
       node65: false,
       node7: false,
+      node76: false,
     }
   }]
 },

--- a/environments.json
+++ b/environments.json
@@ -1443,7 +1443,7 @@
   "node65": {
     "full": "Node.js",
     "family": "Node.js",
-    "short": "Node 6.5",
+    "short": "Node &gt;=6.5 &lt;7",
     "platformtype": "engine",
     "note_id": "harmony-flag",
     "equals": "chrome51",
@@ -1458,10 +1458,25 @@
   "node7": {
     "full": "Node.js",
     "family": "Node.js",
-    "short": "Node 7",
+    "short": "Node 7.0-7.5",
     "platformtype": "engine",
     "note_id": "harmony-flag",
     "equals": "chrome54",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl"
+    ]
+  },
+  "node76": {
+    "full": "Node.js",
+    "family": "Node.js",
+    "short": "Node &gt;=7.6 &lt;8",
+    "platformtype": "engine",
+    "note_id": "harmony-flag",
+    "equals": "chrome55",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -158,8 +158,9 @@
 <th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node 6.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7 engine" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node76 engine" data-browser="node76"><a href="#node76" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform android40 mobile obsolete" data-browser="android40"><a href="#android40" class="browser-name"><abbr title="Android Browser">AN 4.0</abbr></a></th>
 <th class="platform android41 mobile obsolete" data-browser="android41"><a href="#android41" class="browser-name"><abbr title="Android Browser">AN 4.1</abbr></a></th>
 <th class="platform android42 mobile obsolete" data-browser="android42"><a href="#android42" class="browser-name"><abbr title="Android Browser">AN 4.2</abbr></a></th>
@@ -178,7 +179,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="70">2016 features</td>
+      <tr class="category"><td colspan="71">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -235,7 +236,8 @@
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/3</td>
 <td class="tally" data-browser="node65" data-tally="0" data-flagged-tally="1">0/3</td>
-<td class="tally" data-browser="node7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">3/3</td>
+<td class="tally" data-browser="node76" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/3</td>
@@ -308,7 +310,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -381,7 +384,8 @@ var a = 2; a **= 3; return a === 8;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -459,7 +463,8 @@ return true;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -529,7 +534,8 @@ return true;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">3/3</td>
 <td class="tally" data-browser="node65" data-tally="1">3/3</td>
-<td class="tally" data-browser="node7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">3/3</td>
+<td class="tally" data-browser="node76" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/3</td>
@@ -606,7 +612,8 @@ return [1, 2, 3].includes(1)
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -701,7 +708,8 @@ return 24;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -779,7 +787,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -794,7 +803,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="category"><td colspan="70">2016 misc</td>
+<tr class="category"><td colspan="71">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a><a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -861,7 +870,8 @@ return true;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -947,7 +957,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1025,7 +1036,8 @@ return true;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1099,7 +1111,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1174,7 +1187,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1254,7 +1268,8 @@ return passed;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1336,7 +1351,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1351,7 +1367,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="category"><td colspan="70">2017 features</td>
+<tr class="category"><td colspan="71">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1408,7 +1424,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/4</td>
 <td class="tally" data-browser="node65" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally" data-browser="node7" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">4/4</td>
+<td class="tally" data-browser="node76" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -1484,7 +1501,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1564,7 +1582,8 @@ return Array.isArray(e)
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1645,7 +1664,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1721,7 +1741,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1791,7 +1812,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/2</td>
 <td class="tally" data-browser="node65" data-tally="0">0/2</td>
-<td class="tally" data-browser="node7" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally" data-browser="node76" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -1867,7 +1889,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="no flagged" data-browser="node76">Flag</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1943,7 +1966,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="no flagged" data-browser="node76">Flag</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2013,7 +2037,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/2</td>
 <td class="tally" data-browser="node65" data-tally="0">0/2</td>
-<td class="tally" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally" data-browser="node76" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -2086,7 +2111,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2159,7 +2185,8 @@ return Math.min(1,2,3,) === 1;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2229,7 +2256,8 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/15</td>
 <td class="tally" data-browser="node65" data-tally="0">0/15</td>
-<td class="tally" data-browser="node7" data-tally="0" data-flagged-tally="0.2">0/15</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0" data-flagged-tally="0.2">0/15</td>
+<td class="tally" data-browser="node76" data-tally="1">15/15</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/15</td>
@@ -2313,7 +2341,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2397,7 +2426,8 @@ p.catch(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2471,7 +2501,8 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2545,7 +2576,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2625,7 +2657,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2707,7 +2740,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2781,7 +2815,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2860,7 +2895,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2934,7 +2970,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3018,7 +3055,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3102,7 +3140,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3184,7 +3223,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3260,7 +3300,8 @@ return passed;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3333,7 +3374,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3415,7 +3457,8 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="unknown" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3485,7 +3528,8 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
 <td class="tally" data-browser="node65" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
-<td class="tally" data-browser="node7" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
+<td class="tally" data-browser="node76" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/17</td>
@@ -3558,7 +3602,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3631,7 +3676,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3704,7 +3750,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3777,7 +3824,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3850,7 +3898,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3923,7 +3972,8 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3996,7 +4046,8 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4069,7 +4120,8 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4142,7 +4194,8 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4215,7 +4268,8 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4288,7 +4342,8 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4361,7 +4416,8 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4434,7 +4490,8 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4507,7 +4564,8 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4580,7 +4638,8 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4653,7 +4712,8 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4726,7 +4786,8 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-sharedmem-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4741,7 +4802,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="70">2017 misc</td>
+<tr class="category"><td colspan="71">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4806,7 +4867,8 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4882,7 +4944,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4958,7 +5021,8 @@ return (function(){
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4973,7 +5037,7 @@ return (function(){
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="70">2017 annex b</td>
+<tr class="category"><td colspan="71">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -5030,7 +5094,8 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
-<td class="tally not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -5108,7 +5173,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5187,7 +5253,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5266,7 +5333,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5344,7 +5412,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5423,7 +5492,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5502,7 +5572,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5582,7 +5653,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5662,7 +5734,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5743,7 +5816,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5821,7 +5895,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5898,7 +5973,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5978,7 +6054,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -6058,7 +6135,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -6139,7 +6217,8 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -6217,7 +6296,8 @@ return true;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6294,7 +6374,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6364,7 +6445,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">2/4</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">2/4</td>
+<td class="tally not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.5">2/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -6441,7 +6523,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6518,7 +6601,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6600,7 +6684,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6682,7 +6767,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6756,7 +6842,8 @@ return i === 0;
 <td class="yes obsolete not-applicable" data-browser="node5" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="node65" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="node76" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -170,8 +170,9 @@
 <th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node 6.5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
-<th class="platform node7 engine" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
+<th class="platform node76 engine" data-browser="node76"><a href="#node76" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[3]</sup></a></th>
 <th class="platform android40 mobile obsolete" data-browser="android40"><a href="#android40" class="browser-name"><abbr title="Android Browser">AN 4.0</abbr></a></th>
 <th class="platform android41 mobile obsolete" data-browser="android41"><a href="#android41" class="browser-name"><abbr title="Android Browser">AN 4.1</abbr></a></th>
 <th class="platform android42 mobile obsolete" data-browser="android42"><a href="#android42" class="browser-name"><abbr title="Android Browser">AN 4.2</abbr></a></th>
@@ -241,7 +242,8 @@
 <td class="tally obsolete" data-browser="node5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">2/2</td>
 <td class="tally" data-browser="node65" data-tally="1">2/2</td>
-<td class="tally" data-browser="node7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">2/2</td>
+<td class="tally" data-browser="node76" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -310,7 +312,8 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -379,7 +382,8 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -445,7 +449,8 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="node5" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">5/5</td>
 <td class="tally" data-browser="node65" data-tally="1">5/5</td>
-<td class="tally" data-browser="node7" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">5/5</td>
+<td class="tally" data-browser="node76" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
@@ -514,7 +519,8 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -583,7 +589,8 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -652,7 +659,8 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -726,7 +734,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -823,7 +832,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -889,7 +899,8 @@ try {
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/1</td>
@@ -958,7 +969,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1024,7 +1036,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/1</td>
@@ -1093,7 +1106,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1159,7 +1173,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">6/6</td>
 <td class="tally" data-browser="node65" data-tally="1">6/6</td>
-<td class="tally" data-browser="node7" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">6/6</td>
+<td class="tally" data-browser="node76" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
@@ -1228,7 +1243,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1297,7 +1313,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1366,7 +1383,8 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1435,7 +1453,8 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1509,7 +1528,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1606,7 +1626,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1672,7 +1693,8 @@ try {
 <td class="tally obsolete" data-browser="node5" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">7/7</td>
 <td class="tally" data-browser="node65" data-tally="1">7/7</td>
-<td class="tally" data-browser="node7" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">7/7</td>
+<td class="tally" data-browser="node76" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/7</td>
@@ -1741,7 +1763,8 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1810,7 +1833,8 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1879,7 +1903,8 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1953,7 +1978,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2050,7 +2076,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2120,7 +2147,8 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="unknown obsolete" data-browser="android40">?</td>
 <td class="unknown obsolete" data-browser="android41">?</td>
 <td class="unknown obsolete" data-browser="android42">?</td>
@@ -2197,7 +2225,8 @@ try {
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2263,7 +2292,8 @@ try {
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -2332,7 +2362,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -2398,7 +2429,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -2467,7 +2499,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -2533,7 +2566,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -2602,7 +2636,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -2668,7 +2703,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -2737,7 +2773,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -2803,7 +2840,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -2872,7 +2910,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -2938,7 +2977,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -3007,7 +3047,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -3073,7 +3114,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node6" data-tally="1">1/1</td>
 <td class="tally" data-browser="node65" data-tally="1">1/1</td>
-<td class="tally" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">1/1</td>
+<td class="tally" data-browser="node76" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android40" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android41" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android42" data-tally="1">1/1</td>
@@ -3142,7 +3184,8 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -166,8 +166,9 @@
 <th class="platform node4 engine" data-browser="node4"><a href="#node4" class="browser-name"><abbr title="Node.js">Node 4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node5 engine obsolete" data-browser="node5"><a href="#node5" class="browser-name"><abbr title="Node.js">Node 5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform node6 engine obsolete" data-browser="node6"><a href="#node6" class="browser-name"><abbr title="Node.js">Node 6.0-6.4</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node 6.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
-<th class="platform node7 engine" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node65 engine" data-browser="node65"><a href="#node65" class="browser-name"><abbr title="Node.js">Node &gt;=6.5 &lt;7</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node7 engine obsolete" data-browser="node7"><a href="#node7" class="browser-name"><abbr title="Node.js">Node 7.0-7.5</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
+<th class="platform node76 engine" data-browser="node76"><a href="#node76" class="browser-name"><abbr title="Node.js">Node &gt;=7.6 &lt;8</abbr></a><a href="#harmony-flag-note"><sup>[4]</sup></a></th>
 <th class="platform android40 mobile obsolete" data-browser="android40"><a href="#android40" class="browser-name"><abbr title="Android Browser">AN 4.0</abbr></a></th>
 <th class="platform android41 mobile obsolete" data-browser="android41"><a href="#android41" class="browser-name"><abbr title="Android Browser">AN 4.1</abbr></a></th>
 <th class="platform android42 mobile obsolete" data-browser="android42"><a href="#android42" class="browser-name"><abbr title="Android Browser">AN 4.2</abbr></a></th>
@@ -186,7 +187,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="73">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
@@ -245,7 +246,8 @@
 <td class="tally obsolete" data-browser="node5" data-tally="0" data-flagged-tally="1">0/57</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0" data-flagged-tally="1">0/57</td>
 <td class="tally" data-browser="node65" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally" data-browser="node7" data-tally="0" data-flagged-tally="1">0/57</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0" data-flagged-tally="1">0/57</td>
+<td class="tally" data-browser="node76" data-tally="0" data-flagged-tally="1">0/57</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/57</td>
@@ -320,7 +322,8 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -395,7 +398,8 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -470,7 +474,8 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -545,7 +550,8 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -620,7 +626,8 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -695,7 +702,8 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -770,7 +778,8 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -845,7 +854,8 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -920,7 +930,8 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -995,7 +1006,8 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1070,7 +1082,8 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1145,7 +1158,8 @@ return typeof SIMD.Float32x4.abs === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1220,7 +1234,8 @@ return typeof SIMD.Float32x4.add === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1295,7 +1310,8 @@ return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1370,7 +1386,8 @@ return typeof SIMD.Bool16x8.and === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1445,7 +1462,8 @@ return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1520,7 +1538,8 @@ return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1595,7 +1614,8 @@ return typeof SIMD.Float32x4.check === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1670,7 +1690,8 @@ return typeof SIMD.Float32x4.equal === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1745,7 +1766,8 @@ return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1820,7 +1842,8 @@ return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1895,7 +1918,8 @@ return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -1970,7 +1994,8 @@ return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2045,7 +2070,8 @@ return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2120,7 +2146,8 @@ return typeof SIMD.Float32x4.mul === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2195,7 +2222,8 @@ return typeof SIMD.Float32x4.div === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2270,7 +2298,8 @@ return typeof SIMD.Float32x4.load === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2345,7 +2374,8 @@ return typeof SIMD.Float32x4.load1 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2420,7 +2450,8 @@ return typeof SIMD.Float32x4.load2 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2495,7 +2526,8 @@ return typeof SIMD.Float32x4.load3 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2570,7 +2602,8 @@ return typeof SIMD.Float32x4.max === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2645,7 +2678,8 @@ return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2720,7 +2754,8 @@ return typeof SIMD.Float32x4.min === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2795,7 +2830,8 @@ return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2870,7 +2906,8 @@ return typeof SIMD.Float32x4.neg === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -2945,7 +2982,8 @@ return typeof SIMD.Bool16x8.not === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3020,7 +3058,8 @@ return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3095,7 +3134,8 @@ return typeof SIMD.Bool16x8.or === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3170,7 +3210,8 @@ return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3245,7 +3286,8 @@ return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3320,7 +3362,8 @@ return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3395,7 +3438,8 @@ return typeof SIMD.Float32x4.select === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3470,7 +3514,8 @@ return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3545,7 +3590,8 @@ return typeof SIMD.Int32x4.shiftRightByScalar === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3620,7 +3666,8 @@ return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3695,7 +3742,8 @@ return typeof SIMD.Float32x4.splat === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3770,7 +3818,8 @@ return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3845,7 +3894,8 @@ return typeof SIMD.Float32x4.store === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3920,7 +3970,8 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -3995,7 +4046,8 @@ return typeof SIMD.Float32x4.store2 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4070,7 +4122,8 @@ return typeof SIMD.Float32x4.store3 === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4145,7 +4198,8 @@ return typeof SIMD.Float32x4.sub === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4220,7 +4274,8 @@ return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4295,7 +4350,8 @@ return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4370,7 +4426,8 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4447,7 +4504,8 @@ return &apos;Float32x4,Int32x4,Int8x16,Uint32x4,Uint16x8,Uint8x16&apos;.split(&a
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4524,7 +4582,8 @@ return &apos;Float32x4,Uint32x4&apos;.split(&apos;,&apos;).every(function(type){
 <td class="no flagged obsolete" data-browser="node5">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged obsolete" data-browser="node6">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no flagged" data-browser="node65">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no flagged" data-browser="node76">Flag<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4600,7 +4659,8 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4677,7 +4737,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4749,7 +4810,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="node5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="node65" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="node76" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -4826,7 +4888,8 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4908,7 +4971,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -4980,7 +5044,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/2</td>
 <td class="tally" data-browser="node65" data-tally="0">0/2</td>
-<td class="tally" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally" data-browser="node76" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -5062,7 +5127,8 @@ iterator.next().then(function(step){
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5154,7 +5220,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5169,7 +5236,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Draft (stage 2)</td>
+<tr class="category"><td colspan="73">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-function.sent"><span><a class="anchor" href="#test-function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
 var result;
@@ -5237,7 +5304,8 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5320,7 +5388,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5399,7 +5468,8 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5471,7 +5541,8 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="tally obsolete" data-browser="node5" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="node65" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="node7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally" data-browser="node76" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5546,7 +5617,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5621,7 +5693,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="node5">Yes</td>
 <td class="yes obsolete" data-browser="node6">Yes</td>
 <td class="yes" data-browser="node65">Yes</td>
-<td class="yes" data-browser="node7">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
 <td class="yes obsolete" data-browser="android40">Yes</td>
 <td class="yes obsolete" data-browser="android41">Yes</td>
 <td class="yes obsolete" data-browser="android42">Yes</td>
@@ -5696,7 +5769,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5771,7 +5845,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5853,7 +5928,8 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -5928,7 +6004,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no flagged obsolete" data-browser="node6">Flag</td>
 <td class="no flagged" data-browser="node65">Flag</td>
-<td class="no flagged" data-browser="node7">Flag</td>
+<td class="no flagged obsolete" data-browser="node7">Flag</td>
+<td class="no flagged" data-browser="node76">Flag</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6000,7 +6077,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/2</td>
 <td class="tally" data-browser="node65" data-tally="0">0/2</td>
-<td class="tally" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/2</td>
+<td class="tally" data-browser="node76" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/2</td>
@@ -6084,7 +6162,8 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6165,7 +6244,8 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6180,7 +6260,7 @@ return new C().x() === 42;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Proposal (stage 1)</td>
+<tr class="category"><td colspan="73">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions">do expressions</a></span><script data-source="
 return do {
@@ -6245,7 +6325,8 @@ return do {
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6323,7 +6404,8 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6395,7 +6477,8 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/4</td>
 <td class="tally" data-browser="node65" data-tally="0">0/4</td>
-<td class="tally" data-browser="node7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/4</td>
+<td class="tally" data-browser="node76" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
@@ -6470,7 +6553,8 @@ return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6545,7 +6629,8 @@ return Math.isubh(0, 4, 1, 1) === 2;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6620,7 +6705,8 @@ return Math.imulh(0xffffffff, 7) === -1;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6695,7 +6781,8 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6767,7 +6854,8 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="tally obsolete" data-browser="node5" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node6" data-tally="0">0/8</td>
 <td class="tally" data-browser="node65" data-tally="0">0/8</td>
-<td class="tally" data-browser="node7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/8</td>
+<td class="tally" data-browser="node76" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android40" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android41" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android42" data-tally="0">0/8</td>
@@ -6842,7 +6930,8 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6917,7 +7006,8 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -6992,7 +7082,8 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7077,7 +7168,8 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7153,7 +7245,8 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7229,7 +7322,8 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7304,7 +7398,8 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7379,7 +7474,8 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7464,7 +7560,8 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7543,7 +7640,8 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7619,7 +7717,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="node5">No</td>
 <td class="no obsolete" data-browser="node6">No</td>
 <td class="no" data-browser="node65">No</td>
-<td class="no" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no" data-browser="node76">No</td>
 <td class="no obsolete" data-browser="android40">No</td>
 <td class="no obsolete" data-browser="android41">No</td>
 <td class="no obsolete" data-browser="android42">No</td>
@@ -7634,7 +7733,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Strawman (stage 0)</td>
+<tr class="category"><td colspan="73">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7693,7 +7792,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7770,7 +7870,8 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7846,7 +7947,8 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7921,7 +8023,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7993,7 +8096,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -8069,7 +8173,8 @@ return f();
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8144,7 +8249,8 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8224,7 +8330,8 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8310,7 +8417,8 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8392,7 +8500,8 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8464,7 +8573,8 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8541,7 +8651,8 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8618,7 +8729,8 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8690,7 +8802,8 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -8765,7 +8878,8 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8840,7 +8954,8 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8915,7 +9030,8 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8990,7 +9106,8 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9065,7 +9182,8 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9140,7 +9258,8 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9215,7 +9334,8 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9293,7 +9413,8 @@ passed = true;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9365,7 +9486,8 @@ passed = true;
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -9446,7 +9568,8 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9534,7 +9657,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9549,7 +9673,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="72">Pre-strawman</td>
+<tr class="category"><td colspan="73">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -9608,7 +9732,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -9683,7 +9808,8 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9758,7 +9884,8 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9833,7 +9960,8 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9908,7 +10036,8 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9983,7 +10112,8 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10058,7 +10188,8 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10133,7 +10264,8 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10208,7 +10340,8 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10283,7 +10416,8 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="node5" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="node6" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="node65" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="node7" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="node76" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android40" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android41" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="android42" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
1. Add Node 7.6 results
2. Fix the labels for `node65` & `node76` entries.

Re 2: I originally added Node 6.5 results in https://github.com/kangax/compat-table/pull/913 with some doubts on what to put in their short names. @chicoxyzzy suggested just `Node 6.5`; it was correct back then but now it's only confusing - current latest Node 6 is `6.10.0` and Node 6 is an LTS starting from `6.9.0`. "Node 6.5" seems like it doesn't apply to them. On the other hand, writing `Node 6.5-6.10` will get obsolete once `6.11.0` comes out. So I opted for the semver-like `Node >=6.5 <7` & `Node >=7.6 <8`. Let me know what you think.