### PR TITLE
ios8 is based on safari8 not 7

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -1558,7 +1558,7 @@
     "family": "iOS Safari",
     "short": "iOS 8",
     "platformtype": "mobile",
-    "equals": "safari7",
+    "equals": "safari71_8",
     "obsolete": true
   },
   "ios9": {

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -3085,7 +3085,7 @@ try {
 <td class="no obsolete" data-browser="ios51">No</td>
 <td class="no obsolete" data-browser="ios6">No</td>
 <td class="no obsolete" data-browser="ios7">No</td>
-<td class="no obsolete" data-browser="ios8">No</td>
+<td class="yes obsolete" data-browser="ios8">Yes</td>
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>


### PR DESCRIPTION
I'm not 100% sure about this, but it looks to me that ios8 should be based on safari8.
It could be that ios8 shipped with safari7 initially and later updated to 8 but i doubt so.

I tested destructuring on browserstack on a real ios 8 device, and it seems to work, despite compat-table currently saying it shouldn't:
<img width="1273" alt="bildschirmfoto 2017-03-02 um 22 55 32" src="https://cloud.githubusercontent.com/assets/231804/23529101/8bbb1dc6-ff9c-11e6-9d03-b9eaa15631ff.png">


Also the tests on safari on ios8 look exactly the same as for safari7.1/8 and not like safari 7:
<img width="1112" alt="bildschirmfoto 2017-03-02 um 23 37 20" src="https://cloud.githubusercontent.com/assets/231804/23530275/4ef3f0de-ffa1-11e6-8548-49aa1c68288e.png">
