### PR TITLE
Correct Node 4 is based on v8 4.5

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -1400,7 +1400,7 @@
     "full": "Node.js",
     "family": "Node.js",
     "short": "Node 4",
-    "equals": "chrome44",
+    "equals": "chrome45",
     "platformtype": "engine",
     "note_id": "harmony-flag",
     "obsolete": false,


### PR DESCRIPTION
I encountered the wrong data through babel-preset-env, when checking for a bug there.
Node 4 as of the first version 4.0.0 is based on v8 4.5 and not 4.4.
https://nodejs.org/en/download/releases/

I tested all the tests that flipped from no to yes/strict and they indeed work on node 4.
