### PR TITLE
Disabling esintl tests that became invalid with the updated spec

### DIFF
--- a/data-esintl.js
+++ b/data-esintl.js
@@ -85,7 +85,7 @@ exports.tests = [
         node012: true,
       },
     },
-// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+// The spec was updated making this test invalid.  It was disabled until it can be fixed
 //    {
 //      name: 'calling Collator with Collator instance throws error',
 //      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
@@ -252,7 +252,7 @@ exports.tests = [
         node012: true,
       },
     },
-// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+// The spec was updated making this test invalid.  It was disabled until it can be fixed
 //    {
 //      name: 'calling NumberFormat with NumberFormat instance throws error',
 //      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
@@ -365,7 +365,7 @@ exports.tests = [
         node012: true,
       },
     },
-// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+// The spec was updated making this test invalid.  It was disabled until it can be fixed
 //    {
 //      name: 'calling DateTimeFormat with DateTimeFormat instance throws error',
 //      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -85,25 +85,26 @@ exports.tests = [
         node012: true,
       },
     },
-    {
-      name: 'calling Collator with Collator instance throws error',
-      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
-      exec: function(){/*
-        try {
-          Intl.Collator.call(Intl.Collator());
-          return false;
-        } catch(e) {
-          return e instanceof TypeError;
-        }
-      */},
-      res: {
-        ie11: true,
-        edge12: true,
-        firefox29: true,
-        chrome24: true,
-        node012: true,
-      },
-    },
+// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+//    {
+//      name: 'calling Collator with Collator instance throws error',
+//      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
+//      exec: function(){/*
+//        try {
+//          Intl.Collator.call(Intl.Collator());
+//          return false;
+//        } catch(e) {
+//          return e instanceof TypeError;
+//        }
+//      */},
+//      res: {
+//        ie11: true,
+//        edge12: true,
+//        firefox29: true,
+//        chrome24: true,
+//        node012: true,
+//      },
+//    },
     {
       name: 'accepts valid language tags',
       exec: function(){/*
@@ -251,25 +252,26 @@ exports.tests = [
         node012: true,
       },
     },
-    {
-      name: 'calling NumberFormat with NumberFormat instance throws error',
-      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
-      exec: function(){/*
-        try {
-          Intl.NumberFormat.call(Intl.NumberFormat());
-          return false;
-        } catch(e) {
-          return e instanceof TypeError;
-        }
-      */},
-      res: {
-        ie11: true,
-        edge12: true,
-        firefox29: true,
-        chrome24: true,
-        node012: true,
-      },
-    },
+// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+//    {
+//      name: 'calling NumberFormat with NumberFormat instance throws error',
+//      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
+//      exec: function(){/*
+//        try {
+//          Intl.NumberFormat.call(Intl.NumberFormat());
+//          return false;
+//        } catch(e) {
+//          return e instanceof TypeError;
+//        }
+//      */},
+//      res: {
+//        ie11: true,
+//        edge12: true,
+//        firefox29: true,
+//        chrome24: true,
+//        node012: true,
+//      },
+//    },
     {
       name: 'accepts valid language tags',
       exec: function(){/*
@@ -363,25 +365,26 @@ exports.tests = [
         node012: true,
       },
     },
-    {
-      name: 'calling DateTimeFormat with DateTimeFormat instance throws error',
-      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
-      exec: function(){/*
-        try {
-          Intl.DateTimeFormat.call(Intl.DateTimeFormat());
-          return false;
-        } catch(e) {
-          return e instanceof TypeError;
-        }
-      */},
-      res: {
-        ie11: true,
-        edge12: true,
-        firefox29: true,
-        chrome24: true,
-        node012: true,
-      },
-    },
+// The spec was updated making this test ivalid.  It was disabled until it can be fixed
+//    {
+//      name: 'calling DateTimeFormat with DateTimeFormat instance throws error',
+//      spec: 'http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.1.1',
+//      exec: function(){/*
+//        try {
+//          Intl.DateTimeFormat.call(Intl.DateTimeFormat());
+//          return false;
+//        } catch(e) {
+//          return e instanceof TypeError;
+//        }
+//      */},
+//      res: {
+//        ie11: true,
+//        edge12: true,
+//        firefox29: true,
+//        chrome24: true,
+//        node012: true,
+//      },
+//    },
     {
       name: 'accepts valid language tags',
       exec: function(){/*

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -403,72 +403,72 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a></span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
-<td class="tally" data-browser="ie11" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
-<td class="tally" data-browser="edge13" data-tally="1">5/5</td>
-<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge15" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox44" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox46" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox49" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox51" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox52" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox53" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox54" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox55" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="chrome47" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome48" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome49" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome50" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome51" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome52" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome53" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome54" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome55" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome56" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome57" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome58" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome59" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="safari7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="safari9" data-tally="0">0/5</td>
-<td class="tally" data-browser="safari10" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally" data-browser="safari10_1" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="node010" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="node012" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="iojs" data-tally="1">5/5</td>
-<td class="tally" data-browser="node4" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="node5" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="node6" data-tally="1">5/5</td>
-<td class="tally" data-browser="node65" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="node7" data-tally="1">5/5</td>
-<td class="tally" data-browser="node76" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="android43" data-tally="0">0/5</td>
-<td class="tally" data-browser="android44" data-tally="1">5/5</td>
-<td class="tally" data-browser="android50" data-tally="1">5/5</td>
-<td class="tally" data-browser="android51" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="ios51" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ios6" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ios7" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
-<td class="tally" data-browser="ios9" data-tally="0">0/5</td>
-<td class="tally" data-browser="ios10" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
+<td class="tally" data-browser="ie11" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge13" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge14" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="edge15" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox45" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox47" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox48" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox49" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox50" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox51" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox52" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox53" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox54" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox55" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome52" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome53" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome54" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome55" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome56" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome57" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome58" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome59" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="safari9" data-tally="0">0/4</td>
+<td class="tally" data-browser="safari10" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="safari10_1" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
+<td class="tally" data-browser="phantom" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="node010" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="node012" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="iojs" data-tally="1">4/4</td>
+<td class="tally" data-browser="node4" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="node5" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="node6" data-tally="1">4/4</td>
+<td class="tally" data-browser="node65" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">4/4</td>
+<td class="tally" data-browser="node76" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android42" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="android43" data-tally="0">0/4</td>
+<td class="tally" data-browser="android44" data-tally="1">4/4</td>
+<td class="tally" data-browser="android50" data-tally="1">4/4</td>
+<td class="tally" data-browser="android51" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="ios51" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios6" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="ios8" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios9" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios10" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_exists_on_intl_object"><td><span><a class="anchor" href="#test-Intl.Collator_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.Collator === &apos;function&apos;;
@@ -683,82 +683,6 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_calling_Collator_with_Collator_instance_throws_error"><td><span><a class="anchor" href="#test-Intl.Collator_calling_Collator_with_Collator_instance_throws_error">&#xA7;</a>calling Collator with Collator instance throws error</span><script data-source="
-try {
-  Intl.Collator.call(Intl.Collator());
-  return false;
-} catch(e) {
-  return e instanceof TypeError;
-}
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  Intl.Collator.call(Intl.Collator());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  Intl.Collator.call(Intl.Collator());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="edge12">Yes</td>
-<td class="yes" data-browser="edge13">Yes</td>
-<td class="yes" data-browser="edge14">Yes</td>
-<td class="yes unstable" data-browser="edge15">Yes</td>
-<td class="yes obsolete" data-browser="firefox38">Yes</td>
-<td class="yes obsolete" data-browser="firefox44">Yes</td>
-<td class="yes" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox46">Yes</td>
-<td class="yes obsolete" data-browser="firefox47">Yes</td>
-<td class="yes obsolete" data-browser="firefox48">Yes</td>
-<td class="yes obsolete" data-browser="firefox49">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
-<td class="yes obsolete" data-browser="firefox51">Yes</td>
-<td class="yes" data-browser="firefox52">Yes</td>
-<td class="yes unstable" data-browser="firefox53">Yes</td>
-<td class="yes unstable" data-browser="firefox54">Yes</td>
-<td class="yes unstable" data-browser="firefox55">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome47">Yes</td>
-<td class="yes obsolete" data-browser="chrome48">Yes</td>
-<td class="yes obsolete" data-browser="chrome49">Yes</td>
-<td class="yes obsolete" data-browser="chrome50">Yes</td>
-<td class="yes obsolete" data-browser="chrome51">Yes</td>
-<td class="yes obsolete" data-browser="chrome52">Yes</td>
-<td class="yes obsolete" data-browser="chrome53">Yes</td>
-<td class="yes obsolete" data-browser="chrome54">Yes</td>
-<td class="yes obsolete" data-browser="chrome55">Yes</td>
-<td class="yes obsolete" data-browser="chrome56">Yes</td>
-<td class="yes" data-browser="chrome57">Yes</td>
-<td class="yes unstable" data-browser="chrome58">Yes</td>
-<td class="yes unstable" data-browser="chrome59">Yes</td>
-<td class="no obsolete" data-browser="safari51">No</td>
-<td class="no obsolete" data-browser="safari6">No</td>
-<td class="no obsolete" data-browser="safari7">No</td>
-<td class="no obsolete" data-browser="safari71_8">No</td>
-<td class="no obsolete" data-browser="safari9">No</td>
-<td class="no" data-browser="safari10">No</td>
-<td class="no" data-browser="safari10_1">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
-<td class="no obsolete" data-browser="node010">No</td>
-<td class="yes obsolete" data-browser="node012">Yes</td>
-<td class="yes obsolete" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="node4">Yes</td>
-<td class="yes obsolete" data-browser="node5">Yes</td>
-<td class="yes obsolete" data-browser="node6">Yes</td>
-<td class="yes" data-browser="node65">Yes</td>
-<td class="yes obsolete" data-browser="node7">Yes</td>
-<td class="yes" data-browser="node76">Yes</td>
-<td class="no obsolete" data-browser="android40">No</td>
-<td class="no obsolete" data-browser="android41">No</td>
-<td class="no obsolete" data-browser="android42">No</td>
-<td class="no obsolete" data-browser="android43">No</td>
-<td class="yes" data-browser="android44">Yes</td>
-<td class="yes" data-browser="android50">Yes</td>
-<td class="yes" data-browser="android51">Yes</td>
-<td class="no obsolete" data-browser="ios51">No</td>
-<td class="no obsolete" data-browser="ios6">No</td>
-<td class="no obsolete" data-browser="ios7">No</td>
-<td class="no obsolete" data-browser="ios8">No</td>
-<td class="no" data-browser="ios9">No</td>
-<td class="no" data-browser="ios10">No</td>
-</tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-Intl.Collator_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
   // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
@@ -789,7 +713,7 @@ try {
 } catch(e) {
   return false;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.Collator(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -928,7 +852,7 @@ try {
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.compare" id="test-Intl.Collator.prototype.compare_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.compare_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().compare === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().compare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1067,7 +991,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.resolvedOptions" id="test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.Collator().resolvedOptions === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1137,72 +1061,143 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a></span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
-<td class="tally" data-browser="ie11" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="edge12" data-tally="1">6/6</td>
-<td class="tally" data-browser="edge13" data-tally="1">6/6</td>
-<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge15" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox38" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox44" data-tally="1">6/6</td>
-<td class="tally" data-browser="firefox45" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox46" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox47" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox48" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox49" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox51" data-tally="1">6/6</td>
-<td class="tally" data-browser="firefox52" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="firefox53" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="firefox54" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="firefox55" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="chrome47" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome48" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome49" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome50" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome51" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome52" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome53" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome54" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome55" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome56" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome57" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome58" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome59" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="safari7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="safari9" data-tally="0">0/6</td>
-<td class="tally" data-browser="safari10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally" data-browser="safari10_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="node010" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="node012" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="iojs" data-tally="1">6/6</td>
-<td class="tally" data-browser="node4" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="node5" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="node6" data-tally="1">6/6</td>
-<td class="tally" data-browser="node65" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="node7" data-tally="1">6/6</td>
-<td class="tally" data-browser="node76" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="android43" data-tally="0">0/6</td>
-<td class="tally" data-browser="android44" data-tally="1">6/6</td>
-<td class="tally" data-browser="android50" data-tally="1">6/6</td>
-<td class="tally" data-browser="android51" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="ios51" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ios6" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ios7" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
-<td class="tally" data-browser="ios9" data-tally="0">0/6</td>
-<td class="tally" data-browser="ios10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
+<td class="tally" data-browser="ie11" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge13" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge14" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox45" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox47" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox48" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox49" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox50" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox51" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox52" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox53" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox54" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox55" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome52" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome53" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome54" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome55" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome56" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome57" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="chrome58" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="chrome59" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari9" data-tally="0">0/5</td>
+<td class="tally" data-browser="safari10" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="safari10_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
+<td class="tally" data-browser="phantom" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node010" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node012" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="iojs" data-tally="1">5/5</td>
+<td class="tally" data-browser="node4" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="node5" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="node6" data-tally="1">5/5</td>
+<td class="tally" data-browser="node65" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">5/5</td>
+<td class="tally" data-browser="node76" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="android42" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="android43" data-tally="0">0/5</td>
+<td class="tally" data-browser="android44" data-tally="1">5/5</td>
+<td class="tally" data-browser="android50" data-tally="1">5/5</td>
+<td class="tally" data-browser="android51" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="ios51" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios8" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios9" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios10" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+</tr>
+<tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
+return typeof Intl.NumberFormat === &apos;function&apos;;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="no obsolete" data-browser="ie9">No</td>
+<td class="no obsolete" data-browser="ie10">No</td>
+<td class="yes" data-browser="ie11">Yes</td>
+<td class="yes obsolete" data-browser="edge12">Yes</td>
+<td class="yes" data-browser="edge13">Yes</td>
+<td class="yes" data-browser="edge14">Yes</td>
+<td class="yes unstable" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="firefox38">Yes</td>
+<td class="yes obsolete" data-browser="firefox44">Yes</td>
+<td class="yes" data-browser="firefox45">Yes</td>
+<td class="yes obsolete" data-browser="firefox46">Yes</td>
+<td class="yes obsolete" data-browser="firefox47">Yes</td>
+<td class="yes obsolete" data-browser="firefox48">Yes</td>
+<td class="yes obsolete" data-browser="firefox49">Yes</td>
+<td class="yes obsolete" data-browser="firefox50">Yes</td>
+<td class="yes obsolete" data-browser="firefox51">Yes</td>
+<td class="yes" data-browser="firefox52">Yes</td>
+<td class="yes unstable" data-browser="firefox53">Yes</td>
+<td class="yes unstable" data-browser="firefox54">Yes</td>
+<td class="yes unstable" data-browser="firefox55">Yes</td>
+<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="yes obsolete" data-browser="chrome47">Yes</td>
+<td class="yes obsolete" data-browser="chrome48">Yes</td>
+<td class="yes obsolete" data-browser="chrome49">Yes</td>
+<td class="yes obsolete" data-browser="chrome50">Yes</td>
+<td class="yes obsolete" data-browser="chrome51">Yes</td>
+<td class="yes obsolete" data-browser="chrome52">Yes</td>
+<td class="yes obsolete" data-browser="chrome53">Yes</td>
+<td class="yes obsolete" data-browser="chrome54">Yes</td>
+<td class="yes obsolete" data-browser="chrome55">Yes</td>
+<td class="yes obsolete" data-browser="chrome56">Yes</td>
+<td class="yes" data-browser="chrome57">Yes</td>
+<td class="yes unstable" data-browser="chrome58">Yes</td>
+<td class="yes unstable" data-browser="chrome59">Yes</td>
+<td class="no obsolete" data-browser="safari51">No</td>
+<td class="no obsolete" data-browser="safari6">No</td>
+<td class="no obsolete" data-browser="safari7">No</td>
+<td class="no obsolete" data-browser="safari71_8">No</td>
+<td class="no obsolete" data-browser="safari9">No</td>
+<td class="yes" data-browser="safari10">Yes</td>
+<td class="yes" data-browser="safari10_1">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no" data-browser="phantom">No</td>
+<td class="no obsolete" data-browser="node010">No</td>
+<td class="yes obsolete" data-browser="node012">Yes</td>
+<td class="yes obsolete" data-browser="iojs">Yes</td>
+<td class="yes" data-browser="node4">Yes</td>
+<td class="yes obsolete" data-browser="node5">Yes</td>
+<td class="yes obsolete" data-browser="node6">Yes</td>
+<td class="yes" data-browser="node65">Yes</td>
+<td class="yes obsolete" data-browser="node7">Yes</td>
+<td class="yes" data-browser="node76">Yes</td>
+<td class="no obsolete" data-browser="android40">No</td>
+<td class="no obsolete" data-browser="android41">No</td>
+<td class="no obsolete" data-browser="android42">No</td>
+<td class="no obsolete" data-browser="android43">No</td>
+<td class="yes" data-browser="android44">Yes</td>
+<td class="yes" data-browser="android50">Yes</td>
+<td class="yes" data-browser="android51">Yes</td>
+<td class="no obsolete" data-browser="ios51">No</td>
+<td class="no obsolete" data-browser="ios6">No</td>
+<td class="no obsolete" data-browser="ios7">No</td>
+<td class="no obsolete" data-browser="ios8">No</td>
+<td class="no" data-browser="ios9">No</td>
+<td class="yes" data-browser="ios10">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.NumberFormat === &apos;function&apos;;
@@ -1275,80 +1270,9 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
-return typeof Intl.NumberFormat === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.NumberFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="edge12">Yes</td>
-<td class="yes" data-browser="edge13">Yes</td>
-<td class="yes" data-browser="edge14">Yes</td>
-<td class="yes unstable" data-browser="edge15">Yes</td>
-<td class="yes obsolete" data-browser="firefox38">Yes</td>
-<td class="yes obsolete" data-browser="firefox44">Yes</td>
-<td class="yes" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox46">Yes</td>
-<td class="yes obsolete" data-browser="firefox47">Yes</td>
-<td class="yes obsolete" data-browser="firefox48">Yes</td>
-<td class="yes obsolete" data-browser="firefox49">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
-<td class="yes obsolete" data-browser="firefox51">Yes</td>
-<td class="yes" data-browser="firefox52">Yes</td>
-<td class="yes unstable" data-browser="firefox53">Yes</td>
-<td class="yes unstable" data-browser="firefox54">Yes</td>
-<td class="yes unstable" data-browser="firefox55">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome47">Yes</td>
-<td class="yes obsolete" data-browser="chrome48">Yes</td>
-<td class="yes obsolete" data-browser="chrome49">Yes</td>
-<td class="yes obsolete" data-browser="chrome50">Yes</td>
-<td class="yes obsolete" data-browser="chrome51">Yes</td>
-<td class="yes obsolete" data-browser="chrome52">Yes</td>
-<td class="yes obsolete" data-browser="chrome53">Yes</td>
-<td class="yes obsolete" data-browser="chrome54">Yes</td>
-<td class="yes obsolete" data-browser="chrome55">Yes</td>
-<td class="yes obsolete" data-browser="chrome56">Yes</td>
-<td class="yes" data-browser="chrome57">Yes</td>
-<td class="yes unstable" data-browser="chrome58">Yes</td>
-<td class="yes unstable" data-browser="chrome59">Yes</td>
-<td class="no obsolete" data-browser="safari51">No</td>
-<td class="no obsolete" data-browser="safari6">No</td>
-<td class="no obsolete" data-browser="safari7">No</td>
-<td class="no obsolete" data-browser="safari71_8">No</td>
-<td class="no obsolete" data-browser="safari9">No</td>
-<td class="yes" data-browser="safari10">Yes</td>
-<td class="yes" data-browser="safari10_1">Yes</td>
-<td class="yes unstable" data-browser="safaritp">Yes</td>
-<td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no" data-browser="phantom">No</td>
-<td class="no obsolete" data-browser="node010">No</td>
-<td class="yes obsolete" data-browser="node012">Yes</td>
-<td class="yes obsolete" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="node4">Yes</td>
-<td class="yes obsolete" data-browser="node5">Yes</td>
-<td class="yes obsolete" data-browser="node6">Yes</td>
-<td class="yes" data-browser="node65">Yes</td>
-<td class="yes obsolete" data-browser="node7">Yes</td>
-<td class="yes" data-browser="node76">Yes</td>
-<td class="no obsolete" data-browser="android40">No</td>
-<td class="no obsolete" data-browser="android41">No</td>
-<td class="no obsolete" data-browser="android42">No</td>
-<td class="no obsolete" data-browser="android43">No</td>
-<td class="yes" data-browser="android44">Yes</td>
-<td class="yes" data-browser="android50">Yes</td>
-<td class="yes" data-browser="android51">Yes</td>
-<td class="no obsolete" data-browser="ios51">No</td>
-<td class="no obsolete" data-browser="ios6">No</td>
-<td class="no obsolete" data-browser="ios7">No</td>
-<td class="no obsolete" data-browser="ios8">No</td>
-<td class="no" data-browser="ios9">No</td>
-<td class="yes" data-browser="ios10">Yes</td>
-</tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_creates_new_NumberFormat_instances"><td><span><a class="anchor" href="#test-NumberFormat_creates_new_NumberFormat_instances">&#xA7;</a>creates new NumberFormat instances</span><script data-source="
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1419,7 +1343,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_constructor_called_without_new_creates_instances"><td><span><a class="anchor" href="#test-NumberFormat_constructor_called_without_new_creates_instances">&#xA7;</a>constructor called without new creates instances</span><script data-source="
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.NumberFormat() instanceof Intl.NumberFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1488,82 +1412,6 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_calling_NumberFormat_with_NumberFormat_instance_throws_error"><td><span><a class="anchor" href="#test-NumberFormat_calling_NumberFormat_with_NumberFormat_instance_throws_error">&#xA7;</a>calling NumberFormat with NumberFormat instance throws error</span><script data-source="
-try {
-  Intl.NumberFormat.call(Intl.NumberFormat());
-  return false;
-} catch(e) {
-  return e instanceof TypeError;
-}
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\ntry {\n  Intl.NumberFormat.call(Intl.NumberFormat());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  Intl.NumberFormat.call(Intl.NumberFormat());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="edge12">Yes</td>
-<td class="yes" data-browser="edge13">Yes</td>
-<td class="yes" data-browser="edge14">Yes</td>
-<td class="yes unstable" data-browser="edge15">Yes</td>
-<td class="yes obsolete" data-browser="firefox38">Yes</td>
-<td class="yes obsolete" data-browser="firefox44">Yes</td>
-<td class="yes" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox46">Yes</td>
-<td class="yes obsolete" data-browser="firefox47">Yes</td>
-<td class="yes obsolete" data-browser="firefox48">Yes</td>
-<td class="yes obsolete" data-browser="firefox49">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
-<td class="yes obsolete" data-browser="firefox51">Yes</td>
-<td class="yes" data-browser="firefox52">Yes</td>
-<td class="yes unstable" data-browser="firefox53">Yes</td>
-<td class="yes unstable" data-browser="firefox54">Yes</td>
-<td class="yes unstable" data-browser="firefox55">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome47">Yes</td>
-<td class="yes obsolete" data-browser="chrome48">Yes</td>
-<td class="yes obsolete" data-browser="chrome49">Yes</td>
-<td class="yes obsolete" data-browser="chrome50">Yes</td>
-<td class="yes obsolete" data-browser="chrome51">Yes</td>
-<td class="yes obsolete" data-browser="chrome52">Yes</td>
-<td class="yes obsolete" data-browser="chrome53">Yes</td>
-<td class="yes obsolete" data-browser="chrome54">Yes</td>
-<td class="yes obsolete" data-browser="chrome55">Yes</td>
-<td class="yes obsolete" data-browser="chrome56">Yes</td>
-<td class="yes" data-browser="chrome57">Yes</td>
-<td class="yes unstable" data-browser="chrome58">Yes</td>
-<td class="yes unstable" data-browser="chrome59">Yes</td>
-<td class="no obsolete" data-browser="safari51">No</td>
-<td class="no obsolete" data-browser="safari6">No</td>
-<td class="no obsolete" data-browser="safari7">No</td>
-<td class="no obsolete" data-browser="safari71_8">No</td>
-<td class="no obsolete" data-browser="safari9">No</td>
-<td class="no" data-browser="safari10">No</td>
-<td class="no" data-browser="safari10_1">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
-<td class="no obsolete" data-browser="node010">No</td>
-<td class="yes obsolete" data-browser="node012">Yes</td>
-<td class="yes obsolete" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="node4">Yes</td>
-<td class="yes obsolete" data-browser="node5">Yes</td>
-<td class="yes obsolete" data-browser="node6">Yes</td>
-<td class="yes" data-browser="node65">Yes</td>
-<td class="yes obsolete" data-browser="node7">Yes</td>
-<td class="yes" data-browser="node76">Yes</td>
-<td class="no obsolete" data-browser="android40">No</td>
-<td class="no obsolete" data-browser="android41">No</td>
-<td class="no obsolete" data-browser="android42">No</td>
-<td class="no obsolete" data-browser="android43">No</td>
-<td class="yes" data-browser="android44">Yes</td>
-<td class="yes" data-browser="android50">Yes</td>
-<td class="yes" data-browser="android51">Yes</td>
-<td class="no obsolete" data-browser="ios51">No</td>
-<td class="no obsolete" data-browser="ios6">No</td>
-<td class="no obsolete" data-browser="ios7">No</td>
-<td class="no obsolete" data-browser="ios8">No</td>
-<td class="no" data-browser="ios9">No</td>
-<td class="no" data-browser="ios10">No</td>
-</tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-NumberFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
   // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
@@ -1594,7 +1442,7 @@ try {
 } catch(e) {
   return false;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.NumberFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1664,76 +1512,76 @@ try {
 <td class="no" data-browser="ios10">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a></span></td>
-<td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
-<td class="tally" data-browser="ie11" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="edge12" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="edge13" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="edge14" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="edge15" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="firefox38" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox44" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="firefox45" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox46" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox47" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox48" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox49" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox50" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally obsolete" data-browser="firefox51" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="firefox52" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="firefox53" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="firefox54" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="firefox55" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome47" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome48" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome49" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome50" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome51" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome52" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome53" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome54" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome55" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome56" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome57" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="chrome58" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="chrome59" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="safari51" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="safari6" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="safari7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="safari9" data-tally="0">0/7</td>
-<td class="tally" data-browser="safari10" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally" data-browser="safari10_1" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally" data-browser="phantom" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="node010" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="node012" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="iojs" data-tally="1">7/7</td>
-<td class="tally" data-browser="node4" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="node5" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="node6" data-tally="1">7/7</td>
-<td class="tally" data-browser="node65" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="node7" data-tally="1">7/7</td>
-<td class="tally" data-browser="node76" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="android40" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="android41" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="android42" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="android43" data-tally="0">0/7</td>
-<td class="tally" data-browser="android44" data-tally="1">7/7</td>
-<td class="tally" data-browser="android50" data-tally="1">7/7</td>
-<td class="tally" data-browser="android51" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="ios51" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ios6" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ios7" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="ios8" data-tally="0">0/7</td>
-<td class="tally" data-browser="ios9" data-tally="0">0/7</td>
-<td class="tally" data-browser="ios10" data-tally="0.7142857142857143" style="background-color:hsl(85,54%,50%)">5/7</td>
+<td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
+<td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="edge12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally" data-browser="edge13" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally" data-browser="edge14" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="edge15" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="firefox38" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox44" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally" data-browser="firefox45" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox46" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox47" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox48" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox49" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox50" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally obsolete" data-browser="firefox51" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
+<td class="tally" data-browser="firefox52" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="firefox53" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="firefox54" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="firefox55" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="chrome47" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome48" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome49" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome50" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome51" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome52" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome53" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome54" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome55" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome56" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome57" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="chrome58" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="chrome59" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="safari51" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="safari6" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="safari7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="safari71_8" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="safari9" data-tally="0">0/6</td>
+<td class="tally" data-browser="safari10" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="safari10_1" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">6/6</td>
+<td class="tally" data-browser="phantom" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="node010" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="node012" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="iojs" data-tally="1">6/6</td>
+<td class="tally" data-browser="node4" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="node5" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="node6" data-tally="1">6/6</td>
+<td class="tally" data-browser="node65" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="node7" data-tally="1">6/6</td>
+<td class="tally" data-browser="node76" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="android40" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="android41" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="android42" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="android43" data-tally="0">0/6</td>
+<td class="tally" data-browser="android44" data-tally="1">6/6</td>
+<td class="tally" data-browser="android50" data-tally="1">6/6</td>
+<td class="tally" data-browser="android51" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="ios51" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ios6" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ios7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="ios8" data-tally="0">0/6</td>
+<td class="tally" data-browser="ios9" data-tally="0">0/6</td>
+<td class="tally" data-browser="ios10" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-DateTimeFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Intl.DateTimeFormat === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1804,7 +1652,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_creates_new_DateTimeFormat_instances"><td><span><a class="anchor" href="#test-DateTimeFormat_creates_new_DateTimeFormat_instances">&#xA7;</a>creates new DateTimeFormat instances</span><script data-source="
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nreturn new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1875,7 +1723,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_constructor_called_without_new_creates_instances"><td><span><a class="anchor" href="#test-DateTimeFormat_constructor_called_without_new_creates_instances">&#xA7;</a>constructor called without new creates instances</span><script data-source="
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -1944,82 +1792,6 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="no" data-browser="ios9">No</td>
 <td class="yes" data-browser="ios10">Yes</td>
 </tr>
-<tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_calling_DateTimeFormat_with_DateTimeFormat_instance_throws_error"><td><span><a class="anchor" href="#test-DateTimeFormat_calling_DateTimeFormat_with_DateTimeFormat_instance_throws_error">&#xA7;</a>calling DateTimeFormat with DateTimeFormat instance throws error</span><script data-source="
-try {
-  Intl.DateTimeFormat.call(Intl.DateTimeFormat());
-  return false;
-} catch(e) {
-  return e instanceof TypeError;
-}
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  Intl.DateTimeFormat.call(Intl.DateTimeFormat());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  Intl.DateTimeFormat.call(Intl.DateTimeFormat());\n  return false;\n} catch(e) {\n  return e instanceof TypeError;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="no obsolete" data-browser="ie9">No</td>
-<td class="no obsolete" data-browser="ie10">No</td>
-<td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="edge12">Yes</td>
-<td class="yes" data-browser="edge13">Yes</td>
-<td class="yes" data-browser="edge14">Yes</td>
-<td class="yes unstable" data-browser="edge15">Yes</td>
-<td class="yes obsolete" data-browser="firefox38">Yes</td>
-<td class="yes obsolete" data-browser="firefox44">Yes</td>
-<td class="yes" data-browser="firefox45">Yes</td>
-<td class="yes obsolete" data-browser="firefox46">Yes</td>
-<td class="yes obsolete" data-browser="firefox47">Yes</td>
-<td class="yes obsolete" data-browser="firefox48">Yes</td>
-<td class="yes obsolete" data-browser="firefox49">Yes</td>
-<td class="yes obsolete" data-browser="firefox50">Yes</td>
-<td class="yes obsolete" data-browser="firefox51">Yes</td>
-<td class="yes" data-browser="firefox52">Yes</td>
-<td class="yes unstable" data-browser="firefox53">Yes</td>
-<td class="yes unstable" data-browser="firefox54">Yes</td>
-<td class="yes unstable" data-browser="firefox55">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome47">Yes</td>
-<td class="yes obsolete" data-browser="chrome48">Yes</td>
-<td class="yes obsolete" data-browser="chrome49">Yes</td>
-<td class="yes obsolete" data-browser="chrome50">Yes</td>
-<td class="yes obsolete" data-browser="chrome51">Yes</td>
-<td class="yes obsolete" data-browser="chrome52">Yes</td>
-<td class="yes obsolete" data-browser="chrome53">Yes</td>
-<td class="yes obsolete" data-browser="chrome54">Yes</td>
-<td class="yes obsolete" data-browser="chrome55">Yes</td>
-<td class="yes obsolete" data-browser="chrome56">Yes</td>
-<td class="yes" data-browser="chrome57">Yes</td>
-<td class="yes unstable" data-browser="chrome58">Yes</td>
-<td class="yes unstable" data-browser="chrome59">Yes</td>
-<td class="no obsolete" data-browser="safari51">No</td>
-<td class="no obsolete" data-browser="safari6">No</td>
-<td class="no obsolete" data-browser="safari7">No</td>
-<td class="no obsolete" data-browser="safari71_8">No</td>
-<td class="no obsolete" data-browser="safari9">No</td>
-<td class="no" data-browser="safari10">No</td>
-<td class="no" data-browser="safari10_1">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="no" data-browser="phantom">No</td>
-<td class="no obsolete" data-browser="node010">No</td>
-<td class="yes obsolete" data-browser="node012">Yes</td>
-<td class="yes obsolete" data-browser="iojs">Yes</td>
-<td class="yes" data-browser="node4">Yes</td>
-<td class="yes obsolete" data-browser="node5">Yes</td>
-<td class="yes obsolete" data-browser="node6">Yes</td>
-<td class="yes" data-browser="node65">Yes</td>
-<td class="yes obsolete" data-browser="node7">Yes</td>
-<td class="yes" data-browser="node76">Yes</td>
-<td class="no obsolete" data-browser="android40">No</td>
-<td class="no obsolete" data-browser="android41">No</td>
-<td class="no obsolete" data-browser="android42">No</td>
-<td class="no obsolete" data-browser="android43">No</td>
-<td class="yes" data-browser="android44">Yes</td>
-<td class="yes" data-browser="android50">Yes</td>
-<td class="yes" data-browser="android51">Yes</td>
-<td class="no obsolete" data-browser="ios51">No</td>
-<td class="no obsolete" data-browser="ios6">No</td>
-<td class="no obsolete" data-browser="ios7">No</td>
-<td class="no obsolete" data-browser="ios8">No</td>
-<td class="no" data-browser="ios9">No</td>
-<td class="no" data-browser="ios10">No</td>
-</tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
   // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
@@ -2050,7 +1822,7 @@ try {
 } catch(e) {
   return false;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js\n  var validLanguageTags = [\n    \"de\", // ISO 639 language code\n    \"de-DE\", // + ISO 3166-1 country code\n    \"DE-de\", // tags are case-insensitive\n    \"cmn\", // ISO 639 language code\n    \"cmn-Hans\", // + script code\n    \"CMN-hANS\", // tags are case-insensitive\n    \"cmn-hans-cn\", // + ISO 3166-1 country code\n    \"es-419\", // + UN M.49 region code\n    \"es-419-u-nu-latn-cu-bob\", // + Unicode locale extension sequence\n    \"i-klingon\", // grandfathered tag\n    \"cmn-hans-cn-t-ca-u-ca-x-t-u\", // singleton subtags can also be used as private use subtags\n    \"de-gregory-u-ca-gregory\", // variant and extension subtags may be the same\n    \"aa-a-foo-x-a-foo-bar\", // variant subtags can also be used as private use subtags\n    \"x-en-US-12345\", // anything goes in private use tags\n    \"x-12345-12345-en-US\",\n    \"x-en-US-12345-12345\",\n    \"x-en-u-foo\",\n    \"x-en-u-foo-u-bar\"\n  ];\n  for (var i in validLanguageTags) {\n    Intl.DateTimeFormat(validLanguageTags[i]);\n  }\n  return true;\n} catch(e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2122,7 +1894,7 @@ try {
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment"><td><span><a class="anchor" href="#test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment">&#xA7;</a>resolvedOptions().timeZone defaults to the host environment</span><script data-source="
 var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 return tz !== undefined &amp;&amp; tz.length &gt; 0;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar tz = Intl.DateTimeFormat().resolvedOptions().timeZone;\nreturn tz !== undefined && tz.length > 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2201,7 +1973,7 @@ try {
 } catch (e) {
   return false;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  new Intl.DateTimeFormat('en-US', {\n    timeZone: 'Australia/Sydney',\n    timeZoneName: 'long'\n  }).format();\n  return true;\n} catch (e) {\n  return false;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
@@ -2340,7 +2112,7 @@ try {
 </tr>
 <tr class="subtest" data-parent="String.prototype.localeCompare" id="test-String.prototype.localeCompare_exists_on_String_prototype"><td><span><a class="anchor" href="#test-String.prototype.localeCompare_exists_on_String_prototype">&#xA7;</a>exists on String prototype</span><script data-source="
 return typeof String.prototype.localeCompare === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof String.prototype.localeCompare === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -2479,7 +2251,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Number.prototype.toLocaleString" id="test-Number.prototype.toLocaleString_exists_on_Number_prototype"><td><span><a class="anchor" href="#test-Number.prototype.toLocaleString_exists_on_Number_prototype">&#xA7;</a>exists on Number prototype</span><script data-source="
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Number.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -2618,7 +2390,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Array.prototype.toLocaleString" id="test-Array.prototype.toLocaleString_exists_on_Array_prototype"><td><span><a class="anchor" href="#test-Array.prototype.toLocaleString_exists_on_Array_prototype">&#xA7;</a>exists on Array prototype</span><script data-source="
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Array.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -2757,7 +2529,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Object.prototype.toLocaleString" id="test-Object.prototype.toLocaleString_exists_on_Object_prototype"><td><span><a class="anchor" href="#test-Object.prototype.toLocaleString_exists_on_Object_prototype">&#xA7;</a>exists on Object prototype</span><script data-source="
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Object.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -2896,7 +2668,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleString" id="test-Date.prototype.toLocaleString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -3035,7 +2807,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleDateString" id="test-Date.prototype.toLocaleDateString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleDateString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
@@ -3174,7 +2946,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleTimeString" id="test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Date.prototype.toLocaleTimeString === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>


### PR DESCRIPTION
As described in issue #1044, three of the esintl tests are obsolete according to the updated spec.  This patch disables them until they can be fixed.