### PR TITLE
SharedArrayBuffer and Atomics disabled on FFox 52

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -782,7 +782,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -795,7 +795,8 @@ exports.tests = [
          return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
          */},
         res: {
-          firefox52: true,
+          firefox52: firefox.developer,
+          firefox53: true,
           safari10_1: true,
           safaritp: true,
           webkit: true,
@@ -809,7 +810,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           webkit: true,
         }
@@ -820,7 +821,8 @@ exports.tests = [
          return typeof SharedArrayBuffer.prototype.slice === 'function';
          */},
         res: {
-          firefox52: true,
+          firefox52: firefox.developer,
+          firefox53: true,
           safari10_1: true,
           safaritp: true,
           webkit: true,
@@ -832,7 +834,8 @@ exports.tests = [
          return SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';
          */},
         res: {
-          firefox52: true,
+          firefox52: firefox.developer,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -847,7 +850,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -862,7 +865,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -877,7 +880,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -892,7 +895,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -907,7 +910,7 @@ exports.tests = [
         res: {
           firefox48: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -922,7 +925,7 @@ exports.tests = [
         res: {
           firefox48: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -937,7 +940,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -952,7 +955,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -967,7 +970,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -982,7 +985,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -997,7 +1000,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,
@@ -1012,7 +1015,7 @@ exports.tests = [
         res: {
           firefox46: firefox.nightly,
           firefox51: firefox.developer,
-          firefox52: true,
+          firefox53: true,
           chrome48: chrome.sharedmem,
           safari10_1: true,
           safaritp: true,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -3453,7 +3453,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="firefox49" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox50" data-tally="0">0/17</td>
 <td class="tally" data-browser="firefox51" data-tally="0">0/17</td>
-<td class="tally unstable" data-browser="firefox52" data-tally="1">17/17</td>
+<td class="tally unstable" data-browser="firefox52" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="firefox53" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="firefox54" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome47" data-tally="0">0/17</td>
@@ -3526,7 +3526,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3599,7 +3599,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="firefox49">No</td>
 <td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no" data-browser="firefox51">No</td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3672,7 +3672,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3745,7 +3745,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No</td>
 <td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no" data-browser="firefox51">No</td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3818,7 +3818,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="firefox49">No</td>
 <td class="no obsolete" data-browser="firefox50">No</td>
 <td class="no" data-browser="firefox51">No</td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3891,7 +3891,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -3964,7 +3964,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4037,7 +4037,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4110,7 +4110,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4183,7 +4183,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4256,7 +4256,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4329,7 +4329,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4402,7 +4402,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4475,7 +4475,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4548,7 +4548,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4621,7 +4621,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>
@@ -4694,7 +4694,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox49">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox50">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox51">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox52">Yes</td>
+<td class="no unstable" data-browser="firefox52">No<a href="#firefox-developer-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox53">Yes</td>
 <td class="yes unstable" data-browser="firefox54">Yes</td>
 <td class="no obsolete" data-browser="chrome47">No</td>


### PR DESCRIPTION
Both SharedArrayBuffer and Atomics were disabled on FFox 52 (beta).  More details on https://bugzilla.mozilla.org/show_bug.cgi?id=1342095