### PR TITLE
Firefox 52 released, updating expiration data

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -537,7 +537,7 @@
     "short": "FF 38<br> ESR",
     "release": "2015-05-12",
     "retire": "2016-06-07",
-    "obsolete": "very"
+    "obsolete": true
   },
   "firefox39": {
     "full": "Firefox",
@@ -592,7 +592,7 @@
     "family": "SpiderMonkey",
     "short": "FF 45 ESR",
     "release": "2016-03-08",
-    "retire": "2017-06-13",
+    "retire": "2017-08-08",
     "obsolete": false
   },
   "firefox46": {
@@ -646,7 +646,7 @@
   "firefox52": {
     "full": "Firefox",
     "family": "SpiderMonkey",
-    "short": "FF 52 ESR",
+    "short": "FF 52",
     "release": "2017-03-07",
     "obsolete": false
   },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -117,6 +117,7 @@
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge15 desktop unstable" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox44 desktop obsolete" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox46 desktop obsolete" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox">FF 46</abbr></a></th>
@@ -125,7 +126,7 @@
 <th class="platform firefox49 desktop obsolete" data-browser="firefox49"><a href="#firefox49" class="browser-name"><abbr title="Firefox">FF 49</abbr></a></th>
 <th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox">FF 51</abbr></a></th>
-<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52 ESR</abbr></a></th>
+<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52</abbr></a></th>
 <th class="platform firefox53 desktop unstable" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox">FF 53 Beta</abbr></a></th>
 <th class="platform firefox54 desktop unstable" data-browser="firefox54"><a href="#firefox54" class="browser-name"><abbr title="Firefox">FF 54 Aurora</abbr></a></th>
 <th class="platform firefox55 desktop unstable" data-browser="firefox55"><a href="#firefox55" class="browser-name"><abbr title="Firefox">FF 55 Nightly</abbr></a></th>
@@ -178,7 +179,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="70">2016 features</td>
+      <tr class="category"><td colspan="71">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -193,6 +194,7 @@
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.6666666666666666">0/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/3</td>
@@ -266,6 +268,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -339,6 +342,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -417,6 +421,7 @@ return true;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -487,6 +492,7 @@ return true;
 <td class="tally" data-browser="edge13" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">3/3</td>
@@ -564,6 +570,7 @@ return [1, 2, 3].includes(1)
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -659,6 +666,7 @@ return 24;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -737,6 +745,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -794,7 +803,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="category"><td colspan="70">2016 misc</td>
+<tr class="category"><td colspan="71">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a><a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -819,6 +828,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -905,6 +915,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -983,6 +994,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1057,6 +1069,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1132,6 +1145,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1212,6 +1226,7 @@ return passed;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1294,6 +1309,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1351,7 +1367,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="category"><td colspan="70">2017 features</td>
+<tr class="category"><td colspan="71">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1366,6 +1382,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="edge13" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/4</td>
@@ -1442,6 +1459,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1522,6 +1540,7 @@ return Array.isArray(e)
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -1603,6 +1622,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1679,6 +1699,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1749,6 +1770,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/2</td>
@@ -1825,6 +1847,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1901,6 +1924,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1971,6 +1995,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/2</td>
@@ -2044,6 +2069,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2117,6 +2143,7 @@ return Math.min(1,2,3,) === 1;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2187,6 +2214,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.7333333333333333">0/15</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="0.9333333333333333">0/15</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0" data-flagged-tally="1">0/15</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/15</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/15</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/15</td>
@@ -2271,6 +2299,7 @@ p.then(function(result) {
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2355,6 +2384,7 @@ p.catch(function(result) {
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2429,6 +2459,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2503,6 +2534,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2583,6 +2615,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2665,6 +2698,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2739,6 +2773,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2818,6 +2853,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2892,6 +2928,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2976,6 +3013,7 @@ p.then(function(result) {
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3060,6 +3098,7 @@ p.then(function(result) {
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3142,6 +3181,7 @@ p.then(function(result) {
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3218,6 +3258,7 @@ return passed;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3291,6 +3332,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3373,6 +3415,7 @@ p.then(function(result) {
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3443,6 +3486,7 @@ p.then(function(result) {
 <td class="tally" data-browser="edge13" data-tally="0">0/17</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/17</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/17</td>
@@ -3516,6 +3560,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3589,6 +3634,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3662,6 +3708,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3735,6 +3782,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3808,6 +3856,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3881,6 +3930,7 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -3954,6 +4004,7 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4027,6 +4078,7 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4100,6 +4152,7 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4173,6 +4226,7 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4246,6 +4300,7 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4319,6 +4374,7 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4392,6 +4448,7 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4465,6 +4522,7 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4538,6 +4596,7 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4611,6 +4670,7 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4684,6 +4744,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No<a href="#firefox-nightly-note"><sup>[5]</sup></a></td>
@@ -4741,7 +4802,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="70">2017 misc</td>
+<tr class="category"><td colspan="71">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -4764,6 +4825,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4840,6 +4902,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4916,6 +4979,7 @@ return (function(){
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4973,7 +5037,7 @@ return (function(){
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="70">2017 annex b</td>
+<tr class="category"><td colspan="71">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -4988,6 +5052,7 @@ return (function(){
 <td class="tally" data-browser="edge13" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally" data-browser="edge14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="firefox45" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
@@ -5066,6 +5131,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5145,6 +5211,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5224,6 +5291,7 @@ return true;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5302,6 +5370,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5381,6 +5450,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5460,6 +5530,7 @@ return true;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5540,6 +5611,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5620,6 +5692,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5701,6 +5774,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5779,6 +5853,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5856,6 +5931,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5936,6 +6012,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6016,6 +6093,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6097,6 +6175,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6175,6 +6254,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6252,6 +6332,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6322,6 +6403,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge14" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -6399,6 +6481,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6476,6 +6559,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -6558,6 +6642,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6640,6 +6725,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6714,6 +6800,7 @@ return i === 0;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -125,6 +125,7 @@
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge15 desktop unstable" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox44 desktop obsolete" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox46 desktop obsolete" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox">FF 46</abbr></a></th>
@@ -133,7 +134,7 @@
 <th class="platform firefox49 desktop obsolete" data-browser="firefox49"><a href="#firefox49" class="browser-name"><abbr title="Firefox">FF 49</abbr></a></th>
 <th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox">FF 51</abbr></a></th>
-<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52 ESR</abbr></a></th>
+<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52</abbr></a></th>
 <th class="platform firefox53 desktop unstable" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox">FF 53 Beta</abbr></a></th>
 <th class="platform firefox54 desktop unstable" data-browser="firefox54"><a href="#firefox54" class="browser-name"><abbr title="Firefox">FF 54 Aurora</abbr></a></th>
 <th class="platform firefox55 desktop unstable" data-browser="firefox55"><a href="#firefox55" class="browser-name"><abbr title="Firefox">FF 55 Nightly</abbr></a></th>
@@ -201,6 +202,7 @@
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">5/5</td>
@@ -276,6 +278,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -353,6 +356,7 @@ return value === 1;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -428,6 +432,7 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -503,6 +508,7 @@ return [1,].length === 1;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -578,6 +584,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -634,7 +641,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr><th colspan="73" class="separator"></th>
+<tr><th colspan="74" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -652,6 +659,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="edge13" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge14" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox45" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">13/13</td>
@@ -729,6 +737,7 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -806,6 +815,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -883,6 +893,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -960,6 +971,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1037,6 +1049,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1114,6 +1127,7 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1191,6 +1205,7 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1268,6 +1283,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1345,6 +1361,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1422,6 +1439,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1499,6 +1517,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1576,6 +1595,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1653,6 +1673,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1725,6 +1746,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="edge13" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge14" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">12/12</td>
 <td class="tally" data-browser="firefox45" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">12/12</td>
@@ -1802,6 +1824,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1879,6 +1902,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1956,6 +1980,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2033,6 +2058,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2110,6 +2136,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2187,6 +2214,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2264,6 +2292,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2341,6 +2370,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2418,6 +2448,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2495,6 +2526,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2612,6 +2644,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2699,6 +2732,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2771,6 +2805,7 @@ try {
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">2/2</td>
@@ -2848,6 +2883,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2925,6 +2961,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2997,6 +3034,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">3/3</td>
@@ -3074,6 +3112,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3151,6 +3190,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3236,6 +3276,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3313,6 +3354,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3390,6 +3432,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3446,7 +3489,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr><th colspan="73" class="separator"></th>
+<tr><th colspan="74" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -3464,6 +3507,7 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="edge13" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge14" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox45" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">3/3</td>
@@ -3542,6 +3586,7 @@ return result;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3620,6 +3665,7 @@ return result;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3698,6 +3744,7 @@ return result;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3770,6 +3817,7 @@ return result;
 <td class="tally" data-browser="edge13" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge14" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox45" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">8/8</td>
@@ -3847,6 +3895,7 @@ return (function(a,b) { return a === 1 && b === 2; }).apply({}, {0:1, 1:2, lengt
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3924,6 +3973,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3999,6 +4049,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4074,6 +4125,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4150,6 +4202,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4227,6 +4280,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4310,6 +4364,7 @@ return result;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4391,6 +4446,7 @@ catch(e) {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4463,6 +4519,7 @@ catch(e) {
 <td class="tally" data-browser="edge13" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge14" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally" data-browser="firefox45" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">19/19</td>
@@ -4543,6 +4600,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4619,6 +4677,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes" data-browser="edge13">Yes<a href="#strict-mode-ie10-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="edge14">Yes<a href="#strict-mode-ie10-note"><sup>[9]</sup></a></td>
 <td class="yes unstable" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4697,6 +4756,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4789,6 +4849,7 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4867,6 +4928,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -4943,6 +5005,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5023,6 +5086,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5103,6 +5167,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5185,6 +5250,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5264,6 +5330,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5341,6 +5408,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5419,6 +5487,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5501,6 +5570,7 @@ return (function(x){
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5577,6 +5647,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5653,6 +5724,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5729,6 +5801,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5805,6 +5878,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5881,6 +5955,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5957,6 +6032,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -128,6 +128,7 @@
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge15 desktop unstable" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox44 desktop obsolete" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox46 desktop obsolete" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox">FF 46</abbr></a></th>
@@ -136,7 +137,7 @@
 <th class="platform firefox49 desktop obsolete" data-browser="firefox49"><a href="#firefox49" class="browser-name"><abbr title="Firefox">FF 49</abbr></a></th>
 <th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox">FF 51</abbr></a></th>
-<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52 ESR</abbr></a></th>
+<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52</abbr></a></th>
 <th class="platform firefox53 desktop unstable" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox">FF 53 Beta</abbr></a></th>
 <th class="platform firefox54 desktop unstable" data-browser="firefox54"><a href="#firefox54" class="browser-name"><abbr title="Firefox">FF 54 Aurora</abbr></a></th>
 <th class="platform firefox55 desktop unstable" data-browser="firefox55"><a href="#firefox55" class="browser-name"><abbr title="Firefox">FF 55 Nightly</abbr></a></th>
@@ -198,6 +199,7 @@
 <td class="tally" data-browser="edge13" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge14" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox45" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">2/2</td>
@@ -267,6 +269,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -336,6 +339,7 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -402,6 +406,7 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="edge13" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge14" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">5/5</td>
@@ -471,6 +476,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -540,6 +546,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -609,6 +616,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -683,6 +691,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -780,6 +789,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -846,6 +856,7 @@ try {
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -915,6 +926,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -981,6 +993,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -1050,6 +1063,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1116,6 +1130,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge14" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">6/6</td>
@@ -1185,6 +1200,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1254,6 +1270,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1323,6 +1340,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1392,6 +1410,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1466,6 +1485,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1563,6 +1583,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1629,6 +1650,7 @@ try {
 <td class="tally" data-browser="edge13" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="edge14" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally" data-browser="firefox45" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
@@ -1698,6 +1720,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1767,6 +1790,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1836,6 +1860,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1910,6 +1935,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2007,6 +2033,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2077,6 +2104,7 @@ return tz !== undefined &amp;&amp; tz.length &gt; 0;
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2154,6 +2182,7 @@ try {
 <td class="no" data-browser="edge13">No</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2220,6 +2249,7 @@ try {
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2289,6 +2319,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2355,6 +2386,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2424,6 +2456,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2490,6 +2523,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2559,6 +2593,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2625,6 +2660,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2694,6 +2730,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2760,6 +2797,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2829,6 +2867,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2895,6 +2934,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -2964,6 +3004,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3030,6 +3071,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="edge13" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge14" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge15" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox45" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">1/1</td>
@@ -3099,6 +3141,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -124,6 +124,7 @@
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
 <th class="platform edge15 desktop unstable" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[3]</sup></a></th>
+<th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox44 desktop obsolete" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox46 desktop obsolete" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox">FF 46</abbr></a></th>
@@ -132,7 +133,7 @@
 <th class="platform firefox49 desktop obsolete" data-browser="firefox49"><a href="#firefox49" class="browser-name"><abbr title="Firefox">FF 49</abbr></a></th>
 <th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox">FF 51</abbr></a></th>
-<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52 ESR</abbr></a></th>
+<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52</abbr></a></th>
 <th class="platform firefox53 desktop unstable" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox">FF 53 Beta</abbr></a></th>
 <th class="platform firefox54 desktop unstable" data-browser="firefox54"><a href="#firefox54" class="browser-name"><abbr title="Firefox">FF 54 Aurora</abbr></a></th>
 <th class="platform firefox55 desktop unstable" data-browser="firefox55"><a href="#firefox55" class="browser-name"><abbr title="Firefox">FF 55 Nightly</abbr></a></th>
@@ -186,7 +187,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="72">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="73">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-SIMD_(Single_Instruction,_Multiple_Data)"><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/">SIMD (Single Instruction, Multiple Data)</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/57</td>
@@ -202,6 +203,7 @@
 <td class="tally" data-browser="edge13" data-tally="0" data-flagged-tally="0.5263157894736842">0/57</td>
 <td class="tally" data-browser="edge14" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/57</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/57</td>
@@ -277,6 +279,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -352,6 +355,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -427,6 +431,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -502,6 +507,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -577,6 +583,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -652,6 +659,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -727,6 +735,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -802,6 +811,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -877,6 +887,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -952,6 +963,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1027,6 +1039,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1102,6 +1115,7 @@ return typeof SIMD.Float32x4.abs === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1177,6 +1191,7 @@ return typeof SIMD.Float32x4.add === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1252,6 +1267,7 @@ return typeof SIMD.Int16x8.addSaturate === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1327,6 +1343,7 @@ return typeof SIMD.Bool16x8.and === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1402,6 +1419,7 @@ return typeof SIMD.Bool32x4.anyTrue === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1477,6 +1495,7 @@ return typeof SIMD.Bool32x4.allTrue === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1552,6 +1571,7 @@ return typeof SIMD.Float32x4.check === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1627,6 +1647,7 @@ return typeof SIMD.Float32x4.equal === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1702,6 +1723,7 @@ return typeof SIMD.Float32x4.extractLane === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1777,6 +1799,7 @@ return typeof SIMD.Float32x4.greaterThan === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1852,6 +1875,7 @@ return typeof SIMD.Float32x4.greaterThanOrEqual === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1927,6 +1951,7 @@ return typeof SIMD.Float32x4.lessThan === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2002,6 +2027,7 @@ return typeof SIMD.Float32x4.lessThanOrEqual === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2077,6 +2103,7 @@ return typeof SIMD.Float32x4.mul === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2152,6 +2179,7 @@ return typeof SIMD.Float32x4.div === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2227,6 +2255,7 @@ return typeof SIMD.Float32x4.load === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2302,6 +2331,7 @@ return typeof SIMD.Float32x4.load1 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2377,6 +2407,7 @@ return typeof SIMD.Float32x4.load2 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2452,6 +2483,7 @@ return typeof SIMD.Float32x4.load3 === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2527,6 +2559,7 @@ return typeof SIMD.Float32x4.max === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2602,6 +2635,7 @@ return typeof SIMD.Float32x4.maxNum === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2677,6 +2711,7 @@ return typeof SIMD.Float32x4.min === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2752,6 +2787,7 @@ return typeof SIMD.Float32x4.minNum === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2827,6 +2863,7 @@ return typeof SIMD.Float32x4.neg === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2902,6 +2939,7 @@ return typeof SIMD.Bool16x8.not === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2977,6 +3015,7 @@ return typeof SIMD.Float32x4.notEqual === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3052,6 +3091,7 @@ return typeof SIMD.Bool16x8.or === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3127,6 +3167,7 @@ return typeof SIMD.Float32x4.reciprocalApproximation === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3202,6 +3243,7 @@ return typeof SIMD.Float32x4.reciprocalSqrtApproximation === &apos;function&apos
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3277,6 +3319,7 @@ return typeof SIMD.Float32x4.replaceLane === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3352,6 +3395,7 @@ return typeof SIMD.Float32x4.select === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3427,6 +3471,7 @@ return typeof SIMD.Int32x4.shiftLeftByScalar === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3502,6 +3547,7 @@ return typeof SIMD.Int32x4.shiftRightByScalar === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3577,6 +3623,7 @@ return typeof SIMD.Float32x4.shuffle === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3652,6 +3699,7 @@ return typeof SIMD.Float32x4.splat === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3727,6 +3775,7 @@ return typeof SIMD.Float32x4.sqrt === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3802,6 +3851,7 @@ return typeof SIMD.Float32x4.store === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3877,6 +3927,7 @@ return typeof SIMD.Float32x4.store1 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3952,6 +4003,7 @@ return typeof SIMD.Float32x4.store2 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4027,6 +4079,7 @@ return typeof SIMD.Float32x4.store3 === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4102,6 +4155,7 @@ return typeof SIMD.Float32x4.sub === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4177,6 +4231,7 @@ return typeof SIMD.Int16x8.subSaturate === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4252,6 +4307,7 @@ return typeof SIMD.Float32x4.swizzle === &apos;function&apos;;
 <td class="no flagged" data-browser="edge13">Flag</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4327,6 +4383,7 @@ return typeof SIMD.Bool16x8.xor === &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4404,6 +4461,7 @@ return &apos;Float32x4,Int32x4,Int8x16,Uint32x4,Uint16x8,Uint8x16&apos;.split(&a
 <td class="no" data-browser="edge13">No</td>
 <td class="no flagged" data-browser="edge14">Flag</td>
 <td class="no flagged unstable" data-browser="edge15">Flag</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4481,6 +4539,7 @@ return &apos;Float32x4,Uint32x4&apos;.split(&apos;,&apos;).every(function(type){
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4557,6 +4616,7 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4634,6 +4694,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4706,6 +4767,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/2</td>
@@ -4783,6 +4845,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4865,6 +4928,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -4937,6 +5001,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/2</td>
@@ -5019,6 +5084,7 @@ iterator.next().then(function(step){
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5111,6 +5177,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5169,7 +5236,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Draft (stage 2)</td>
+<tr class="category"><td colspan="73">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-function.sent"><span><a class="anchor" href="#test-function.sent">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">function.sent</a></span><script data-source="
 var result;
@@ -5194,6 +5261,7 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5277,6 +5345,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5356,6 +5425,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5428,6 +5498,7 @@ return new C().x + C.y === &apos;xy&apos;;
 <td class="tally" data-browser="edge13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5503,6 +5574,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5578,6 +5650,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -5653,6 +5726,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5728,6 +5802,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5810,6 +5885,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5885,6 +5961,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -5961,6 +6038,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6033,6 +6111,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="edge13" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/2</td>
@@ -6117,6 +6196,7 @@ return new C(42).x() === 42;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6198,6 +6278,7 @@ return new C().x() === 42;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6256,7 +6337,7 @@ return new C().x() === 42;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Proposal (stage 1)</td>
+<tr class="category"><td colspan="73">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions">do expressions</a></span><script data-source="
 return do {
@@ -6278,6 +6359,7 @@ return do {
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6356,6 +6438,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6428,6 +6511,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="edge13" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/4</td>
@@ -6503,6 +6587,7 @@ return Math.iaddh(0xffffffff, 1, 1, 1) === 3;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6578,6 +6663,7 @@ return Math.isubh(0, 4, 1, 1) === 2;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6653,6 +6739,7 @@ return Math.imulh(0xffffffff, 7) === -1;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6728,6 +6815,7 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6800,6 +6888,7 @@ return Math.umulh(0xffffffff, 7) === 6;
 <td class="tally" data-browser="edge13" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox45" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="0">0/8</td>
@@ -6875,6 +6964,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -6950,6 +7040,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7025,6 +7116,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7110,6 +7202,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7186,6 +7279,7 @@ return &apos;forEach&apos; in Observable.prototype &amp;&amp; o.forEach(function
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7262,6 +7356,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7337,6 +7432,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7412,6 +7508,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7497,6 +7594,7 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7576,6 +7674,7 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7652,6 +7751,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -7710,7 +7810,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr class="category"><td colspan="72">Strawman (stage 0)</td>
+<tr class="category"><td colspan="73">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7726,6 +7826,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -7803,6 +7904,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7879,6 +7981,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7954,6 +8057,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8026,6 +8130,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -8102,6 +8207,7 @@ return f();
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8177,6 +8283,7 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8257,6 +8364,7 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8343,6 +8451,7 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8425,6 +8534,7 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8497,6 +8607,7 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -8574,6 +8685,7 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8651,6 +8763,7 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8723,6 +8836,7 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -8798,6 +8912,7 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8873,6 +8988,7 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8948,6 +9064,7 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9023,6 +9140,7 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9098,6 +9216,7 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9173,6 +9292,7 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9248,6 +9368,7 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9326,6 +9447,7 @@ passed = true;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9398,6 +9520,7 @@ passed = true;
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -9479,6 +9602,7 @@ return (function f(n){
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9567,6 +9691,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9625,7 +9750,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="ios9" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="ios10" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="72">Pre-strawman</td>
+<tr class="category"><td colspan="73">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -9641,6 +9766,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -9716,6 +9842,7 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9791,6 +9918,7 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9866,6 +9994,7 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9941,6 +10070,7 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10016,6 +10146,7 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10091,6 +10222,7 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10166,6 +10298,7 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10241,6 +10374,7 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10316,6 +10450,7 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no not-applicable" data-browser="edge13" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge14" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="edge15" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="firefox38" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox44" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox45" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox46" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -114,6 +114,7 @@
 <th class="platform edge13 desktop" data-browser="edge13"><a href="#edge13" class="browser-name"><abbr title="Microsoft Edge">Edge 13</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge14 desktop" data-browser="edge14"><a href="#edge14" class="browser-name"><abbr title="Microsoft Edge">Edge 14</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
 <th class="platform edge15 desktop unstable" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge">Edge 15</abbr></a><a href="#edge-experimental-flag-note"><sup>[2]</sup></a></th>
+<th class="platform firefox38 desktop obsolete" data-browser="firefox38"><a href="#firefox38" class="browser-name"><abbr title="Firefox">FF 38<br> ESR</abbr></a></th>
 <th class="platform firefox44 desktop obsolete" data-browser="firefox44"><a href="#firefox44" class="browser-name"><abbr title="Firefox">FF 44</abbr></a></th>
 <th class="platform firefox45 desktop" data-browser="firefox45"><a href="#firefox45" class="browser-name"><abbr title="Firefox">FF 45 ESR</abbr></a></th>
 <th class="platform firefox46 desktop obsolete" data-browser="firefox46"><a href="#firefox46" class="browser-name"><abbr title="Firefox">FF 46</abbr></a></th>
@@ -122,7 +123,7 @@
 <th class="platform firefox49 desktop obsolete" data-browser="firefox49"><a href="#firefox49" class="browser-name"><abbr title="Firefox">FF 49</abbr></a></th>
 <th class="platform firefox50 desktop obsolete" data-browser="firefox50"><a href="#firefox50" class="browser-name"><abbr title="Firefox">FF 50</abbr></a></th>
 <th class="platform firefox51 desktop obsolete" data-browser="firefox51"><a href="#firefox51" class="browser-name"><abbr title="Firefox">FF 51</abbr></a></th>
-<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52 ESR</abbr></a></th>
+<th class="platform firefox52 desktop" data-browser="firefox52"><a href="#firefox52" class="browser-name"><abbr title="Firefox">FF 52</abbr></a></th>
 <th class="platform firefox53 desktop unstable" data-browser="firefox53"><a href="#firefox53" class="browser-name"><abbr title="Firefox">FF 53 Beta</abbr></a></th>
 <th class="platform firefox54 desktop unstable" data-browser="firefox54"><a href="#firefox54" class="browser-name"><abbr title="Firefox">FF 54 Aurora</abbr></a></th>
 <th class="platform firefox55 desktop unstable" data-browser="firefox55"><a href="#firefox55" class="browser-name"><abbr title="Firefox">FF 55 Nightly</abbr></a></th>
@@ -181,6 +182,7 @@
 <td class="tally" data-browser="edge13" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge14" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="edge15" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox44" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox46" data-tally="1">4/4</td>
@@ -247,6 +249,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -321,6 +324,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -387,6 +391,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -542,6 +547,7 @@ return true;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -609,6 +615,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -660,7 +667,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -679,6 +686,7 @@ return 'caller' in function(){};
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -751,6 +759,7 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -825,6 +834,7 @@ return f(1, 'boo');
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -893,6 +903,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -944,7 +955,7 @@ return typeof Function.prototype.isGenerator == 'function';
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -962,6 +973,7 @@ return new C instanceof C;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1032,6 +1044,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1100,6 +1113,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1178,6 +1192,7 @@ return executed;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1246,6 +1261,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1314,6 +1330,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1365,7 +1382,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -1384,6 +1401,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1450,6 +1468,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1516,6 +1535,7 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1582,6 +1602,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1652,6 +1673,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1719,6 +1741,7 @@ return arr[1] === arr;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -1770,7 +1793,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a></span><script data-source="function () {
 /* global Iterator */
@@ -1819,6 +1842,7 @@ catch(e) {
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -1925,6 +1949,7 @@ catch(e) {
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2030,6 +2055,7 @@ global.test((function () {
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2098,6 +2124,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2171,6 +2198,7 @@ return passed;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2222,7 +2250,7 @@ return passed;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -2255,6 +2283,7 @@ try {
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2327,6 +2356,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2401,6 +2431,7 @@ return true;
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2467,6 +2498,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2533,6 +2565,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2584,7 +2617,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;);
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.trimLeft"><span><a class="anchor" href="#test-String.prototype.trimLeft">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft">String.prototype.trimLeft</a></span><script data-source="function () { return typeof String.prototype.trimLeft === &apos;function&apos; }">test(
 function () { return typeof String.prototype.trimLeft === 'function' }())</script></td>
@@ -2599,6 +2632,7 @@ function () { return typeof String.prototype.trimLeft === 'function' }())</scrip
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2663,6 +2697,7 @@ function () { return typeof String.prototype.trimRight === 'function' }())</scri
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2727,6 +2762,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2791,6 +2827,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2842,7 +2879,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a></span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -2857,6 +2894,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -2931,6 +2969,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -2982,7 +3021,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios9">Yes</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a></span><script data-source="function () { return typeof Object.prototype.watch == &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch == 'function' }())</script></td>
@@ -2997,6 +3036,7 @@ function () { return typeof Object.prototype.watch == 'function' }())</script></
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3061,6 +3101,7 @@ function () { return typeof Object.prototype.unwatch == 'function' }())</script>
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3125,6 +3166,7 @@ function () { return typeof Object.prototype.eval == 'function' }())</script></t
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3191,6 +3233,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3242,7 +3285,7 @@ return typeof Object.observe == &apos;function&apos;;
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a></span><script data-source="function () {
 try {
@@ -3269,6 +3312,7 @@ try {
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3337,6 +3381,7 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3405,6 +3450,7 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3473,6 +3519,7 @@ return 'fileName' in new Error();
 <td class="no" data-browser="edge13">No</td>
 <td class="no" data-browser="edge14">No</td>
 <td class="no unstable" data-browser="edge15">No</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
 <td class="yes obsolete" data-browser="firefox44">Yes</td>
 <td class="yes" data-browser="firefox45">Yes</td>
 <td class="yes obsolete" data-browser="firefox46">Yes</td>
@@ -3541,6 +3588,7 @@ return 'description' in new Error();
 <td class="yes" data-browser="edge13">Yes</td>
 <td class="yes" data-browser="edge14">Yes</td>
 <td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="no obsolete" data-browser="firefox38">No</td>
 <td class="no obsolete" data-browser="firefox44">No</td>
 <td class="no" data-browser="firefox45">No</td>
 <td class="no obsolete" data-browser="firefox46">No</td>
@@ -3592,7 +3640,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios9">No</td>
 <td class="no" data-browser="ios10">No</td>
 </tr>
-<tr><th colspan="64" class="separator"></th>
+<tr><th colspan="65" class="separator"></th>
 </tr>
 </tbody>
       </table>


### PR DESCRIPTION
Firefox 52 was released today this was already pushed.  This patch fixes some retirement dates and removes "ESR" from the current version to avoid confusion.